### PR TITLE
Sprint 3 · S1 · Multi-tenancy v2 + wipe operativo (buildings, property_owners, ownership_stakes, roles pm_*)

### DIFF
--- a/supabase/migrations/20260429_01_member_role_pm_values.sql
+++ b/supabase/migrations/20260429_01_member_role_pm_values.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Sprint 3 · S1 — Parte 1/2 — Agregar valores pm_* al enum member_role
+-- =============================================================================
+-- Postgres no permite usar un enum value recién agregado en la misma transacción
+-- donde se hizo ADD VALUE. Por eso esta migración va separada de la siguiente.
+--
+-- Los valores antiguos (owner, admin, operator, viewer, agent) quedan en el
+-- enum sin uso post-wipe (deuda menor aceptable; PG no permite DROP VALUE).
+-- =============================================================================
+
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'pm_owner';
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'pm_admin';
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'pm_operator';
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'pm_viewer';
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'client';

--- a/supabase/migrations/20260429_02_multitenancy_v2.sql
+++ b/supabase/migrations/20260429_02_multitenancy_v2.sql
@@ -1,0 +1,282 @@
+-- =============================================================================
+-- Sprint 3 · S1 — Parte 2/2 — Multitenancy v2 + wipe operativo
+-- =============================================================================
+-- Objetivo:
+--   1. Wipe de tablas operativas (preserva auth.users; vacía organizations y
+--      org_members para que el onboarding de BaW Operations arranque de cero).
+--   2. Capa Buildings entre Organizations y Units.
+--   3. Capa Property Owners + ownership_stakes (validación sum<=100 por building).
+--   4. RLS endurecido por org_id en todas las tablas nuevas usando los roles
+--      pm_* (declarados en la migración 20260429_01).
+--
+-- Pre-requisito: la migración 20260429_01_member_role_pm_values.sql debe haberse
+-- aplicado antes (los valores pm_* del enum no pueden usarse en la misma tx
+-- donde se agregaron).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1) WIPE de tablas operativas
+-- -----------------------------------------------------------------------------
+
+TRUNCATE TABLE
+  public.payment_ledger,
+  public.payments,
+  public.contracts,
+  public.reservations,
+  public.tenant_applications,
+  public.occupants,
+  public.unit_prices,
+  public.pricing_config,
+  public.str_seasons,
+  public.expenses,
+  public.incidents,
+  public.tasks,
+  public.escalation_rules,
+  public.audit_log,
+  public.webhook_events,
+  public.whatsapp_notifications,
+  public.units
+RESTART IDENTITY CASCADE;
+
+DELETE FROM public.org_members;
+DELETE FROM public.organizations;
+
+-- -----------------------------------------------------------------------------
+-- 2) Tabla buildings
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.buildings (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id      uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  name        text NOT NULL,
+  address     text,
+  city        text,
+  state       text,
+  country     text NOT NULL DEFAULT 'MX',
+  postal_code text,
+  notes       text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT buildings_name_per_org_unique UNIQUE (org_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS buildings_org_id_idx ON public.buildings(org_id);
+
+ALTER TABLE public.buildings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS buildings_select ON public.buildings;
+DROP POLICY IF EXISTS buildings_insert ON public.buildings;
+DROP POLICY IF EXISTS buildings_update ON public.buildings;
+DROP POLICY IF EXISTS buildings_delete ON public.buildings;
+
+CREATE POLICY buildings_select ON public.buildings
+  FOR SELECT USING (
+    org_id IN (SELECT om.org_id FROM public.org_members om WHERE om.user_id = auth.uid())
+  );
+
+CREATE POLICY buildings_insert ON public.buildings
+  FOR INSERT WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY buildings_update ON public.buildings
+  FOR UPDATE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY buildings_delete ON public.buildings
+  FOR DELETE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin')
+    )
+  );
+
+-- -----------------------------------------------------------------------------
+-- 3) Units — agregar building_id NOT NULL (tabla está vacía post-wipe)
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE public.units
+  ADD COLUMN IF NOT EXISTS building_id uuid REFERENCES public.buildings(id) ON DELETE CASCADE;
+
+ALTER TABLE public.units
+  ALTER COLUMN building_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS units_building_id_idx ON public.units(building_id);
+
+ALTER TABLE public.units
+  DROP CONSTRAINT IF EXISTS units_org_id_number_key;
+
+ALTER TABLE public.units
+  DROP CONSTRAINT IF EXISTS units_building_id_number_key;
+
+ALTER TABLE public.units
+  ADD CONSTRAINT units_building_id_number_key UNIQUE (building_id, number);
+
+-- -----------------------------------------------------------------------------
+-- 4) Tabla property_owners
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.property_owners (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id        uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  user_id       uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  full_name     text NOT NULL,
+  email         text,
+  phone         text,
+  rfc           text,
+  bank_info     jsonb,
+  notes         text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS property_owners_org_id_idx  ON public.property_owners(org_id);
+CREATE INDEX IF NOT EXISTS property_owners_user_id_idx ON public.property_owners(user_id);
+
+ALTER TABLE public.property_owners ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS property_owners_select ON public.property_owners;
+DROP POLICY IF EXISTS property_owners_insert ON public.property_owners;
+DROP POLICY IF EXISTS property_owners_update ON public.property_owners;
+DROP POLICY IF EXISTS property_owners_delete ON public.property_owners;
+
+CREATE POLICY property_owners_select ON public.property_owners
+  FOR SELECT USING (
+    org_id IN (SELECT om.org_id FROM public.org_members om WHERE om.user_id = auth.uid())
+    OR user_id = auth.uid()
+  );
+
+CREATE POLICY property_owners_insert ON public.property_owners
+  FOR INSERT WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY property_owners_update ON public.property_owners
+  FOR UPDATE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+    OR user_id = auth.uid()
+  );
+
+CREATE POLICY property_owners_delete ON public.property_owners
+  FOR DELETE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin')
+    )
+  );
+
+-- -----------------------------------------------------------------------------
+-- 5) Tabla ownership_stakes (M:N building↔property_owner)
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.ownership_stakes (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id              uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  building_id         uuid NOT NULL REFERENCES public.buildings(id) ON DELETE CASCADE,
+  property_owner_id   uuid NOT NULL REFERENCES public.property_owners(id) ON DELETE CASCADE,
+  percentage          numeric(5,2) NOT NULL CHECK (percentage > 0 AND percentage <= 100),
+  starts_on           date,
+  ends_on             date,
+  notes               text,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ownership_stakes_unique UNIQUE (building_id, property_owner_id)
+);
+
+CREATE INDEX IF NOT EXISTS ownership_stakes_org_id_idx      ON public.ownership_stakes(org_id);
+CREATE INDEX IF NOT EXISTS ownership_stakes_building_id_idx ON public.ownership_stakes(building_id);
+CREATE INDEX IF NOT EXISTS ownership_stakes_owner_id_idx    ON public.ownership_stakes(property_owner_id);
+
+CREATE OR REPLACE FUNCTION public.check_ownership_stakes_sum()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  total numeric;
+BEGIN
+  SELECT COALESCE(SUM(percentage), 0) INTO total
+  FROM public.ownership_stakes
+  WHERE building_id = NEW.building_id
+    AND id <> COALESCE(NEW.id, '00000000-0000-0000-0000-000000000000'::uuid);
+  IF total + NEW.percentage > 100 THEN
+    RAISE EXCEPTION 'Suma de ownership stakes para building % excede 100%% (intentado: %)',
+      NEW.building_id, total + NEW.percentage;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ownership_stakes_sum_check ON public.ownership_stakes;
+CREATE TRIGGER ownership_stakes_sum_check
+  BEFORE INSERT OR UPDATE ON public.ownership_stakes
+  FOR EACH ROW EXECUTE FUNCTION public.check_ownership_stakes_sum();
+
+ALTER TABLE public.ownership_stakes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS ownership_stakes_select ON public.ownership_stakes;
+DROP POLICY IF EXISTS ownership_stakes_insert ON public.ownership_stakes;
+DROP POLICY IF EXISTS ownership_stakes_update ON public.ownership_stakes;
+DROP POLICY IF EXISTS ownership_stakes_delete ON public.ownership_stakes;
+
+CREATE POLICY ownership_stakes_select ON public.ownership_stakes
+  FOR SELECT USING (
+    org_id IN (SELECT om.org_id FROM public.org_members om WHERE om.user_id = auth.uid())
+    OR property_owner_id IN (SELECT po.id FROM public.property_owners po WHERE po.user_id = auth.uid())
+  );
+
+CREATE POLICY ownership_stakes_insert ON public.ownership_stakes
+  FOR INSERT WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY ownership_stakes_update ON public.ownership_stakes
+  FOR UPDATE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY ownership_stakes_delete ON public.ownership_stakes
+  FOR DELETE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin')
+    )
+  );
+
+-- -----------------------------------------------------------------------------
+-- 6) Comentarios documentales
+-- -----------------------------------------------------------------------------
+
+COMMENT ON TABLE public.buildings        IS 'Sprint 3 v2: capa edificio entre organizations y units. Una org puede gestionar múltiples buildings.';
+COMMENT ON TABLE public.property_owners  IS 'Sprint 3 v2: dueños del inmueble (no tenants). Pueden ligarse a auth.users vía portal Property Owner.';
+COMMENT ON TABLE public.ownership_stakes IS 'Sprint 3 v2: relación M:N building↔property_owner con porcentaje de propiedad. Trigger valida sum<=100 por building.';
+COMMENT ON COLUMN public.units.building_id IS 'Sprint 3 v2: FK a buildings. NOT NULL — toda unit pertenece a un building.';
+
+-- =============================================================================
+-- FIN — multitenancy v2
+-- =============================================================================

--- a/supabase/seed-examples/README.md
+++ b/supabase/seed-examples/README.md
@@ -1,0 +1,29 @@
+# Seed Examples
+
+Esta carpeta contiene **seeds de referencia históricos**, NO migraciones que deban
+correrse contra la base.
+
+Los seeds aquí se preservan como ejemplos de cómo poblar BaW OS para desarrollo
+local o testing, pero el flujo canónico de creación de datos en producción es el
+**onboarding wizard** (`/onboarding`), no SQL directo.
+
+## Archivos
+
+- `mateos-809.sql` — Seed original del MVP Mateos (Sprint 2, Org `ed4308c7-2bdb-46f2-be69-7c59674838e2`).
+  Estructura pre-Sprint 3: usa `units.org_id` directo (sin `building_id`),
+  enum `member_role` con `owner/admin/operator/viewer/agent`. **NO se puede correr
+  tal cual en BaW OS post-Sprint 3** porque el schema cambió (units ahora requiere
+  `building_id NOT NULL` y los roles canónicos son `pm_*`).
+
+  Para reactivar en local, primero sembrar un `building` y mapear los `org_id`
+  → `building_id` correspondientes.
+
+## Por qué se preserva
+
+Como el wipe operativo del Sprint 3 borró la data Mateos en producción, este
+archivo es la única referencia escrita de la configuración inicial usada para
+validar el sistema durante Sprint 1–2 (16 unidades, 9 contracts, 21 incidents,
+3 payments).
+
+Sirve como **fixture de referencia** para tests futuros y como evidencia
+auditoria del estado pre-multitenancy v2.

--- a/supabase/seed-examples/mateos-809.sql
+++ b/supabase/seed-examples/mateos-809.sql
@@ -1,0 +1,156 @@
+-- BaW OS — Seed Mateos 809P (corte 26-abr-2026)
+-- Idempotente: usa funciones helper que UPDATE si existe, INSERT si no.
+-- No depende de UNIQUE constraints específicos.
+-- Datos vivos del Notion "BaW Mateos 809P — Estado Operativo Vivo".
+-- Org Mateos: ed4308c7-2bdb-46f2-be69-7c59674838e2 (preexistente).
+
+-- ============================================================
+-- HELPER FUNCTIONS (idempotentes, scope: este seed)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION pg_temp.seed_unit(
+  p_org_id uuid, p_number text, p_type text, p_floor int, p_status text, p_notes text
+) RETURNS uuid LANGUAGE plpgsql AS $fn$
+DECLARE v_id uuid;
+BEGIN
+  SELECT id INTO v_id FROM units WHERE org_id = p_org_id AND number = p_number LIMIT 1;
+  IF v_id IS NULL THEN
+    INSERT INTO units (org_id, number, type, floor, status, notes)
+    VALUES (p_org_id, p_number, p_type, p_floor, p_status, p_notes)
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE units
+    SET type = p_type, floor = p_floor, status = p_status, notes = p_notes
+    WHERE id = v_id;
+  END IF;
+  RETURN v_id;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION pg_temp.seed_occupant(
+  p_org_id uuid, p_name text, p_phone text, p_type text
+) RETURNS uuid LANGUAGE plpgsql AS $fn$
+DECLARE v_id uuid;
+BEGIN
+  SELECT id INTO v_id FROM occupants WHERE org_id = p_org_id AND name = p_name LIMIT 1;
+  IF v_id IS NULL THEN
+    INSERT INTO occupants (org_id, name, phone, type)
+    VALUES (p_org_id, p_name, p_phone, p_type)
+    RETURNING id INTO v_id;
+  END IF;
+  RETURN v_id;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION pg_temp.seed_contract(
+  p_org_id uuid, p_unit_id uuid, p_occ_id uuid,
+  p_amount numeric, p_payment_day int, p_start date, p_end date, p_status text
+) RETURNS uuid LANGUAGE plpgsql AS $fn$
+DECLARE v_id uuid;
+BEGIN
+  SELECT id INTO v_id FROM contracts
+   WHERE unit_id = p_unit_id AND occupant_id = p_occ_id
+   ORDER BY created_at DESC LIMIT 1;
+  IF v_id IS NULL THEN
+    INSERT INTO contracts (org_id, unit_id, occupant_id, monthly_amount, payment_day, start_date, end_date, status)
+    VALUES (p_org_id, p_unit_id, p_occ_id, p_amount, p_payment_day, p_start, p_end, p_status)
+    RETURNING id INTO v_id;
+  END IF;
+  RETURN v_id;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION pg_temp.seed_payment(
+  p_org_id uuid, p_contract_id uuid,
+  p_amount numeric, p_rent numeric, p_water numeric,
+  p_due date, p_status text, p_paid date
+) RETURNS uuid LANGUAGE plpgsql AS $fn$
+DECLARE v_id uuid;
+BEGIN
+  IF p_contract_id IS NULL THEN RETURN NULL; END IF;
+  SELECT id INTO v_id FROM payments
+   WHERE contract_id = p_contract_id
+     AND due_date >= date_trunc('month', p_due)::date
+     AND due_date < (date_trunc('month', p_due) + interval '1 month')::date
+   LIMIT 1;
+  IF v_id IS NULL THEN
+    IF p_paid IS NOT NULL THEN
+      INSERT INTO payments (org_id, contract_id, amount, rent_amount, water_fee, due_date, status, paid_date)
+      VALUES (p_org_id, p_contract_id, p_amount, p_rent, p_water, p_due, p_status, p_paid)
+      RETURNING id INTO v_id;
+    ELSE
+      INSERT INTO payments (org_id, contract_id, amount, rent_amount, water_fee, due_date, status)
+      VALUES (p_org_id, p_contract_id, p_amount, p_rent, p_water, p_due, p_status)
+      RETURNING id INTO v_id;
+    END IF;
+  END IF;
+  RETURN v_id;
+END $fn$;
+
+-- ============================================================
+-- SEED PRINCIPAL
+-- ============================================================
+
+DO $$
+DECLARE
+  v_org uuid := 'ed4308c7-2bdb-46f2-be69-7c59674838e2';
+  u_d102 uuid; u_d202 uuid; u_d203 uuid; u_d204 uuid;
+  u_d301 uuid; u_d302 uuid; u_d401 uuid; u_d402 uuid; u_d404 uuid;
+  o_erik uuid; o_pat uuid; o_let uuid; o_jose uuid; o_humb uuid;
+  o_jorge uuid; o_arturo uuid; o_martin uuid; o_d202 uuid;
+  c_d102 uuid; c_d203 uuid; c_d204 uuid; c_d301 uuid; c_d302 uuid;
+  c_d401 uuid; c_d402 uuid; c_d404 uuid; c_d202 uuid;
+BEGIN
+  -- 1. UNIDADES (16)
+  PERFORM pg_temp.seed_unit(v_org, 'D101', 'STR', 1, 'available', 'Tipo 01 Básico 102m². Drenaje recurrente. Mantenimiento pendiente.');
+  u_d102 := pg_temp.seed_unit(v_org, 'D102', 'LTR', 1, 'occupied',  'Tipo 02 Confort 122m². Erik Mauricio Núñez Rivera.');
+  PERFORM pg_temp.seed_unit(v_org, 'D103', 'STR', 1, 'available', 'Tipo 03 Clásico 131m². Requiere remodelación profunda.');
+  PERFORM pg_temp.seed_unit(v_org, 'D104', 'STR', 1, 'available', 'Tipo 04 Superior 149m². Baño y cocina urgentes.');
+  PERFORM pg_temp.seed_unit(v_org, 'D201', 'MTR', 2, 'available', 'Tipo 01 Básico. Acuerdo Natturaly $2,000/persona, mín verbal $6,000. Pendiente confirmar.');
+  u_d202 := pg_temp.seed_unit(v_org, 'D202', 'MTR', 2, 'occupied',  'Tipo 02 Confort. 1 mujer hoy, pagó $2,000 abril. Mover a D303 en mayo, liberar D202.');
+  u_d203 := pg_temp.seed_unit(v_org, 'D203', 'LTR', 2, 'occupied',  'Tipo 03 Clásico. Patricia Hernández. Contrato vencido — renovación pendiente.');
+  u_d204 := pg_temp.seed_unit(v_org, 'D204', 'LTR', 2, 'occupied',  'Tipo 04 Superior. Leticia (Felipe Gómez paga). Contrato vencido.');
+  u_d301 := pg_temp.seed_unit(v_org, 'D301', 'LTR', 3, 'occupied',  'Tipo 01 Básico. José Luis Bautista (Misioneros SUD). Boiler dañado, medidor CFE pendiente.');
+  u_d302 := pg_temp.seed_unit(v_org, 'D302', 'LTR', 3, 'occupied',  'Tipo 02 Confort. Humberto Ortiz. MOROSO ~$32K. Decisión legal/cobranza requerida.');
+  PERFORM pg_temp.seed_unit(v_org, 'D303', 'MTR', 3, 'reserved',  'Tipo 03 Clásico. Reservada para renta variable mayo (recibirá ocupante actual de D202).');
+  PERFORM pg_temp.seed_unit(v_org, 'D304', 'STR', 3, 'available', 'Tipo 04 Superior. Vacante.');
+  u_d401 := pg_temp.seed_unit(v_org, 'D401', 'LTR', 4, 'occupied',  'Tipo 01 Básico. Jorge Alberto Álvarez. Contrato vencido ago-2024.');
+  u_d402 := pg_temp.seed_unit(v_org, 'D402', 'LTR', 4, 'occupied',  'Tipo 02 Confort. Arturo Osornio. MOROSO ~$80K. CASO CRÍTICO.');
+  PERFORM pg_temp.seed_unit(v_org, 'D403', 'STR', 4, 'available', 'Tipo 03 Clásico. VACANTE — Daniel Mercado no cerró.');
+  u_d404 := pg_temp.seed_unit(v_org, 'D404', 'LTR', 4, 'occupied',  'Tipo 04 Superior. Martín Briones (colaborador mantenimiento). Contrato vencido ene-2025.');
+
+  -- 2. OCCUPANTS
+  o_erik   := pg_temp.seed_occupant(v_org, 'Erik Mauricio Núñez Rivera',         NULL, 'ltr');
+  o_pat    := pg_temp.seed_occupant(v_org, 'Patricia Hernández',                  NULL, 'ltr');
+  o_let    := pg_temp.seed_occupant(v_org, 'Leticia (Felipe Gómez paga)',         NULL, 'ltr');
+  o_jose   := pg_temp.seed_occupant(v_org, 'José Luis Bautista (Misioneros SUD)', NULL, 'ltr');
+  o_humb   := pg_temp.seed_occupant(v_org, 'Humberto Ortiz',                      NULL, 'ltr');
+  o_jorge  := pg_temp.seed_occupant(v_org, 'Jorge Alberto Álvarez',               NULL, 'ltr');
+  o_arturo := pg_temp.seed_occupant(v_org, 'Arturo Osornio',                      NULL, 'ltr');
+  o_martin := pg_temp.seed_occupant(v_org, 'Martín Briones',                      NULL, 'ltr');
+  o_d202   := pg_temp.seed_occupant(v_org, 'Ocupante D202 (renta variable abr-2026)', NULL, 'both');
+
+  -- 3. CONTRACTS
+  c_d102 := pg_temp.seed_contract(v_org, u_d102, o_erik,   8250, 1, '2025-09-01', NULL,         'active');
+  c_d203 := pg_temp.seed_contract(v_org, u_d203, o_pat,    5050, 1, '2024-01-01', '2025-12-31', 'en_renovacion');
+  c_d204 := pg_temp.seed_contract(v_org, u_d204, o_let,    5050, 1, '2024-01-01', '2025-12-31', 'en_renovacion');
+  c_d301 := pg_temp.seed_contract(v_org, u_d301, o_jose,   7450, 1, '2025-06-01', NULL,         'active');
+  c_d302 := pg_temp.seed_contract(v_org, u_d302, o_humb,   4750, 1, '2024-03-01', NULL,         'active');
+  c_d401 := pg_temp.seed_contract(v_org, u_d401, o_jorge,  4750, 1, '2023-08-01', '2024-08-31', 'en_renovacion');
+  c_d402 := pg_temp.seed_contract(v_org, u_d402, o_arturo, 3800, 1, '2023-01-01', NULL,         'active');
+  c_d404 := pg_temp.seed_contract(v_org, u_d404, o_martin, 5550, 1, '2024-01-01', '2025-01-31', 'en_renovacion');
+  c_d202 := pg_temp.seed_contract(v_org, u_d202, o_d202,   2000, 1, '2026-04-01', '2026-04-30', 'active');
+
+  -- 4. PAYMENTS — estados puntuales abril 2026
+  -- D202 — pagó $2,000 abril
+  PERFORM pg_temp.seed_payment(v_org, c_d202, 2000, 2000, 0,   '2026-04-01', 'paid', '2026-04-15');
+  -- D302 — Humberto Ortiz — late (parte de mora ~$32K)
+  PERFORM pg_temp.seed_payment(v_org, c_d302, 5000, 4750, 250, '2026-04-01', 'late', NULL);
+  -- D402 — Arturo Osornio — late (parte de mora ~$80K)
+  PERFORM pg_temp.seed_payment(v_org, c_d402, 4050, 3800, 250, '2026-04-01', 'late', NULL);
+
+END $$;
+
+-- Comentarios operativos (no se almacenan, solo para reviewers):
+-- - Ingreso nominal estimado: ~$46,650/mes incluyendo morosos (D102 8250 + D203/D204 5050x2 + D301 7450 + D302 4750 + D401 4750 + D402 3800 + D404 5550 + D202 2000).
+-- - Conservador: ~$38,100/mes excluyendo D302 y D402.
+-- - D403 vacante (Daniel Mercado no cerró).
+-- - D303 reservada para renta variable mayo (recibirá ocupante de D202).
+-- - Locales y bodegas rooftop NO modeladas en `units` — pendiente de Sprint 3.


### PR DESCRIPTION
## Sprint 3 · S1 — Multitenancy v2 + wipe operativo

Primer PR del Sprint Nocturno BaW OS (22:00 → 06:00 CST). Reemplaza al [PR #4](https://github.com/zxy-vc/baw-os/pull/4) (cerrado sin merge).

### 🎯 Objetivo

Establecer la nueva arquitectura multi-tenant de 5 capas (PM Company → PM Users → Buildings → Units → Property Owners) y hacer wipe operativo para que el onboarding de `BaW Operations` arranque desde cero, sin residuos del seed Mateos pre-v2.

### 📦 Cambios

**Migraciones (2):**

1. `20260429_01_member_role_pm_values.sql` — Agrega valores `pm_owner`, `pm_admin`, `pm_operator`, `pm_viewer`, `client` al enum `member_role`. Separada de la migración 02 porque Postgres no permite usar valores recién agregados a un enum en la misma transacción.

2. `20260429_02_multitenancy_v2.sql` — Wipe + nuevas tablas:
   - **TRUNCATE CASCADE** de 17 tablas operativas (units, contracts, payments, occupants, incidents, etc.).
   - **DELETE** de `organizations` y `org_members` (preservando `auth.users`).
   - **`buildings`** — capa nueva entre `organizations` y `units`. Una org puede gestionar múltiples buildings.
   - **`units.building_id`** NOT NULL + constraint `(building_id, number)` único reemplaza al viejo `(org_id, number)`.
   - **`property_owners`** — dueños del inmueble (no tenants). Pueden ligarse opcionalmente a `auth.users` vía portal Property Owner.
   - **`ownership_stakes`** — relación M:N building↔property_owner con porcentaje. Trigger `check_ownership_stakes_sum` valida `sum(percentage) <= 100` por building.
   - **RLS endurecido** en las 3 tablas nuevas: SELECT por `org_id` del JWT (los Property Owners también ven las suyas vía `user_id`); INSERT/UPDATE/DELETE restringidos a roles `pm_owner|pm_admin|pm_operator` (DELETE solo `pm_owner|pm_admin`).

**Seed histórico:**

3. `supabase/seed-examples/mateos-809.sql` + `README.md` — Preserva el seed original Mateos como referencia auditoria. **NO ejecutable post-v2** (esquema incompatible: falta `building_id`, roles `owner/admin` ya no son canónicos).

### ✅ Verificación post-aplicación

Aplicado vía MCP `apply_migration` en proyecto `zlcgxmllaeweypyodvzk`:

```
buildings        : 0 filas (tabla nueva)
property_owners  : 0 filas (tabla nueva)
ownership_stakes : 0 filas (tabla nueva)
units, contracts, payments, occupants,
incidents, pricing_config, organizations,
org_members                            : 0 filas (wipe OK)
member_role enum: {owner, admin, operator, viewer, agent,
                   pm_owner, pm_admin, pm_operator, pm_viewer, client}
```

`auth.users` intacto — los humanos siguen pudiendo loguearse y el onboarding S3 los recreará en `org_members` con rol `pm_owner` al crear la nueva org `BaW Operations`.

### 🧱 Decisiones de diseño

- **Roles antiguos preservados como deuda menor** — Postgres no permite `DROP VALUE` de enum. Los valores `owner/admin/operator/viewer/agent` quedan en el tipo pero sin uso post-wipe. La app debe filtrar por los nuevos `pm_*` en todas las queries de ahora en adelante.
- **`building_id` NOT NULL desde el inicio** — la tabla units quedó vacía con el TRUNCATE, así que podemos exigirlo sin migración de datos. Toda unit debe pertenecer a un building (no se permiten unidades huérfanas).
- **`property_owners.user_id` nullable** — un property owner existe en el sistema antes de aceptar la invitación al portal. Se completa cuando el dueño hace el primer login.
- **Trigger sum<=100** vs. constraint — usamos trigger porque CHECK constraint no puede agregar entre filas. Mensaje de error en español para UX directa.

### 🔗 Referencias

- **Notion log de avances:** [Sprint Nocturno BaW OS](https://app.notion.com/p/Perplexity-Personal-Computer-Log-de-avances-351169373e72813c9f8cd10f3e35d232)
- **Decisión de wipe:** confirmada por Fran (`zxy.vc/#agente`) — reset total para arrancar onboarding desde cero como BaW Operations.
- **PR #4 cerrado:** seed Mateos preservado en `supabase/seed-examples/mateos-809.sql`.

### 🚦 No-merge automático

Este PR queda **abierto para revisión manual mañana**. No se mergea a `main` automáticamente.

### Próximo PR

S2 — Roster v0.2 en Notion (no requiere PR de código; solo edición de doc).
S3 — Onboarding wizard `/onboarding` 4 pasos + Mission Control empty state → ese sí será PR.
