### PR TITLE
Sprint 3 · S4 · Identidad UI (WorkspaceSwitcher + ProfileMenu + Agentes)

### DIFF
--- a/src/components/AgentsList.tsx
+++ b/src/components/AgentsList.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+// BaW OS — AgentsList (Sprint 3 / S4)
+// Sección "Agentes" en el sidebar con los 11 agentes del workforce v0.2:
+// 1 coordinador (BaW) + 10 especialistas. Status placeholder (idle/running/paused).
+// Sin links activos todavía — la página individual de cada agente vendrá en sprints
+// posteriores. Hoy solo muestra presencia visual y prepara la jerarquía mental.
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, Bot, Circle } from 'lucide-react'
+
+type AgentStatus = 'idle' | 'running' | 'paused' | 'planned'
+
+interface Agent {
+  key: string
+  name: string
+  role: 'coordinator' | 'core' | 'experience' | 'intelligence'
+  status: AgentStatus
+}
+
+const AGENTS: Agent[] = [
+  // Coordinador (no se prefija con "Agente")
+  { key: 'baw', name: 'BaW', role: 'coordinator', status: 'idle' },
+  // Operaciones Core
+  { key: 'cobranza', name: 'Agente Cobranza', role: 'core', status: 'planned' },
+  { key: 'facturacion', name: 'Agente Facturación', role: 'core', status: 'planned' },
+  { key: 'mantenimiento', name: 'Agente Mantenimiento', role: 'core', status: 'planned' },
+  // Experiencia
+  { key: 'atencion', name: 'Agente Atención', role: 'experience', status: 'planned' },
+  { key: 'reservas', name: 'Agente Reservas', role: 'experience', status: 'planned' },
+  { key: 'tarifas', name: 'Agente Tarifas', role: 'experience', status: 'planned' },
+  { key: 'renovaciones', name: 'Agente Renovaciones', role: 'experience', status: 'planned' },
+  // Inteligencia
+  { key: 'reportes', name: 'Agente Reportes', role: 'intelligence', status: 'planned' },
+  { key: 'auditoria', name: 'Agente Auditoría', role: 'intelligence', status: 'planned' },
+  { key: 'fiscal', name: 'Agente Fiscal', role: 'intelligence', status: 'planned' },
+]
+
+const ROLE_LABEL: Record<Agent['role'], string> = {
+  coordinator: 'Coordinador',
+  core: 'Operaciones Core',
+  experience: 'Experiencia',
+  intelligence: 'Inteligencia',
+}
+
+const STATUS_DOT: Record<AgentStatus, { color: string; label: string }> = {
+  idle: { color: '#86efac', label: 'Activo' },
+  running: { color: '#60a5fa', label: 'Corriendo' },
+  paused: { color: '#fbbf24', label: 'Pausado' },
+  planned: { color: '#52525b', label: 'Planeado' },
+}
+
+interface Props {
+  expanded: boolean
+}
+
+export default function AgentsList({ expanded }: Props) {
+  const [open, setOpen] = useState(false)
+
+  if (!expanded) {
+    // Modo colapsado: un solo ícono que indica que hay sección de agentes
+    return (
+      <button
+        type="button"
+        title="Agentes"
+        className="flex items-center justify-center h-9 w-[40px] mx-2 rounded-md hover:bg-white/5"
+        style={{ color: 'var(--baw-muted)' }}
+      >
+        <Bot className="w-[18px] h-[18px]" />
+      </button>
+    )
+  }
+
+  // Agrupar por rol
+  const groups: Array<{ label: string; agents: Agent[] }> = [
+    {
+      label: ROLE_LABEL.coordinator,
+      agents: AGENTS.filter((a) => a.role === 'coordinator'),
+    },
+    {
+      label: ROLE_LABEL.core,
+      agents: AGENTS.filter((a) => a.role === 'core'),
+    },
+    {
+      label: ROLE_LABEL.experience,
+      agents: AGENTS.filter((a) => a.role === 'experience'),
+    },
+    {
+      label: ROLE_LABEL.intelligence,
+      agents: AGENTS.filter((a) => a.role === 'intelligence'),
+    },
+  ]
+
+  return (
+    <div className="mx-2 mb-2">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between h-7 px-3 rounded-md text-[10px] uppercase tracking-wider hover:bg-white/5"
+        style={{ color: 'var(--baw-muted)' }}
+      >
+        <span className="flex items-center gap-1.5">
+          <Bot size={11} />
+          Agentes ({AGENTS.length})
+        </span>
+        {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+      </button>
+
+      {open && (
+        <ul className="mt-1 space-y-0.5">
+          {groups.map((g) => (
+            <li key={g.label} className="mt-1.5">
+              <div
+                className="px-3 pt-1 pb-0.5 text-[9px] uppercase tracking-wider"
+                style={{ color: 'var(--baw-muted)', opacity: 0.7 }}
+              >
+                {g.label}
+              </div>
+              <ul>
+                {g.agents.map((a) => {
+                  const dot = STATUS_DOT[a.status]
+                  return (
+                    <li key={a.key}>
+                      <div
+                        className="flex items-center justify-between gap-2 px-3 py-1 rounded-md hover:bg-white/5 cursor-default"
+                        title={`${a.name} · ${dot.label}`}
+                      >
+                        <span
+                          className="text-[11.5px] truncate"
+                          style={{
+                            color:
+                              a.status === 'planned'
+                                ? 'var(--baw-muted)'
+                                : 'var(--baw-text)',
+                          }}
+                        >
+                          {a.name}
+                        </span>
+                        <Circle
+                          size={6}
+                          fill={dot.color}
+                          stroke={dot.color}
+                          aria-label={dot.label}
+                        />
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { Search, Bell } from 'lucide-react'
 import Sidebar from '@/components/Sidebar'
 import AuthGuard from '@/components/AuthGuard'
+import ProfileMenu from '@/components/ProfileMenu'
 import ThemeProvider from '@/components/ThemeProvider'
 import { ToastProvider } from '@/components/Toast'
 import ContractAlertsBanner from '@/components/ContractAlertsBanner'
@@ -148,18 +149,8 @@ function GlobalHeader({ pathname }: { pathname: string }) {
             )}
           </Link>
 
-          {/* User avatar */}
-          <div
-            className="inline-flex items-center justify-center w-8 h-8 rounded-full text-[12px] font-semibold"
-            style={{
-              backgroundColor: 'rgba(59, 130, 246, 0.15)',
-              color: '#60A5FA',
-              border: '1px solid rgba(59, 130, 246, 0.3)',
-            }}
-            title="Account"
-          >
-            MR
-          </div>
+          {/* User avatar / profile menu (sprint S4) */}
+          <ProfileMenu />
         </div>
       </div>
     </header>

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+// BaW OS — ProfileMenu (Sprint 3 / S4)
+// Reemplaza el <div>MR</div> hardcoded en AppShell.
+// Lee user_profiles para nombre/avatar; muestra menú con perfil, tema y logout.
+
+import { useEffect, useState, useRef } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { User, LogOut, Settings, Sun, Moon, Monitor } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+
+type ThemePref = 'light' | 'dark' | 'system'
+
+interface UserBasics {
+  id: string
+  email: string | null
+  full_name: string | null
+  avatar_url: string | null
+}
+
+function getInitials(nameOrEmail: string | null): string {
+  if (!nameOrEmail) return '·'
+  const cleaned = nameOrEmail.trim()
+  if (!cleaned) return '·'
+  // Si es email, usar primera letra del local-part
+  if (cleaned.includes('@')) {
+    return cleaned[0].toUpperCase()
+  }
+  const parts = cleaned.split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return '·'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+export default function ProfileMenu() {
+  const router = useRouter()
+  const [user, setUser] = useState<UserBasics | null>(null)
+  const [open, setOpen] = useState(false)
+  const [theme, setTheme] = useState<ThemePref>('dark')
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    async function load() {
+      const { data: sd } = await supabase.auth.getSession()
+      const session = sd.session
+      if (!session) {
+        setUser(null)
+        return
+      }
+      // Intentar leer user_profiles; si no existe, fallback al auth user
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('full_name, avatar_url')
+        .eq('user_id', session.user.id)
+        .maybeSingle()
+      setUser({
+        id: session.user.id,
+        email: session.user.email ?? null,
+        full_name: profile?.full_name ?? null,
+        avatar_url: profile?.avatar_url ?? null,
+      })
+    }
+    load()
+
+    // Tema inicial desde localStorage
+    try {
+      const t = localStorage.getItem('baw:theme') as ThemePref | null
+      if (t === 'light' || t === 'dark' || t === 'system') {
+        setTheme(t)
+        applyTheme(t)
+      }
+    } catch {
+      // ignore
+    }
+
+    function onClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [])
+
+  function applyTheme(t: ThemePref) {
+    const root = document.documentElement
+    if (t === 'system') {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      root.classList.toggle('dark', prefersDark)
+    } else {
+      root.classList.toggle('dark', t === 'dark')
+    }
+  }
+
+  function changeTheme(t: ThemePref) {
+    setTheme(t)
+    try {
+      localStorage.setItem('baw:theme', t)
+    } catch {
+      // ignore
+    }
+    applyTheme(t)
+  }
+
+  async function handleLogout() {
+    await supabase.auth.signOut()
+    router.replace('/login')
+  }
+
+  const displayName = user?.full_name || user?.email || 'Cuenta'
+  const initials = getInitials(user?.full_name || user?.email || null)
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center justify-center w-8 h-8 rounded-full text-[12px] font-semibold overflow-hidden"
+        style={{
+          backgroundColor: 'rgba(59, 130, 246, 0.15)',
+          color: '#60A5FA',
+          border: '1px solid rgba(59, 130, 246, 0.3)',
+        }}
+        title={displayName}
+        aria-label="Abrir menú de cuenta"
+      >
+        {user?.avatar_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={user.avatar_url}
+            alt={displayName}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          initials
+        )}
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-2 w-60 rounded-md shadow-lg z-50 overflow-hidden"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          {/* Header */}
+          <div
+            className="px-3 py-2.5"
+            style={{ borderBottom: '1px solid var(--baw-border)' }}
+          >
+            <div
+              className="text-[12px] font-medium truncate"
+              style={{ color: 'var(--baw-text)' }}
+            >
+              {displayName}
+            </div>
+            {user?.email && user.email !== displayName && (
+              <div
+                className="text-[11px] truncate"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                {user.email}
+              </div>
+            )}
+          </div>
+
+          {/* Items */}
+          <ul>
+            <li>
+              <Link
+                href="/settings"
+                onClick={() => setOpen(false)}
+                className="flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
+                style={{ color: 'var(--baw-text)' }}
+              >
+                <User size={14} />
+                Mi perfil
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/settings"
+                onClick={() => setOpen(false)}
+                className="flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
+                style={{ color: 'var(--baw-text)' }}
+              >
+                <Settings size={14} />
+                Configuración
+              </Link>
+            </li>
+          </ul>
+
+          <div
+            className="border-t"
+            style={{ borderColor: 'var(--baw-border)' }}
+          />
+
+          {/* Theme picker */}
+          <div className="px-3 py-2">
+            <div
+              className="text-[10px] uppercase tracking-wider mb-1.5"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              Tema
+            </div>
+            <div className="flex gap-1">
+              <ThemeButton
+                active={theme === 'light'}
+                onClick={() => changeTheme('light')}
+                icon={<Sun size={13} />}
+                label="Claro"
+              />
+              <ThemeButton
+                active={theme === 'dark'}
+                onClick={() => changeTheme('dark')}
+                icon={<Moon size={13} />}
+                label="Oscuro"
+              />
+              <ThemeButton
+                active={theme === 'system'}
+                onClick={() => changeTheme('system')}
+                icon={<Monitor size={13} />}
+                label="Auto"
+              />
+            </div>
+          </div>
+
+          <div
+            className="border-t"
+            style={{ borderColor: 'var(--baw-border)' }}
+          />
+
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="w-full flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
+            style={{ color: 'var(--baw-muted)' }}
+          >
+            <LogOut size={14} />
+            Cerrar sesión
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ThemeButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex-1 flex flex-col items-center gap-0.5 py-1.5 rounded-md text-[10px]"
+      style={{
+        backgroundColor: active ? 'rgba(59,130,246,0.12)' : 'transparent',
+        border: active
+          ? '1px solid var(--baw-primary)'
+          : '1px solid var(--baw-border)',
+        color: active ? 'var(--baw-primary)' : 'var(--baw-muted)',
+      }}
+    >
+      {icon}
+      {label}
+    </button>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,7 +7,6 @@ import {
   Building2,
   FileText,
   LayoutDashboard,
-  LogOut,
   Menu,
   X,
   Wrench,
@@ -29,6 +28,8 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { supabase } from '@/lib/supabase'
+import WorkspaceSwitcher from '@/components/WorkspaceSwitcher'
+import AgentsList from '@/components/AgentsList'
 
 type NavItem = {
   name: string
@@ -116,12 +117,6 @@ export default function Sidebar() {
     try {
       window.localStorage.setItem('baw-sidebar-pinned', next ? '1' : '0')
     } catch {}
-  }
-
-  async function handleLogout() {
-    await supabase.auth.signOut()
-    router.push('/login')
-    router.refresh()
   }
 
   function badgeFor(item: NavItem) {
@@ -297,46 +292,20 @@ export default function Sidebar() {
           })}
         </nav>
 
-        {/* Footer: building selector + logout */}
+        {/* Agentes (sprint S4) */}
+        <div
+          className="shrink-0 pt-2"
+          style={{ borderTop: '1px solid #2A2A32' }}
+        >
+          <AgentsList expanded={expanded} />
+        </div>
+
+        {/* Footer: workspace switcher real (sprint S4). Logout movido a ProfileMenu. */}
         <div
           className="shrink-0 py-2"
           style={{ borderTop: '1px solid #2A2A32' }}
         >
-          <button
-            type="button"
-            className="flex items-center h-9 mx-2 rounded-md transition-colors hover:bg-white/5 w-[calc(100%-16px)]"
-            style={{ color: 'var(--baw-text)' }}
-            title={!expanded ? 'Frontier Bay' : undefined}
-          >
-            <span className="flex items-center justify-center w-[40px] shrink-0">
-              <Building2 className="w-[18px] h-[18px]" style={{ color: 'var(--baw-muted)' }} />
-            </span>
-            {expanded && (
-              <span className="flex items-center justify-between flex-1 min-w-0 pr-3">
-                <span className="flex flex-col items-start min-w-0">
-                  <span className="text-[12px] font-medium truncate">Frontier Bay</span>
-                  <span className="text-[10px]" style={{ color: 'var(--baw-muted)' }}>
-                    Mateos 809, CDMX
-                  </span>
-                </span>
-                <ChevronRight className="w-3.5 h-3.5" style={{ color: 'var(--baw-muted)' }} />
-              </span>
-            )}
-          </button>
-
-          <button
-            onClick={handleLogout}
-            className="flex items-center h-9 mx-2 rounded-md transition-colors hover:bg-white/5 w-[calc(100%-16px)]"
-            style={{ color: 'var(--baw-muted)' }}
-            title={!expanded ? 'Cerrar sesión' : undefined}
-          >
-            <span className="flex items-center justify-center w-[40px] shrink-0">
-              <LogOut className="w-[18px] h-[18px]" />
-            </span>
-            {expanded && (
-              <span className="text-[13px] font-medium">Cerrar sesión</span>
-            )}
-          </button>
+          <WorkspaceSwitcher expanded={expanded} />
         </div>
       </aside>
     </>

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+// BaW OS — WorkspaceSwitcher (Sprint 3 / S4)
+// Reemplaza el chip "Frontier Bay" hardcoded en Sidebar.
+// Lee organizations + buildings reales del usuario via useActiveContext.
+
+import { useState, useRef, useEffect } from 'react'
+import { Building2, ChevronRight, Check, Plus } from 'lucide-react'
+import Link from 'next/link'
+import { useActiveContext } from '@/lib/useActiveContext'
+
+interface Props {
+  expanded: boolean
+}
+
+export default function WorkspaceSwitcher({ expanded }: Props) {
+  const {
+    loading,
+    orgs,
+    buildings,
+    activeOrgId,
+    activeBuildingId,
+    setActiveOrgId,
+    setActiveBuildingId,
+  } = useActiveContext()
+
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [])
+
+  const activeOrg = orgs.find((o) => o.id === activeOrgId)
+  const activeBuilding = buildings.find((b) => b.id === activeBuildingId)
+  const buildingsForActiveOrg = buildings.filter(
+    (b) => b.org_id === activeOrgId,
+  )
+
+  // Estados sin datos
+  const isEmpty = !loading && orgs.length === 0
+  const titleText = isEmpty
+    ? 'Sin PM Company'
+    : activeOrg?.name ?? '—'
+  const subText = isEmpty
+    ? 'Empezar onboarding'
+    : activeBuilding
+    ? `${activeBuilding.name}${activeBuilding.city ? `, ${activeBuilding.city}` : ''}`
+    : 'Sin edificio'
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => !isEmpty && setOpen((o) => !o)}
+        className="flex items-center h-9 mx-2 rounded-md transition-colors hover:bg-white/5 w-[calc(100%-16px)]"
+        style={{ color: 'var(--baw-text)' }}
+        title={!expanded ? titleText : undefined}
+      >
+        <span className="flex items-center justify-center w-[40px] shrink-0">
+          <Building2
+            className="w-[18px] h-[18px]"
+            style={{ color: 'var(--baw-muted)' }}
+          />
+        </span>
+        {expanded && (
+          <span className="flex items-center justify-between flex-1 min-w-0 pr-3">
+            <span className="flex flex-col items-start min-w-0">
+              <span className="text-[12px] font-medium truncate">
+                {titleText}
+              </span>
+              <span
+                className="text-[10px] truncate"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                {subText}
+              </span>
+            </span>
+            {!isEmpty && (
+              <ChevronRight
+                className="w-3.5 h-3.5"
+                style={{ color: 'var(--baw-muted)' }}
+              />
+            )}
+          </span>
+        )}
+      </button>
+
+      {open && expanded && !isEmpty && (
+        <div
+          className="absolute left-2 right-2 bottom-full mb-2 rounded-md shadow-lg z-50 overflow-hidden"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          {orgs.length > 1 && (
+            <>
+              <div
+                className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                PM Company
+              </div>
+              <ul>
+                {orgs.map((org) => (
+                  <li key={org.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setActiveOrgId(org.id)
+                      }}
+                      className="w-full flex items-center justify-between gap-2 px-3 py-1.5 text-[12px] hover:bg-white/5"
+                      style={{ color: 'var(--baw-text)' }}
+                    >
+                      <span className="truncate">{org.name}</span>
+                      {org.id === activeOrgId && (
+                        <Check
+                          size={12}
+                          style={{ color: 'var(--baw-primary)' }}
+                        />
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <div
+                className="border-t my-1"
+                style={{ borderColor: 'var(--baw-border)' }}
+              />
+            </>
+          )}
+
+          <div
+            className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider"
+            style={{ color: 'var(--baw-muted)' }}
+          >
+            Edificio
+          </div>
+          {buildingsForActiveOrg.length === 0 ? (
+            <div
+              className="px-3 py-2 text-[12px]"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              Esta organización aún no tiene edificios.
+            </div>
+          ) : (
+            <ul>
+              {buildingsForActiveOrg.map((b) => (
+                <li key={b.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setActiveBuildingId(b.id)
+                      setOpen(false)
+                    }}
+                    className="w-full flex items-center justify-between gap-2 px-3 py-1.5 text-[12px] hover:bg-white/5"
+                    style={{ color: 'var(--baw-text)' }}
+                  >
+                    <span className="flex flex-col items-start min-w-0">
+                      <span className="truncate">{b.name}</span>
+                      {b.city && (
+                        <span
+                          className="text-[10px] truncate"
+                          style={{ color: 'var(--baw-muted)' }}
+                        >
+                          {b.city}
+                        </span>
+                      )}
+                    </span>
+                    {b.id === activeBuildingId && (
+                      <Check
+                        size={12}
+                        style={{ color: 'var(--baw-primary)' }}
+                      />
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div
+            className="border-t mt-1"
+            style={{ borderColor: 'var(--baw-border)' }}
+          />
+          <Link
+            href="/onboarding"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
+            style={{ color: 'var(--baw-primary)' }}
+          >
+            <Plus size={12} />
+            Agregar edificio
+          </Link>
+        </div>
+      )}
+
+      {/* CTA cuando no hay nada */}
+      {isEmpty && expanded && (
+        <Link
+          href="/onboarding"
+          className="absolute inset-0 flex items-center"
+          aria-label="Empezar onboarding"
+        />
+      )}
+    </div>
+  )
+}

--- a/src/lib/useActiveContext.ts
+++ b/src/lib/useActiveContext.ts
@@ -1,0 +1,199 @@
+'use client'
+
+// BaW OS — useActiveContext (Sprint 3 / S4)
+// Hook compartido que mantiene la PM Company y el Building activos.
+// Persiste la selección en localStorage. Se hidrata desde Supabase la primera
+// vez que se monta tras login. Lee `org_members` para saber a qué orgs
+// pertenece el usuario y `buildings` para listarlos por org.
+
+import { useEffect, useState, useCallback } from 'react'
+import { supabase } from '@/lib/supabase'
+
+const STORAGE_KEY_ORG = 'baw:active_org_id'
+const STORAGE_KEY_BUILDING = 'baw:active_building_id'
+
+export interface OrgOption {
+  id: string
+  name: string
+  slug: string
+}
+
+export interface BuildingOption {
+  id: string
+  org_id: string
+  name: string
+  city: string | null
+}
+
+export interface ActiveContext {
+  loading: boolean
+  userId: string | null
+  userEmail: string | null
+  orgs: OrgOption[]
+  buildings: BuildingOption[]
+  activeOrgId: string | null
+  activeBuildingId: string | null
+  setActiveOrgId: (id: string) => void
+  setActiveBuildingId: (id: string) => void
+  refresh: () => Promise<void>
+}
+
+export function useActiveContext(): ActiveContext {
+  const [loading, setLoading] = useState(true)
+  const [userId, setUserId] = useState<string | null>(null)
+  const [userEmail, setUserEmail] = useState<string | null>(null)
+  const [orgs, setOrgs] = useState<OrgOption[]>([])
+  const [buildings, setBuildings] = useState<BuildingOption[]>([])
+  const [activeOrgId, setActiveOrgIdState] = useState<string | null>(null)
+  const [activeBuildingId, setActiveBuildingIdState] = useState<string | null>(
+    null,
+  )
+
+  const setActiveOrgId = useCallback((id: string) => {
+    setActiveOrgIdState(id)
+    try {
+      localStorage.setItem(STORAGE_KEY_ORG, id)
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const setActiveBuildingId = useCallback((id: string) => {
+    setActiveBuildingIdState(id)
+    try {
+      localStorage.setItem(STORAGE_KEY_BUILDING, id)
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const { data: sessionData } = await supabase.auth.getSession()
+      const session = sessionData.session
+      if (!session) {
+        setUserId(null)
+        setUserEmail(null)
+        setOrgs([])
+        setBuildings([])
+        return
+      }
+      setUserId(session.user.id)
+      setUserEmail(session.user.email ?? null)
+
+      // Memberships del usuario
+      const { data: members } = await supabase
+        .from('org_members')
+        .select('org_id, organizations(id, name, slug)')
+        .eq('user_id', session.user.id)
+
+      const orgList: OrgOption[] = (members || [])
+        .map((m: any) => {
+          const org = Array.isArray(m.organizations)
+            ? m.organizations[0]
+            : m.organizations
+          return org
+            ? { id: org.id, name: org.name, slug: org.slug }
+            : null
+        })
+        .filter(Boolean) as OrgOption[]
+
+      setOrgs(orgList)
+
+      // Determinar org activa
+      let nextActiveOrg: string | null = null
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY_ORG)
+        if (stored && orgList.some((o) => o.id === stored)) {
+          nextActiveOrg = stored
+        }
+      } catch {
+        // ignore
+      }
+      if (!nextActiveOrg && orgList.length > 0) {
+        nextActiveOrg = orgList[0].id
+      }
+      setActiveOrgIdState(nextActiveOrg)
+
+      // Buildings de todas las orgs del usuario
+      if (orgList.length > 0) {
+        const { data: bldgs } = await supabase
+          .from('buildings')
+          .select('id, org_id, name, city')
+          .in(
+            'org_id',
+            orgList.map((o) => o.id),
+          )
+          .order('name', { ascending: true })
+
+        const bldList: BuildingOption[] = (bldgs as any[]) || []
+        setBuildings(bldList)
+
+        let nextActiveBld: string | null = null
+        try {
+          const stored = localStorage.getItem(STORAGE_KEY_BUILDING)
+          if (
+            stored &&
+            bldList.some(
+              (b) => b.id === stored && b.org_id === nextActiveOrg,
+            )
+          ) {
+            nextActiveBld = stored
+          }
+        } catch {
+          // ignore
+        }
+        if (!nextActiveBld && nextActiveOrg) {
+          const first = bldList.find((b) => b.org_id === nextActiveOrg)
+          nextActiveBld = first?.id ?? null
+        }
+        setActiveBuildingIdState(nextActiveBld)
+      } else {
+        setBuildings([])
+        setActiveBuildingIdState(null)
+      }
+    } catch (e) {
+      // soft-fail: el componente que consume el hook decide qué mostrar
+      // eslint-disable-next-line no-console
+      console.error('useActiveContext refresh error', e)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  // Si cambia la org activa, ajustar el building activo si pertenece a otra org
+  useEffect(() => {
+    if (!activeOrgId) return
+    if (activeBuildingId) {
+      const current = buildings.find((b) => b.id === activeBuildingId)
+      if (current && current.org_id === activeOrgId) return
+    }
+    const first = buildings.find((b) => b.org_id === activeOrgId)
+    setActiveBuildingIdState(first?.id ?? null)
+    if (first) {
+      try {
+        localStorage.setItem(STORAGE_KEY_BUILDING, first.id)
+      } catch {
+        // ignore
+      }
+    }
+  }, [activeOrgId, activeBuildingId, buildings])
+
+  return {
+    loading,
+    userId,
+    userEmail,
+    orgs,
+    buildings,
+    activeOrgId,
+    activeBuildingId,
+    setActiveOrgId,
+    setActiveBuildingId,
+    refresh,
+  }
+}


### PR DESCRIPTION
## Sprint 3 · S4 · Identidad UI (WorkspaceSwitcher + ProfileMenu + Agentes)

Reemplaza los placeholders hardcodeados que quedaban del Sprint 1 y agrega visibilidad de los agentes del workforce v0.2.

### Cambios

#### 1. `src/lib/useActiveContext.ts` — hook compartido

Mantiene la **PM Company** y el **Building** activos en cualquier punto de la app. Lee `org_members` para listar las orgs del usuario, `buildings` para listarlos por org, y persiste la selección en `localStorage` (`baw:active_org_id`, `baw:active_building_id`). Si la org activa cambia, ajusta el building activo automáticamente al primero disponible.

API expuesta: `loading`, `userId`, `userEmail`, `orgs`, `buildings`, `activeOrgId`, `activeBuildingId`, `setActiveOrgId`, `setActiveBuildingId`, `refresh`.

#### 2. `src/components/WorkspaceSwitcher.tsx` — chip inferior izquierdo real

Reemplaza el `<button>` con texto "Frontier Bay / Mateos 809, CDMX" hardcodeado en `Sidebar.tsx`. Ahora:

- Lee la PM Company y el Building activos del hook.
- Dropdown con dos secciones: **PM Company** (sólo si el usuario pertenece a más de una) y **Edificio** (filtrados por org activa).
- Estado vacío cuando el usuario no tiene memberships: muestra "Sin PM Company / Empezar onboarding" con link a `/onboarding`.
- Item final del dropdown: "Agregar edificio" → también va a `/onboarding`.

#### 3. `src/components/ProfileMenu.tsx` — avatar superior derecho real

Reemplaza el `<div>MR</div>` hardcodeado en `AppShell.tsx`. Ahora:

- Lee `user_profiles` (full_name, avatar_url) con fallback al email del session.
- Avatar: imagen si hay `avatar_url`, iniciales generadas si no.
- Menú dropdown: nombre + email, links a "Mi perfil" y "Configuración", **theme picker** (Claro / Oscuro / Auto, persistido en `localStorage` y aplicado a `document.documentElement`), y **Cerrar sesión** (movido aquí desde el sidebar).

#### 4. `src/components/AgentsList.tsx` — sección Agentes en sidebar

Sección colapsable arriba del WorkspaceSwitcher con los **11 agentes del workforce v0.2**:

| Grupo | Agentes |
|---|---|
| Coordinador | **BaW** (status: idle) |
| Operaciones Core | Cobranza, Facturación, Mantenimiento (planeado) |
| Experiencia | Atención, Reservas, Tarifas, Renovaciones (planeado) |
| Inteligencia | Reportes, Auditoría, Fiscal (planeado) |

Cada item tiene un dot de color indicando status (`idle` verde, `running` azul, `paused` amarillo, `planned` gris). En modo colapsado solo se ve el ícono `Bot`.

> Solo presencia visual por ahora — los runtimes de agentes vendrán en sprints posteriores. Lo importante hoy es que la jerarquía mental queda visible: "BaW" sin "Agente", separado del resto.

#### 5. Limpieza

- `Sidebar.tsx`: removido `handleLogout` (ahora vive en `ProfileMenu`) y los imports de iconos que ya no se usan ahí.
- `AppShell.tsx`: el avatar ahora delega 100% en `<ProfileMenu />`.

### Verificación

- ✅ `npx tsc --noEmit` sin errores.
- ✅ `next build` compila las 30+ rutas.
- ⏳ Pendiente prueba E2E con un usuario logueado en preview Vercel (S6).

### Decisiones

- **Theme picker en ProfileMenu**, no en Settings, porque es una preferencia de usuario que se quiere cambiar rápido. Settings sigue accesible para configuración de la org.
- **Hook compartido** en lugar de Context Provider para mantener simplicidad — cada componente que lo necesite hace fetch propio (rápido porque viene de `auth.getSession()` en sesión + un par de selects). Si esto duele en performance lo migramos a un provider.
- **Agentes Core / Experiencia / Inteligencia con status `planned`** porque sus runtimes no existen aún. BaW queda en `idle` (existe como concepto, espera ser invocado).

### Referencia

- Doc maestro v0.2 §3 (catálogo) y §4.1 (BaW como coordinador, no agente especialista).
- PR base: #5 (Multi-tenancy v2) y #6 (Onboarding wizard v2).
- Log nocturno en Notion.

🤖 Generado por Perplexity Personal Computer en sprint nocturno autónomo (S4).
