### PR TITLE
feat: connect baw-design submodule and import canonical tokens

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "design/baw-design"]
+	path = design/baw-design
+	url = https://github.com/zxy-vc/baw-design.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baw-os",
-  "version": "0.5.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baw-os",
-      "version": "0.5.1",
+      "version": "1.2.0",
       "dependencies": {
         "@stripe/stripe-js": "^3.5.0",
         "@supabase/ssr": "^0.3.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,4 @@
+@import "../../design/baw-design/tokens/index.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary

Conecta el repo `baw-design` (sistema de diseño canónico) a `baw-os` como submódulo Git e importa los tokens OKLCH al inicio de `globals.css`. Inicia la fase de **coexistencia gradual** entre tokens HEX legacy (`--baw-*`) y tokens canónicos (`--brand-*`, `--agent-*`).

## Cambios

- **Nuevo submódulo**: `design/baw-design` → [zxy-vc/baw-design](https://github.com/zxy-vc/baw-design) pinned a commit `f750d1c`
- **`src/app/globals.css`**: `@import` de `design/baw-design/tokens/index.css` al inicio del archivo, antes de las directivas de Tailwind
- **`.gitmodules`**: registra el submódulo
- **`package-lock.json`**: actualizado por `npm install` durante la verificación

## Estrategia de migración

Coexistencia, no big-bang. Detalle completo en [ADR 0011](https://github.com/zxy-vc/baw-design/blob/main/decisions/0011-coexistencia-tokens-migracion.md):

- Los `--baw-*` legacy permanecen sin cambios y siguen alimentando todos los componentes en producción
- Los `--brand-*`, `--agent-*` canónicos están disponibles para código nuevo
- Migración componente por componente cuando cada uno entre al pipeline de actualización
- `success/warning/danger` semánticas aún por crear en `baw-design` antes de migrar badges

## Validación local

- `npm run dev` arranca sin errores
- `GET /` → 200 OK
- Sin regresión visual aparente

## Notas

- El submódulo apunta a un repo **privado**. CI/Vercel necesitarán deploy key o token cuando builds remotos requieran clonar el submódulo. Issue trackeable a futuro, no bloquea hoy.
- Branch listo para merge si las builds de Vercel pasan.

Closes phase 1 connection between `baw-design` and `baw-os`.