### PR TITLE
Sprint 3 · S6 · Bug bash + fix crítico getOrgId() post-wipe

### DIFF
--- a/BUG_BASH_S6.md
+++ b/BUG_BASH_S6.md
@@ -1,0 +1,60 @@
+# Bug Bash · Sprint 3 / S6
+
+**Fecha:** 2026-04-29 04:30–05:30 CST
+**Operador:** Perplexity Personal Computer (autónomo)
+
+## Journeys recorridos
+
+1. ✅ Onboarding desde cero (`/onboarding`) — wizard de 4 pasos verificado por código contra el API v2 (S3). Contrato body↔handler alineado, RLS service-role bypass funcional, rollback en cascada presente.
+2. ✅ Mission Control empty state (`/`) — empty state honesto cuando no hay unidades+contratos.
+3. ⚠️ Alta de unidad (`/units` + UnitModal) — depende de `getOrgId()` legacy. **Ver Bug #1**.
+4. ⚠️ Alta de contrato (`/contracts/new`) — depende de `getOrgId()` legacy. **Ver Bug #1**.
+5. ⚠️ Registro de pago (`/payments` + `/cobros`) — depende de `getOrgId()` legacy. **Ver Bug #1**.
+6. ⚠️ Owner portal (`/owner/[token]`, `/portal/[token]`, `/tenant/[token]`) — usa tokens, debería estar OK.
+7. ⚠️ Settings (`/settings`) — depende de `getOrgId()` legacy. **Ver Bug #1**.
+
+## Bugs encontrados
+
+### Bug #1 (BLOCKER, parche temporal aplicado)
+
+**Síntoma:** tras el wipe operativo de S1, todas las APIs legacy (~73 archivos: `/api/units`, `/api/contracts`, `/api/payments`, `/api/tasks`, `/api/notifications`, `/api/whatsapp/*`, etc.) seguían apuntando a `ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'` (la UUID Mateos eliminada en S1). Resultado esperado: cualquier query legacy retorna 0 filas o error de FK contra una org inexistente.
+
+**Causa raíz:** `src/lib/api-auth.ts` definía `ORG_ID` como constante hardcoded.
+
+**Parche aplicado en S6 (PR #9):**
+- `getOrgId()` ahora usa cache con TTL (60s) que se rellena dinámicamente con la primera organization disponible.
+- Nuevo `getOrgIdAsync()` para usar en APIs nuevas — resuelve via service-role la primera org en `organizations` ordenada por `created_at`.
+- Nuevo `setActiveOrgId(orgId)` que el onboarding llama tras crear la nueva PM Company para calentar el cache inmediatamente.
+- Soporta env var `BAW_FALLBACK_ORG_ID` para casos edge.
+
+**Limitaciones del parche:**
+- Best-effort, no es seguro en multi-tenant real (la primera org gana).
+- Cualquier nuevo PM Company creado en una segunda sesión **no** será visible para las APIs legacy hasta que el cache expire (60s) o reinicies el server.
+- No respeta el principio "el org_id debe venir del JWT del usuario actual".
+
+**Decisión humana pendiente (Fran):** refactor real para leer `org_id` del JWT del usuario en cada API legacy. Opciones:
+1. Middleware Next.js que inyecta header `x-baw-org-id` en cada request server-side.
+2. Cada API recibe `cookies()` y lee `org_id` del JWT directamente.
+3. Migrar las 73 APIs a `getOrgIdAsync()` con `await` (atómico pero requiere tocar todos los handlers).
+
+### Bug #2 (resuelto en S3, no en este sprint)
+
+**Síntoma histórico:** el API onboarding pre-S3 insertaba `occupants.type = 'tenant'` que viola el CHECK constraint `IN ('ltr', 'str', 'both')`. Causaba 500 al onboarding inicial.
+
+**Causa raíz:** mismatch entre el código TypeScript y el schema real de `occupants.type` (es TEXT con CHECK, no enum).
+
+**Estado:** corregido en PR #6 (Sprint 3 / S3) cuando se reescribió el API completo. El nuevo wizard no crea occupants en el onboarding (los crea cuando se firma el primer contrato).
+
+### Bug #3 (no crítico, deuda documentada)
+
+**Síntoma:** 206 referencias HEX/`rgba()` directas en componentes individuales (`Sidebar.tsx`, `AppShell.tsx`, `ui/status.tsx`, etc.) siguen vivas tras la migración a tokens canónicos OKLCH del PR #8 (S5).
+
+**Estado:** no bloquea el rendering — los aliases `--baw-*` migran automáticamente todos los consumidores via CSS. Migrar las 206 ocurrencias a `var(--brand-*)`/`var(--agent-*)`/`var(--green-*)`/etc. mejora consistencia visual en wide-gamut pero no afecta funcionalidad.
+
+**Recomendación:** sprint posterior dedicado, idealmente con visual regression tests.
+
+## Recomendación al despertar
+
+1. Revisar PRs #5, #6, #7, #8, #9 en orden de dependencia.
+2. Decidir camino del refactor `getOrgId` (Bug #1 sigue siendo deuda crítica).
+3. Probar onboarding E2E en preview de Vercel del PR #9 antes de merge a main.

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,92 +1,204 @@
-// BaW OS — Onboarding Wizard API
-import { NextRequest } from 'next/server'
-import { createServiceClient, getOrgId, apiOk, apiError } from '@/lib/api-auth'
+// BaW OS — Onboarding Wizard v2 API (Sprint 3 / S3)
+// Crea PM Company → org_member (pm_owner) → Building → Units → Property Owner → ownership_stake
+// en un único request. Usa service-role para bypass de RLS y se hace best-effort de rollback.
 
-interface OnboardingBody {
-  building: { name: string; address: string; city: string }
-  units: Array<{ number: string; type: 'STR' | 'MTR' | 'LTR'; floor: number }>
-  tenants: Array<{
+import { NextRequest } from 'next/server'
+import { createServiceClient, apiOk, apiError } from '@/lib/api-auth'
+
+interface UnitInput {
+  number: string
+  type: 'STR' | 'MTR' | 'LTR'
+  floor: number
+}
+
+interface OwnerInput {
+  full_name: string
+  email: string | null
+  phone: string | null
+  rfc: string | null
+  percentage: number
+  user_id: string | null
+}
+
+interface OnboardingV2Body {
+  user_id: string
+  pm: { name: string; slug: string }
+  building: {
     name: string
-    phone?: string
-    unit_number: string
-    monthly_amount: number
-    start_date: string
-  }>
+    address: string | null
+    city: string
+    state: string | null
+    country: string
+    postal_code: string | null
+  }
+  units: UnitInput[]
+  owner_mode: 'self' | 'client' | 'skip'
+  owner: OwnerInput | null
 }
 
 export async function POST(request: NextRequest) {
+  let createdOrgId: string | null = null
   try {
-    const body = (await request.json()) as OnboardingBody
-    const supabase = createServiceClient()
-    const orgId = getOrgId()
+    const body = (await request.json()) as OnboardingV2Body
 
-    if (!body.units || body.units.length === 0) {
+    // Validaciones mínimas
+    if (!body.user_id) return apiError('user_id es obligatorio', 400)
+    if (!body.pm?.name || !body.pm?.slug)
+      return apiError('PM Company name y slug son obligatorios', 400)
+    if (!body.building?.name || !body.building?.city)
+      return apiError('Edificio: name y city son obligatorios', 400)
+    if (!body.units || body.units.length === 0)
       return apiError('Se requiere al menos una unidad', 400)
+
+    const supabase = createServiceClient()
+
+    // 1) PM Company (organizations)
+    const { data: org, error: orgErr } = await supabase
+      .from('organizations')
+      .insert({
+        name: body.pm.name,
+        slug: body.pm.slug,
+        settings: { onboarded_at: new Date().toISOString() },
+      })
+      .select('id')
+      .single()
+
+    if (orgErr || !org) {
+      // 23505 = unique violation
+      const msg =
+        orgErr?.code === '23505'
+          ? `El slug "${body.pm.slug}" ya existe. Cambia el nombre o slug.`
+          : `Error creando PM Company: ${orgErr?.message ?? 'desconocido'}`
+      return apiError(msg, 400)
+    }
+    createdOrgId = org.id
+
+    // 2) org_member del usuario actual como pm_owner
+    const { error: memberErr } = await supabase.from('org_members').insert({
+      org_id: org.id,
+      user_id: body.user_id,
+      role: 'pm_owner',
+    })
+    if (memberErr) {
+      await rollback(supabase, createdOrgId!)
+      return apiError(`Error creando membresía: ${memberErr.message}`, 500)
     }
 
-    // 1. Crear unidades
+    // 3) Building
+    const { data: bld, error: bldErr } = await supabase
+      .from('buildings')
+      .insert({
+        org_id: org.id,
+        name: body.building.name,
+        address: body.building.address,
+        city: body.building.city,
+        state: body.building.state,
+        country: body.building.country || 'MX',
+        postal_code: body.building.postal_code,
+      })
+      .select('id')
+      .single()
+    if (bldErr || !bld) {
+      await rollback(supabase, createdOrgId!)
+      return apiError(`Error creando edificio: ${bldErr?.message}`, 500)
+    }
+
+    // 4) Units (bulk insert)
     const unitInserts = body.units.map((u) => ({
-      org_id: orgId,
+      org_id: org.id,
+      building_id: bld.id,
       number: u.number,
       type: u.type,
       floor: u.floor,
       status: 'available',
-      notes: `Creada via onboarding — ${body.building.name}`,
     }))
-
     const { data: createdUnits, error: unitsErr } = await supabase
       .from('units')
       .insert(unitInserts)
-      .select('id, number')
-
-    if (unitsErr) return apiError(`Error creando unidades: ${unitsErr.message}`, 500)
-
-    // Mapa número → id para enlazar inquilinos
-    const unitMap = new Map<string, string>()
-    for (const u of createdUnits || []) {
-      unitMap.set(u.number, u.id)
+      .select('id')
+    if (unitsErr) {
+      await rollback(supabase, createdOrgId!)
+      return apiError(`Error creando unidades: ${unitsErr.message}`, 500)
     }
 
-    // 2. Crear inquilinos y contratos
-    let contractsCreated = 0
-    for (const t of body.tenants || []) {
-      const unitId = unitMap.get(t.unit_number)
-      if (!unitId || !t.name) continue
-
-      // Crear occupant
-      const { data: occ, error: occErr } = await supabase
-        .from('occupants')
-        .insert({
-          org_id: orgId,
-          name: t.name,
-          phone: t.phone || null,
-          type: 'tenant',
-        })
+    // 5) Property Owner + ownership_stake (si aplica)
+    let ownerId: string | null = null
+    if (body.owner_mode !== 'skip' && body.owner) {
+      const ownerData = {
+        org_id: org.id,
+        user_id: body.owner.user_id, // null en modo client, user actual en modo self
+        full_name: body.owner.full_name,
+        email: body.owner.email,
+        phone: body.owner.phone,
+        rfc: body.owner.rfc,
+      }
+      const { data: po, error: poErr } = await supabase
+        .from('property_owners')
+        .insert(ownerData)
         .select('id')
         .single()
+      if (poErr || !po) {
+        await rollback(supabase, createdOrgId!)
+        return apiError(
+          `Error creando Property Owner: ${poErr?.message}`,
+          500,
+        )
+      }
+      ownerId = po.id
 
-      if (occErr || !occ) continue
-
-      // Crear contrato activo
-      const { error: cErr } = await supabase.from('contracts').insert({
-        org_id: orgId,
-        unit_id: unitId,
-        occupant_id: occ.id,
-        monthly_amount: t.monthly_amount,
-        payment_day: 1,
-        start_date: t.start_date,
-        status: 'active',
+      const pct = clampPercentage(body.owner.percentage, body.owner_mode)
+      const { error: stakeErr } = await supabase.from('ownership_stakes').insert({
+        org_id: org.id,
+        building_id: bld.id,
+        property_owner_id: po.id,
+        percentage: pct,
+        starts_on: new Date().toISOString().slice(0, 10),
       })
-
-      if (!cErr) {
-        contractsCreated++
-        // Marcar unidad como ocupada
-        await supabase.from('units').update({ status: 'occupied' }).eq('id', unitId)
+      if (stakeErr) {
+        await rollback(supabase, createdOrgId!)
+        return apiError(
+          `Error creando ownership stake: ${stakeErr.message}`,
+          500,
+        )
       }
     }
 
-    return apiOk({ units_created: createdUnits?.length || 0, contracts_created: contractsCreated })
+    return apiOk({
+      org_id: org.id,
+      building_id: bld.id,
+      units_created: createdUnits?.length ?? 0,
+      property_owner_id: ownerId,
+    })
   } catch (err) {
-    return apiError(err instanceof Error ? err.message : 'Error interno', 500)
+    if (createdOrgId) {
+      try {
+        const supabase = createServiceClient()
+        await rollback(supabase, createdOrgId!)
+      } catch {
+        // best-effort
+      }
+    }
+    return apiError(
+      err instanceof Error ? err.message : 'Error interno',
+      500,
+    )
   }
+}
+
+// Rollback best-effort cuando algún paso falla. Confía en CASCADE de FK.
+async function rollback(
+  supabase: ReturnType<typeof createServiceClient>,
+  orgId: string,
+) {
+  // Buildings, units, property_owners, ownership_stakes, org_members tienen
+  // ON DELETE CASCADE desde organizations.
+  await supabase.from('organizations').delete().eq('id', orgId)
+}
+
+function clampPercentage(v: number, mode: 'self' | 'client' | 'skip'): number {
+  if (mode === 'self') return 100
+  const n = Number(v)
+  if (!Number.isFinite(n) || n <= 0) return 100
+  if (n > 100) return 100
+  return Math.round(n * 100) / 100
 }

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -3,7 +3,7 @@
 // en un único request. Usa service-role para bypass de RLS y se hace best-effort de rollback.
 
 import { NextRequest } from 'next/server'
-import { createServiceClient, apiOk, apiError } from '@/lib/api-auth'
+import { createServiceClient, apiOk, apiError, setActiveOrgId } from '@/lib/api-auth'
 
 interface UnitInput {
   number: string
@@ -72,6 +72,10 @@ export async function POST(request: NextRequest) {
       return apiError(msg, 400)
     }
     createdOrgId = org.id
+    // Sprint 3 / S6: caliente el cache de org_id legacy para que las APIs
+    // existentes (que usan getOrgId() síncrono) operen contra la org recién
+    // creada sin necesidad de un refresh manual.
+    setActiveOrgId(org.id)
 
     // 2) org_member del usuario actual como pm_owner
     const { error: memberErr } = await supabase.from('org_members').insert({

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,15 +1,41 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { Building2, Plus, Trash2, CheckCircle, ArrowLeft, ArrowRight, SkipForward } from 'lucide-react'
+// BaW OS — Onboarding Wizard v2 (Sprint 3 / S3)
+// Modelo de 5 capas: PM Company → PM Users → Buildings → Units → Property Owners
+// 4 pasos: PM Company · Edificio · Unidades · Property Owner
 
-// Tipos del wizard
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import {
+  Building2,
+  Briefcase,
+  Home,
+  UserCog,
+  CheckCircle2,
+  ArrowLeft,
+  ArrowRight,
+  Plus,
+  Trash2,
+  AlertTriangle,
+} from 'lucide-react'
+
+// -----------------------------------------------------------------------------
+// Tipos
+// -----------------------------------------------------------------------------
+
+interface PMCompanyData {
+  name: string
+  slug: string
+}
+
 interface BuildingData {
   name: string
   address: string
   city: string
-  total_units: number
+  state: string
+  country: string
+  postal_code: string
 }
 
 interface UnitRow {
@@ -18,53 +44,182 @@ interface UnitRow {
   floor: number
 }
 
-interface TenantRow {
-  name: string
+type OwnerMode = 'self' | 'client' | 'skip'
+
+interface OwnerData {
+  full_name: string
+  email: string
   phone: string
-  unit_number: string
-  monthly_amount: number
-  start_date: string
+  rfc: string
+  percentage: number
 }
 
-const STEPS = ['Edificio', 'Unidades', 'Inquilinos', 'Listo']
+const STEPS = [
+  { key: 'pm', label: 'PM Company', icon: Briefcase },
+  { key: 'building', label: 'Edificio', icon: Building2 },
+  { key: 'units', label: 'Unidades', icon: Home },
+  { key: 'owner', label: 'Property Owner', icon: UserCog },
+]
 
-export default function OnboardingWizard() {
+// -----------------------------------------------------------------------------
+// Utils
+// -----------------------------------------------------------------------------
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 60)
+}
+
+// -----------------------------------------------------------------------------
+// Componente principal
+// -----------------------------------------------------------------------------
+
+export default function OnboardingWizardV2() {
   const router = useRouter()
   const [step, setStep] = useState(0)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [result, setResult] = useState<{ units_created: number; contracts_created: number } | null>(null)
+  const [authChecked, setAuthChecked] = useState(false)
+  const [userId, setUserId] = useState<string | null>(null)
+  const [userEmail, setUserEmail] = useState<string | null>(null)
 
-  // Paso 1 — Edificio
+  // Paso 1 — PM Company (pre-poblado)
+  const [pm, setPM] = useState<PMCompanyData>({
+    name: 'BaW Operations',
+    slug: 'baw-operations',
+  })
+
+  // Paso 2 — Edificio
   const [building, setBuilding] = useState<BuildingData>({
     name: '',
     address: '',
     city: '',
-    total_units: 4,
+    state: '',
+    country: 'MX',
+    postal_code: '',
   })
 
-  // Paso 2 — Unidades
+  // Paso 3 — Unidades (bulk)
+  const [unitConfig, setUnitConfig] = useState({
+    count: 4,
+    prefix: '',
+    startNumber: 101,
+    floors: 4,
+    type: 'LTR' as UnitRow['type'],
+  })
   const [units, setUnits] = useState<UnitRow[]>([])
 
-  // Paso 3 — Inquilinos
-  const [tenants, setTenants] = useState<TenantRow[]>([])
+  // Paso 4 — Property Owner
+  const [ownerMode, setOwnerMode] = useState<OwnerMode>('self')
+  const [owner, setOwner] = useState<OwnerData>({
+    full_name: '',
+    email: '',
+    phone: '',
+    rfc: '',
+    percentage: 100,
+  })
 
-  // Al avanzar del paso 1 al 2, precarga filas vacías
-  function goToStep2() {
-    if (!building.name || !building.address || !building.city || building.total_units < 1) {
-      setError('Completa todos los campos antes de continuar.')
+  // Resultado final
+  const [result, setResult] = useState<{
+    org_id: string
+    building_id: string
+    units_created: number
+  } | null>(null)
+
+  // Auth gate (client-side: requiere usuario autenticado)
+  useEffect(() => {
+    async function checkAuth() {
+      const { data } = await supabase.auth.getSession()
+      const session = data.session
+      if (!session) {
+        router.replace('/login?redirect=/onboarding')
+        return
+      }
+      setUserId(session.user.id)
+      setUserEmail(session.user.email ?? null)
+      // Pre-poblar email del owner si modo "self"
+      setOwner((o) => ({ ...o, email: session.user.email ?? '' }))
+      setAuthChecked(true)
+    }
+    checkAuth()
+  }, [router])
+
+  // Mantener slug sincronizado mientras el usuario teclea el name
+  useEffect(() => {
+    setPM((p) => ({ ...p, slug: slugify(p.name) }))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pm.name])
+
+  // ---------------------------------------------------------------------------
+  // Handlers de navegación
+  // ---------------------------------------------------------------------------
+
+  function validateStep(idx: number): string | null {
+    if (idx === 0) {
+      if (!pm.name.trim()) return 'El nombre del PM Company es obligatorio.'
+      if (!pm.slug.trim()) return 'El slug es obligatorio (se genera automáticamente).'
+      return null
+    }
+    if (idx === 1) {
+      if (!building.name.trim()) return 'El nombre del edificio es obligatorio.'
+      if (!building.city.trim()) return 'La ciudad es obligatoria.'
+      return null
+    }
+    if (idx === 2) {
+      if (units.length === 0)
+        return 'Genera o agrega al menos una unidad antes de continuar.'
+      const numbers = units.map((u) => u.number.trim())
+      if (numbers.some((n) => !n)) return 'Todas las unidades deben tener número.'
+      const dup = numbers.find((n, i) => numbers.indexOf(n) !== i)
+      if (dup) return `Hay números duplicados: ${dup}`
+      return null
+    }
+    if (idx === 3) {
+      if (ownerMode === 'self') return null
+      if (ownerMode === 'skip') return null
+      if (!owner.full_name.trim())
+        return 'El nombre del propietario es obligatorio.'
+      if (owner.percentage <= 0 || owner.percentage > 100)
+        return 'El porcentaje debe estar entre 1 y 100.'
+      return null
+    }
+    return null
+  }
+
+  function next() {
+    const err = validateStep(step)
+    if (err) {
+      setError(err)
       return
     }
     setError(null)
-    if (units.length === 0) {
-      const rows: UnitRow[] = Array.from({ length: building.total_units }, (_, i) => ({
-        number: String(i + 1),
-        type: 'LTR',
-        floor: 1,
-      }))
-      setUnits(rows)
+    setStep(step + 1)
+  }
+
+  function back() {
+    setError(null)
+    if (step > 0) setStep(step - 1)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Generación de unidades en bulk
+  // ---------------------------------------------------------------------------
+
+  function generateUnits() {
+    const rows: UnitRow[] = []
+    const { count, prefix, startNumber, floors, type } = unitConfig
+    const perFloor = floors > 0 ? Math.ceil(count / floors) : count
+    for (let i = 0; i < count; i++) {
+      const floor = Math.min(floors, Math.floor(i / perFloor) + 1)
+      const num = `${prefix}${startNumber + i}`
+      rows.push({ number: num, type, floor })
     }
-    setStep(1)
+    setUnits(rows)
   }
 
   function addUnit() {
@@ -81,388 +236,920 @@ export default function OnboardingWizard() {
     setUnits(copy)
   }
 
-  function addTenant() {
-    setTenants([...tenants, { name: '', phone: '', unit_number: '', monthly_amount: 0, start_date: '' }])
-  }
+  // ---------------------------------------------------------------------------
+  // Submit final
+  // ---------------------------------------------------------------------------
 
-  function removeTenant(idx: number) {
-    setTenants(tenants.filter((_, i) => i !== idx))
-  }
-
-  function updateTenant(idx: number, field: keyof TenantRow, value: string | number) {
-    const copy = [...tenants]
-    copy[idx] = { ...copy[idx], [field]: value }
-    setTenants(copy)
-  }
-
-  // Enviar todo al API en el paso final
   async function handleSubmit() {
+    const err = validateStep(3)
+    if (err) {
+      setError(err)
+      return
+    }
+    if (!userId) {
+      setError('Sesión expirada. Vuelve a iniciar sesión.')
+      return
+    }
     setSubmitting(true)
     setError(null)
     try {
+      const payload = {
+        user_id: userId,
+        pm: { name: pm.name.trim(), slug: pm.slug.trim() },
+        building: {
+          name: building.name.trim(),
+          address: building.address.trim() || null,
+          city: building.city.trim(),
+          state: building.state.trim() || null,
+          country: building.country.trim() || 'MX',
+          postal_code: building.postal_code.trim() || null,
+        },
+        units: units.map((u) => ({
+          number: u.number.trim(),
+          type: u.type,
+          floor: Number(u.floor) || 1,
+        })),
+        owner_mode: ownerMode,
+        owner:
+          ownerMode === 'self'
+            ? {
+                full_name: pm.name,
+                email: userEmail,
+                phone: null,
+                rfc: null,
+                percentage: 100,
+                user_id: userId,
+              }
+            : ownerMode === 'client'
+            ? {
+                full_name: owner.full_name.trim(),
+                email: owner.email.trim() || null,
+                phone: owner.phone.trim() || null,
+                rfc: owner.rfc.trim() || null,
+                percentage: Number(owner.percentage),
+                user_id: null,
+              }
+            : null,
+      }
+
       const res = await fetch('/api/onboarding', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          building: { name: building.name, address: building.address, city: building.city },
-          units: units.map((u) => ({ number: u.number, type: u.type, floor: u.floor })),
-          tenants: tenants.filter((t) => t.name && t.unit_number),
-        }),
+        body: JSON.stringify(payload),
       })
-      const data = await res.json()
-      if (!res.ok || !data.success) throw new Error(data.error || 'Error al guardar')
-      setResult(data.data)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Error desconocido')
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        throw new Error(json.error || `HTTP ${res.status}`)
+      }
+      setResult(json.data)
+      // Mover al paso 5 (resumen)
+      setStep(4)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error inesperado.')
     } finally {
       setSubmitting(false)
     }
   }
 
-  // Validaciones por paso
-  const step1Valid = building.name && building.address && building.city && building.total_units >= 1
-  const step2Valid = units.length >= 1 && units.every((u) => u.number)
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  if (!authChecked) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <span className="muted-text text-[13px]">Cargando sesión…</span>
+      </div>
+    )
+  }
 
   return (
-    <div className="min-h-screen flex items-start justify-center pt-12 px-4 bg-black">
-      <div className="w-full max-w-2xl">
-        {/* Regresar al dashboard */}
-        <button
-          onClick={() => router.push('/')}
-          className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-white transition-colors mb-6"
+    <div
+      className="min-h-screen px-4 py-10"
+      style={{ backgroundColor: 'var(--baw-bg)', color: 'var(--baw-text)' }}
+    >
+      <div className="max-w-3xl mx-auto">
+        {/* Header */}
+        <header className="mb-8 text-center">
+          <h1 className="text-[28px] font-semibold tracking-tight">
+            Bienvenido a BaW OS
+          </h1>
+          <p className="muted-text text-[14px] mt-2">
+            Configura tu PM Company en cuatro pasos. BaW empieza a operar contigo
+            desde el primer edificio.
+          </p>
+        </header>
+
+        {/* Stepper */}
+        <Stepper currentStep={step} />
+
+        {/* Error banner */}
+        {error && (
+          <div
+            className="mt-6 px-4 py-3 rounded-md flex items-start gap-2 text-[13px]"
+            style={{
+              backgroundColor: 'rgba(248, 113, 113, 0.08)',
+              border: '1px solid rgba(248, 113, 113, 0.3)',
+              color: '#fca5a5',
+            }}
+          >
+            <AlertTriangle size={16} className="mt-0.5 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Step content */}
+        <div
+          className="mt-6 rounded-lg p-6"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
         >
-          <ArrowLeft className="w-4 h-4" /> Regresar al dashboard
-        </button>
-
-        {/* Progress bar */}
-        <div className="flex items-center justify-between mb-8">
-          {STEPS.map((label, i) => (
-            <div key={label} className="flex items-center gap-2 flex-1">
-              <div
-                className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold shrink-0 transition-colors ${
-                  i < step
-                    ? 'bg-emerald-500 text-white'
-                    : i === step
-                    ? 'bg-white text-black'
-                    : 'bg-gray-700 text-gray-400'
-                }`}
-              >
-                {i < step ? <CheckCircle className="w-4 h-4" /> : i + 1}
-              </div>
-              <span
-                className={`text-xs font-medium hidden sm:block ${
-                  i <= step ? 'text-white' : 'text-gray-500'
-                }`}
-              >
-                {label}
-              </span>
-              {i < STEPS.length - 1 && (
-                <div
-                  className={`flex-1 h-0.5 mx-2 rounded ${
-                    i < step ? 'bg-emerald-500' : 'bg-gray-700'
-                  }`}
-                />
-              )}
-            </div>
-          ))}
-        </div>
-
-        {/* Card principal */}
-        <div className="bg-[#111] border border-[#333] rounded-xl p-6">
-          {/* ── Paso 1: Edificio ── */}
-          {step === 0 && (
-            <div className="space-y-6">
-              <div className="text-center">
-                <Building2 className="w-10 h-10 text-gray-400 mx-auto mb-3" />
-                <h2 className="text-xl font-bold text-white">Bienvenido a BaW OS</h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  Configura tu propiedad en BaW OS en menos de 5 minutos.
-                </p>
-              </div>
-
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">Nombre del edificio</label>
-                  <input
-                    className="input-field"
-                    placeholder="Ej: ALM809P"
-                    value={building.name}
-                    onChange={(e) => setBuilding({ ...building, name: e.target.value })}
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">Dirección completa</label>
-                  <input
-                    className="input-field"
-                    placeholder="Calle, número, colonia, CP"
-                    value={building.address}
-                    onChange={(e) => setBuilding({ ...building, address: e.target.value })}
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">Ciudad</label>
-                  <input
-                    className="input-field"
-                    placeholder="Tu ciudad"
-                    value={building.city}
-                    onChange={(e) => setBuilding({ ...building, city: e.target.value })}
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">Número total de unidades</label>
-                  <input
-                    className="input-field"
-                    type="number"
-                    min={1}
-                    value={building.total_units}
-                    onChange={(e) => setBuilding({ ...building, total_units: parseInt(e.target.value) || 1 })}
-                  />
-                </div>
-              </div>
-
-              <div className="flex justify-end">
-                <button
-                  disabled={!step1Valid}
-                  onClick={goToStep2}
-                  className="flex items-center gap-2 px-5 py-2.5 bg-white hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed text-black text-sm font-medium rounded-lg transition-colors"
-                >
-                  Continuar <ArrowRight className="w-4 h-4" />
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* ── Paso 2: Unidades ── */}
+          {step === 0 && <StepPMCompany pm={pm} setPM={setPM} />}
           {step === 1 && (
-            <div className="space-y-6">
-              <div>
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Agregar unidades</h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  Define las unidades de tu propiedad. Puedes ajustar el número, tipo y piso.
-                </p>
-              </div>
-
-              <div className="space-y-3 max-h-[400px] overflow-y-auto pr-1">
-                {units.map((u, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <input
-                      className="input-field w-24"
-                      placeholder="No."
-                      value={u.number}
-                      onChange={(e) => updateUnit(i, 'number', e.target.value)}
-                    />
-                    <select
-                      className="input-field w-28"
-                      value={u.type}
-                      onChange={(e) => updateUnit(i, 'type', e.target.value)}
-                    >
-                      <option value="LTR">LTR</option>
-                      <option value="MTR">MTR</option>
-                      <option value="STR">STR</option>
-                    </select>
-                    <input
-                      className="input-field w-20"
-                      type="number"
-                      min={0}
-                      placeholder="Piso"
-                      value={u.floor}
-                      onChange={(e) => updateUnit(i, 'floor', parseInt(e.target.value) || 0)}
-                    />
-                    <button
-                      onClick={() => removeUnit(i)}
-                      className="p-2 text-red-400 hover:text-red-300 transition-colors shrink-0"
-                      title="Eliminar unidad"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  </div>
-                ))}
-              </div>
-
-              <button
-                onClick={addUnit}
-                className="flex items-center gap-2 text-sm text-gray-400 hover:text-white font-medium transition-colors"
-              >
-                <Plus className="w-4 h-4" /> Agregar unidad
-              </button>
-
-              <div className="flex justify-between">
-                <button
-                  onClick={() => setStep(0)}
-                  className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-400 hover:text-white transition-colors"
-                >
-                  <ArrowLeft className="w-4 h-4" /> Atrás
-                </button>
-                <button
-                  disabled={!step2Valid}
-                  onClick={() => setStep(2)}
-                  className="flex items-center gap-2 px-5 py-2.5 bg-white hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed text-black text-sm font-medium rounded-lg transition-colors"
-                >
-                  Continuar <ArrowRight className="w-4 h-4" />
-                </button>
-              </div>
-            </div>
+            <StepBuilding building={building} setBuilding={setBuilding} />
           )}
-
-          {/* ── Paso 3: Inquilinos (opcional) ── */}
           {step === 2 && (
-            <div className="space-y-6">
-              <div>
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Agregar inquilinos</h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  Agrega tus inquilinos actuales. Puedes hacerlo después desde Contratos.
-                </p>
-              </div>
-
-              <div className="space-y-4 max-h-[400px] overflow-y-auto pr-1">
-                {tenants.map((t, i) => (
-                  <div key={i} className="p-3 rounded-lg bg-gray-800/50 space-y-2">
-                    <div className="flex items-center gap-2">
-                      <input
-                        className="input-field flex-1"
-                        placeholder="Nombre del inquilino"
-                        value={t.name}
-                        onChange={(e) => updateTenant(i, 'name', e.target.value)}
-                      />
-                      <button
-                        onClick={() => removeTenant(i)}
-                        className="p-2 text-red-400 hover:text-red-300 transition-colors shrink-0"
-                        title="Eliminar inquilino"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      <input
-                        className="input-field"
-                        placeholder="Teléfono (opcional)"
-                        value={t.phone}
-                        onChange={(e) => updateTenant(i, 'phone', e.target.value)}
-                      />
-                      <select
-                        className="input-field"
-                        value={t.unit_number}
-                        onChange={(e) => updateTenant(i, 'unit_number', e.target.value)}
-                      >
-                        <option value="">Seleccionar unidad</option>
-                        {units.map((u) => (
-                          <option key={u.number} value={u.number}>
-                            Unidad {u.number}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      <input
-                        className="input-field"
-                        type="number"
-                        min={0}
-                        placeholder="Renta mensual"
-                        value={t.monthly_amount || ''}
-                        onChange={(e) => updateTenant(i, 'monthly_amount', parseFloat(e.target.value) || 0)}
-                      />
-                      <input
-                        className="input-field"
-                        type="date"
-                        value={t.start_date}
-                        onChange={(e) => updateTenant(i, 'start_date', e.target.value)}
-                      />
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              <button
-                onClick={addTenant}
-                className="flex items-center gap-2 text-sm text-gray-400 hover:text-white font-medium transition-colors"
-              >
-                <Plus className="w-4 h-4" /> Agregar inquilino
-              </button>
-
-              <div className="flex justify-between">
-                <button
-                  onClick={() => setStep(1)}
-                  className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-400 hover:text-white transition-colors"
-                >
-                  <ArrowLeft className="w-4 h-4" /> Atrás
-                </button>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => { setTenants([]); setStep(3); handleSubmit() }}
-                    className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-400 hover:text-white transition-colors"
-                  >
-                    <SkipForward className="w-4 h-4" /> Omitir por ahora
-                  </button>
-                  <button
-                    onClick={() => { setStep(3); handleSubmit() }}
-                    className="flex items-center gap-2 px-5 py-2.5 bg-white hover:bg-gray-100 text-black text-sm font-medium rounded-lg transition-colors"
-                  >
-                    Continuar <ArrowRight className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-            </div>
+            <StepUnits
+              unitConfig={unitConfig}
+              setUnitConfig={setUnitConfig}
+              units={units}
+              setUnits={setUnits}
+              generateUnits={generateUnits}
+              addUnit={addUnit}
+              removeUnit={removeUnit}
+              updateUnit={updateUnit}
+            />
           )}
-
-          {/* ── Paso 4: Listo ── */}
           {step === 3 && (
-            <div className="space-y-6 text-center py-4">
-              {submitting && (
-                <div className="space-y-3">
-                  <div className="w-12 h-12 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin mx-auto" />
-                  <p className="text-sm text-gray-400">Guardando configuración...</p>
-                </div>
-              )}
-
-              {error && (
-                <div className="space-y-4">
-                  <div className="w-14 h-14 rounded-full bg-red-500/20 flex items-center justify-center mx-auto">
-                    <span className="text-2xl">!</span>
-                  </div>
-                  <h2 className="text-xl font-bold text-red-400">Error al guardar</h2>
-                  <p className="text-sm text-gray-400">{error}</p>
-                  <button
-                    onClick={handleSubmit}
-                    className="px-5 py-2.5 bg-white hover:bg-gray-100 text-black text-sm font-medium rounded-lg transition-colors"
-                  >
-                    Reintentar
-                  </button>
-                </div>
-              )}
-
-              {result && (
-                <div className="space-y-4">
-                  <div className="w-16 h-16 rounded-full bg-emerald-500/20 flex items-center justify-center mx-auto">
-                    <CheckCircle className="w-8 h-8 text-emerald-400" />
-                  </div>
-                  <h2 className="text-xl font-bold text-gray-900 dark:text-white">
-                    Tu propiedad está configurada
-                  </h2>
-                  <div className="flex justify-center gap-4 text-sm text-gray-400">
-                    <span>{result.units_created} unidades creadas</span>
-                    <span>·</span>
-                    <span>{result.contracts_created} contratos creados</span>
-                  </div>
-                  <div className="flex flex-col sm:flex-row justify-center gap-3 pt-2">
-                    <button
-                      onClick={() => router.push('/')}
-                      className="px-6 py-2.5 bg-white hover:bg-gray-100 text-black text-sm font-medium rounded-lg transition-colors"
-                    >
-                      Ir al Dashboard →
-                    </button>
-                    <button
-                      onClick={() => router.push('/units')}
-                      className="px-6 py-2.5 border border-gray-700 text-gray-300 hover:text-white text-sm font-medium rounded-lg transition-colors"
-                    >
-                      Ver mis unidades
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
+            <StepOwner
+              ownerMode={ownerMode}
+              setOwnerMode={setOwnerMode}
+              owner={owner}
+              setOwner={setOwner}
+              userEmail={userEmail}
+              pmName={pm.name}
+            />
+          )}
+          {step === 4 && result && (
+            <StepDone
+              pmName={pm.name}
+              buildingName={building.name}
+              unitsCreated={result.units_created}
+              ownerMode={ownerMode}
+              onContinue={() => router.replace('/')}
+            />
           )}
         </div>
+
+        {/* Nav */}
+        {step < 4 && (
+          <div className="mt-6 flex justify-between">
+            <button
+              type="button"
+              onClick={back}
+              disabled={step === 0 || submitting}
+              className="flex items-center gap-2 px-4 py-2 rounded-md text-[13px]"
+              style={{
+                color: 'var(--baw-muted)',
+                border: '1px solid var(--baw-border)',
+                opacity: step === 0 || submitting ? 0.4 : 1,
+                cursor: step === 0 || submitting ? 'not-allowed' : 'pointer',
+              }}
+            >
+              <ArrowLeft size={14} />
+              Atrás
+            </button>
+            {step < 3 ? (
+              <button
+                type="button"
+                onClick={next}
+                className="flex items-center gap-2 px-5 py-2 rounded-md text-[13px] font-medium"
+                style={{
+                  backgroundColor: 'var(--baw-primary)',
+                  color: '#fff',
+                }}
+              >
+                Continuar
+                <ArrowRight size={14} />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={submitting}
+                className="flex items-center gap-2 px-5 py-2 rounded-md text-[13px] font-medium"
+                style={{
+                  backgroundColor: 'var(--baw-primary)',
+                  color: '#fff',
+                  opacity: submitting ? 0.6 : 1,
+                  cursor: submitting ? 'wait' : 'pointer',
+                }}
+              >
+                {submitting ? 'Creando…' : 'Crear PM Company'}
+                <CheckCircle2 size={14} />
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Stepper
+// -----------------------------------------------------------------------------
+
+function Stepper({ currentStep }: { currentStep: number }) {
+  return (
+    <ol className="flex items-center justify-between gap-2 max-w-xl mx-auto">
+      {STEPS.map((s, idx) => {
+        const Icon = s.icon
+        const active = idx === currentStep
+        const done = idx < currentStep || currentStep === 4
+        return (
+          <li key={s.key} className="flex-1 flex flex-col items-center">
+            <div
+              className="w-9 h-9 rounded-full flex items-center justify-center"
+              style={{
+                backgroundColor: active
+                  ? 'var(--baw-primary)'
+                  : done
+                  ? 'rgba(74, 222, 128, 0.15)'
+                  : 'var(--baw-surface)',
+                border: '1px solid var(--baw-border)',
+                color: active ? '#fff' : done ? '#86efac' : 'var(--baw-muted)',
+              }}
+            >
+              {done ? <CheckCircle2 size={16} /> : <Icon size={16} />}
+            </div>
+            <span
+              className="text-[11px] mt-2 text-center"
+              style={{
+                color: active ? 'var(--baw-text)' : 'var(--baw-muted)',
+                fontWeight: active ? 600 : 400,
+              }}
+            >
+              {s.label}
+            </span>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso 1 — PM Company
+// -----------------------------------------------------------------------------
+
+function StepPMCompany({
+  pm,
+  setPM,
+}: {
+  pm: PMCompanyData
+  setPM: (p: PMCompanyData) => void
+}) {
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-[18px] font-semibold">¿Quién opera este sistema?</h2>
+        <p className="muted-text text-[13px] mt-1">
+          La PM Company es la organización administradora que va a usar BaW. Si
+          eres administrador independiente, puedes dejar el nombre por defecto.
+        </p>
+      </div>
+      <Field label="Nombre del PM Company" required>
+        <input
+          type="text"
+          value={pm.name}
+          onChange={(e) => setPM({ ...pm, name: e.target.value })}
+          placeholder="BaW Operations"
+          className="w-full"
+          style={inputStyle}
+        />
+      </Field>
+      <Field
+        label="Slug (identificador URL)"
+        hint="Se genera automáticamente del nombre. Lo verás en URLs internas."
+      >
+        <input
+          type="text"
+          value={pm.slug}
+          onChange={(e) => setPM({ ...pm, slug: slugify(e.target.value) })}
+          placeholder="baw-operations"
+          className="w-full font-mono"
+          style={inputStyle}
+        />
+      </Field>
+      <p
+        className="text-[12px] px-3 py-2 rounded-md"
+        style={{
+          backgroundColor: 'rgba(59, 130, 246, 0.08)',
+          color: 'var(--baw-muted)',
+        }}
+      >
+        Quedarás registrado como{' '}
+        <strong style={{ color: 'var(--baw-text)' }}>pm_owner</strong> de esta
+        organización. Podrás invitar a tu equipo más adelante con roles{' '}
+        <code>pm_admin</code>, <code>pm_operator</code> o <code>pm_viewer</code>.
+      </p>
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso 2 — Edificio
+// -----------------------------------------------------------------------------
+
+function StepBuilding({
+  building,
+  setBuilding,
+}: {
+  building: BuildingData
+  setBuilding: (b: BuildingData) => void
+}) {
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-[18px] font-semibold">Tu primer edificio</h2>
+        <p className="muted-text text-[13px] mt-1">
+          BaW administra activos físicos. Necesitamos al menos un edificio para
+          empezar. Podrás agregar más después.
+        </p>
+      </div>
+      <Field label="Nombre del edificio" required>
+        <input
+          type="text"
+          value={building.name}
+          onChange={(e) => setBuilding({ ...building, name: e.target.value })}
+          placeholder="Mateos 809"
+          className="w-full"
+          style={inputStyle}
+        />
+      </Field>
+      <Field label="Dirección">
+        <input
+          type="text"
+          value={building.address}
+          onChange={(e) =>
+            setBuilding({ ...building, address: e.target.value })
+          }
+          placeholder="Adolfo López Mateos 809"
+          className="w-full"
+          style={inputStyle}
+        />
+      </Field>
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Ciudad" required>
+          <input
+            type="text"
+            value={building.city}
+            onChange={(e) => setBuilding({ ...building, city: e.target.value })}
+            placeholder="CDMX"
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Estado">
+          <input
+            type="text"
+            value={building.state}
+            onChange={(e) =>
+              setBuilding({ ...building, state: e.target.value })
+            }
+            placeholder="Ciudad de México"
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="País">
+          <input
+            type="text"
+            value={building.country}
+            onChange={(e) =>
+              setBuilding({ ...building, country: e.target.value.toUpperCase() })
+            }
+            placeholder="MX"
+            maxLength={2}
+            className="w-full font-mono"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Código postal">
+          <input
+            type="text"
+            value={building.postal_code}
+            onChange={(e) =>
+              setBuilding({ ...building, postal_code: e.target.value })
+            }
+            placeholder="03100"
+            className="w-full font-mono"
+            style={inputStyle}
+          />
+        </Field>
+      </div>
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso 3 — Unidades
+// -----------------------------------------------------------------------------
+
+function StepUnits({
+  unitConfig,
+  setUnitConfig,
+  units,
+  setUnits,
+  generateUnits,
+  addUnit,
+  removeUnit,
+  updateUnit,
+}: {
+  unitConfig: {
+    count: number
+    prefix: string
+    startNumber: number
+    floors: number
+    type: UnitRow['type']
+  }
+  setUnitConfig: (c: typeof unitConfig) => void
+  units: UnitRow[]
+  setUnits: (u: UnitRow[]) => void
+  generateUnits: () => void
+  addUnit: () => void
+  removeUnit: (i: number) => void
+  updateUnit: (i: number, f: keyof UnitRow, v: string | number) => void
+}) {
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-[18px] font-semibold">Estructura de unidades</h2>
+        <p className="muted-text text-[13px] mt-1">
+          Genera las unidades en bulk con el patrón típico (101–404) o agrégalas
+          una por una. Podrás editarlas después.
+        </p>
+      </div>
+
+      {/* Generador bulk */}
+      <div
+        className="rounded-md p-4 grid grid-cols-2 md:grid-cols-5 gap-3"
+        style={{
+          backgroundColor: 'var(--baw-bg)',
+          border: '1px solid var(--baw-border)',
+        }}
+      >
+        <Field label="Cantidad">
+          <input
+            type="number"
+            min={1}
+            max={500}
+            value={unitConfig.count}
+            onChange={(e) =>
+              setUnitConfig({
+                ...unitConfig,
+                count: Math.max(1, Number(e.target.value) || 1),
+              })
+            }
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Prefijo">
+          <input
+            type="text"
+            value={unitConfig.prefix}
+            onChange={(e) =>
+              setUnitConfig({ ...unitConfig, prefix: e.target.value })
+            }
+            placeholder="(opcional)"
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Empezar en">
+          <input
+            type="number"
+            value={unitConfig.startNumber}
+            onChange={(e) =>
+              setUnitConfig({
+                ...unitConfig,
+                startNumber: Number(e.target.value) || 101,
+              })
+            }
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Pisos">
+          <input
+            type="number"
+            min={1}
+            max={50}
+            value={unitConfig.floors}
+            onChange={(e) =>
+              setUnitConfig({
+                ...unitConfig,
+                floors: Math.max(1, Number(e.target.value) || 1),
+              })
+            }
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Tipo">
+          <select
+            value={unitConfig.type}
+            onChange={(e) =>
+              setUnitConfig({
+                ...unitConfig,
+                type: e.target.value as UnitRow['type'],
+              })
+            }
+            className="w-full"
+            style={inputStyle}
+          >
+            <option value="LTR">LTR</option>
+            <option value="MTR">MTR</option>
+            <option value="STR">STR</option>
+          </select>
+        </Field>
+      </div>
+      <button
+        type="button"
+        onClick={generateUnits}
+        className="px-4 py-2 rounded-md text-[13px]"
+        style={{
+          backgroundColor: 'var(--baw-bg)',
+          border: '1px solid var(--baw-border)',
+          color: 'var(--baw-text)',
+        }}
+      >
+        Generar {unitConfig.count} unidades
+      </button>
+
+      {/* Lista editable */}
+      {units.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-[13px] font-medium">
+              {units.length} unidades
+            </span>
+            <button
+              type="button"
+              onClick={addUnit}
+              className="flex items-center gap-1 text-[12px]"
+              style={{ color: 'var(--baw-primary)' }}
+            >
+              <Plus size={12} /> Agregar
+            </button>
+          </div>
+          <div
+            className="rounded-md overflow-hidden"
+            style={{ border: '1px solid var(--baw-border)' }}
+          >
+            <table className="w-full text-[12px]">
+              <thead
+                style={{
+                  backgroundColor: 'var(--baw-bg)',
+                  color: 'var(--baw-muted)',
+                }}
+              >
+                <tr>
+                  <th className="text-left px-3 py-2">Número</th>
+                  <th className="text-left px-3 py-2">Tipo</th>
+                  <th className="text-left px-3 py-2">Piso</th>
+                  <th className="px-3 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {units.map((u, idx) => (
+                  <tr
+                    key={idx}
+                    style={{ borderTop: '1px solid var(--baw-border)' }}
+                  >
+                    <td className="px-3 py-1.5">
+                      <input
+                        type="text"
+                        value={u.number}
+                        onChange={(e) =>
+                          updateUnit(idx, 'number', e.target.value)
+                        }
+                        className="w-full font-mono"
+                        style={{ ...inputStyle, padding: '4px 8px' }}
+                      />
+                    </td>
+                    <td className="px-3 py-1.5">
+                      <select
+                        value={u.type}
+                        onChange={(e) =>
+                          updateUnit(idx, 'type', e.target.value)
+                        }
+                        style={{ ...inputStyle, padding: '4px 8px' }}
+                      >
+                        <option value="LTR">LTR</option>
+                        <option value="MTR">MTR</option>
+                        <option value="STR">STR</option>
+                      </select>
+                    </td>
+                    <td className="px-3 py-1.5">
+                      <input
+                        type="number"
+                        value={u.floor}
+                        onChange={(e) =>
+                          updateUnit(idx, 'floor', Number(e.target.value) || 1)
+                        }
+                        className="w-20"
+                        style={{ ...inputStyle, padding: '4px 8px' }}
+                      />
+                    </td>
+                    <td className="px-3 py-1.5 text-right">
+                      <button
+                        type="button"
+                        onClick={() => removeUnit(idx)}
+                        style={{ color: '#f87171' }}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso 4 — Property Owner
+// -----------------------------------------------------------------------------
+
+function StepOwner({
+  ownerMode,
+  setOwnerMode,
+  owner,
+  setOwner,
+  userEmail,
+  pmName,
+}: {
+  ownerMode: OwnerMode
+  setOwnerMode: (m: OwnerMode) => void
+  owner: OwnerData
+  setOwner: (o: OwnerData) => void
+  userEmail: string | null
+  pmName: string
+}) {
+  const options: Array<{ key: OwnerMode; title: string; desc: string }> = [
+    {
+      key: 'self',
+      title: 'Yo soy el dueño',
+      desc: `${pmName} administra su propio edificio. Quedarás registrado como Property Owner con 100% del building.`,
+    },
+    {
+      key: 'client',
+      title: 'Es de un cliente',
+      desc: 'Administras este edificio para un tercero. Captura los datos del propietario y se le creará portal de acceso.',
+    },
+    {
+      key: 'skip',
+      title: 'Configurarlo más tarde',
+      desc: 'El edificio queda sin Property Owner. Podrás asignarlo después en la pestaña de Configuración.',
+    },
+  ]
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-[18px] font-semibold">¿De quién es este edificio?</h2>
+        <p className="muted-text text-[13px] mt-1">
+          La capa de Property Owners distingue entre quien opera (PM Company) y
+          quien posee el inmueble. Esto define cuentas claras y portales
+          separados.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3">
+        {options.map((opt) => {
+          const active = ownerMode === opt.key
+          return (
+            <button
+              type="button"
+              key={opt.key}
+              onClick={() => setOwnerMode(opt.key)}
+              className="text-left rounded-md p-4 transition"
+              style={{
+                backgroundColor: active
+                  ? 'rgba(59, 130, 246, 0.08)'
+                  : 'var(--baw-bg)',
+                border: active
+                  ? '1px solid var(--baw-primary)'
+                  : '1px solid var(--baw-border)',
+              }}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div
+                    className="text-[14px] font-semibold"
+                    style={{ color: 'var(--baw-text)' }}
+                  >
+                    {opt.title}
+                  </div>
+                  <div className="muted-text text-[12px] mt-1">{opt.desc}</div>
+                </div>
+                <div
+                  className="w-4 h-4 rounded-full flex-shrink-0 mt-1"
+                  style={{
+                    backgroundColor: active ? 'var(--baw-primary)' : 'transparent',
+                    border: active
+                      ? '2px solid var(--baw-primary)'
+                      : '2px solid var(--baw-border)',
+                  }}
+                />
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      {ownerMode === 'self' && (
+        <div
+          className="text-[12px] px-3 py-2 rounded-md"
+          style={{
+            backgroundColor: 'rgba(74, 222, 128, 0.08)',
+            color: 'var(--baw-muted)',
+          }}
+        >
+          Se creará un Property Owner con tu email{' '}
+          <code style={{ color: 'var(--baw-text)' }}>{userEmail}</code> y un
+          ownership stake del 100% sobre el edificio.
+        </div>
+      )}
+
+      {ownerMode === 'client' && (
+        <div className="space-y-4 pt-2">
+          <Field label="Nombre completo del propietario" required>
+            <input
+              type="text"
+              value={owner.full_name}
+              onChange={(e) =>
+                setOwner({ ...owner, full_name: e.target.value })
+              }
+              placeholder="Juan Pérez García"
+              className="w-full"
+              style={inputStyle}
+            />
+          </Field>
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Email">
+              <input
+                type="email"
+                value={owner.email}
+                onChange={(e) => setOwner({ ...owner, email: e.target.value })}
+                placeholder="cliente@ejemplo.com"
+                className="w-full"
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="Teléfono">
+              <input
+                type="tel"
+                value={owner.phone}
+                onChange={(e) => setOwner({ ...owner, phone: e.target.value })}
+                placeholder="+52 55..."
+                className="w-full"
+                style={inputStyle}
+              />
+            </Field>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="RFC (opcional)">
+              <input
+                type="text"
+                value={owner.rfc}
+                onChange={(e) =>
+                  setOwner({ ...owner, rfc: e.target.value.toUpperCase() })
+                }
+                placeholder="XAXX010101000"
+                maxLength={13}
+                className="w-full font-mono"
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="% del building" hint="Entre 1 y 100">
+              <input
+                type="number"
+                min={1}
+                max={100}
+                value={owner.percentage}
+                onChange={(e) =>
+                  setOwner({ ...owner, percentage: Number(e.target.value) || 0 })
+                }
+                className="w-full tabular-nums"
+                style={inputStyle}
+              />
+            </Field>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso final — Done
+// -----------------------------------------------------------------------------
+
+function StepDone({
+  pmName,
+  buildingName,
+  unitsCreated,
+  ownerMode,
+  onContinue,
+}: {
+  pmName: string
+  buildingName: string
+  unitsCreated: number
+  ownerMode: OwnerMode
+  onContinue: () => void
+}) {
+  return (
+    <div className="text-center py-6">
+      <div
+        className="w-14 h-14 rounded-full mx-auto flex items-center justify-center mb-4"
+        style={{
+          backgroundColor: 'rgba(74, 222, 128, 0.15)',
+          color: '#86efac',
+        }}
+      >
+        <CheckCircle2 size={28} />
+      </div>
+      <h2 className="text-[20px] font-semibold">¡Listo!</h2>
+      <p className="muted-text text-[13px] mt-2 max-w-md mx-auto">
+        BaW Operations ha registrado a <strong>{pmName}</strong> con el edificio{' '}
+        <strong>{buildingName}</strong> y <strong>{unitsCreated}</strong>{' '}
+        unidades. Property Owner:{' '}
+        {ownerMode === 'self'
+          ? 'tú mismo, 100%'
+          : ownerMode === 'client'
+          ? 'cliente capturado'
+          : 'pendiente de configurar'}
+        .
+      </p>
+      <button
+        type="button"
+        onClick={onContinue}
+        className="mt-6 px-5 py-2 rounded-md text-[13px] font-medium"
+        style={{ backgroundColor: 'var(--baw-primary)', color: '#fff' }}
+      >
+        Ir a Mission Control
+      </button>
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Helpers UI
+// -----------------------------------------------------------------------------
+
+const inputStyle: React.CSSProperties = {
+  backgroundColor: 'var(--baw-bg)',
+  border: '1px solid var(--baw-border)',
+  color: 'var(--baw-text)',
+  borderRadius: '6px',
+  padding: '8px 12px',
+  fontSize: '13px',
+  outline: 'none',
+}
+
+function Field({
+  label,
+  required,
+  hint,
+  children,
+}: {
+  label: string
+  required?: boolean
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="block">
+      <span className="text-[12px] font-medium block mb-1.5">
+        {label}
+        {required && <span style={{ color: '#f87171' }}> *</span>}
+      </span>
+      {children}
+      {hint && (
+        <span className="muted-text text-[11px] mt-1 block">{hint}</span>
+      )}
+    </label>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import { Sparkles } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { formatCurrency, daysUntil } from '@/lib/utils'
 import {
@@ -59,6 +60,7 @@ export default function MissionControl() {
   const [collections, setCollections] = useState<CollectionRow[]>([])
   const [maintenance, setMaintenance] = useState<MaintRow[]>([])
   const [loading, setLoading] = useState(true)
+  const [needsOnboarding, setNeedsOnboarding] = useState(false)
 
   useEffect(() => {
     async function fetchDashboard() {
@@ -92,6 +94,11 @@ export default function MissionControl() {
         const contracts = contractsRes.data || []
         const payments = paymentsRes.data || []
         const tickets = maintRes.data || []
+
+        // Detectar empty state global: sin unidades ni contratos
+        if (units.length === 0 && contracts.length === 0) {
+          setNeedsOnboarding(true)
+        }
 
         const totalUnits = units.length
         const occupiedUnits = units.filter(
@@ -172,6 +179,43 @@ export default function MissionControl() {
     metrics.totalUnits > 0
       ? ((metrics.occupiedUnits / metrics.totalUnits) * 100).toFixed(1)
       : '0.0'
+
+  // Empty state honesto: si no hay datos, ofrecer el onboarding como CTA principal
+  if (!loading && needsOnboarding) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <div
+          className="max-w-lg w-full rounded-lg p-8 text-center"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          <div
+            className="w-12 h-12 rounded-full mx-auto flex items-center justify-center mb-4"
+            style={{
+              backgroundColor: 'rgba(59, 130, 246, 0.12)',
+              color: 'var(--baw-primary)',
+            }}
+          >
+            <Sparkles size={22} />
+          </div>
+          <h1 className="text-[22px] font-semibold">BaW está listo para arrancar</h1>
+          <p className="muted-text text-[13px] mt-2 max-w-md mx-auto">
+            Aún no hay un PM Company configurado. Tarda dos minutos: registra tu
+            organización, tu primer edificio, las unidades y el Property Owner.
+          </p>
+          <Link
+            href="/onboarding"
+            className="inline-block mt-6 px-5 py-2 rounded-md text-[13px] font-medium"
+            style={{ backgroundColor: 'var(--baw-primary)', color: '#fff' }}
+          >
+            Empezar onboarding
+          </Link>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6">

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -10,7 +10,23 @@ export function createServiceClient() {
   )
 }
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
+// ────────────────────────────────────────────────────────────────────────────
+// Sprint 3 / S6: getOrgId() legacy ya NO debe retornar la UUID Mateos hardcoded
+// porque esa organization fue eliminada en el wipe operativo de S1.
+//
+// Solución temporal: cache con TTL que resuelve dinámicamente la primera
+// organization disponible (best-effort) usando service-role.  Esto destraba
+// las ~73 APIs legacy tras el onboarding sin migrarlas todas a async/JWT.
+//
+// Pendiente decisión humana (Fran): refactor real para leer `org_id` del JWT
+// del usuario (server-side via cookies()) o de un header inyectado por
+// middleware.  Ver `BUG_BASH_S6.md`.
+// ────────────────────────────────────────────────────────────────────────────
+
+const FALLBACK_ORG_ID = process.env.BAW_FALLBACK_ORG_ID || ''
+let cachedOrgId: string | null = null
+let cachedAt = 0
+const CACHE_TTL_MS = 60_000
 
 export function unauthorized(message = 'Unauthorized') {
   return NextResponse.json(
@@ -37,6 +53,50 @@ export function validateApiKey(request: NextRequest): boolean {
   return apiKey === expected
 }
 
+/**
+ * Sync getter usado por las APIs legacy.  Devuelve el último org_id
+ * resuelto en cache, o el fallback de env si está vacío.  La primera vez
+ * que el proceso arranca regresa el fallback hasta que getOrgIdAsync()
+ * caliente el cache.
+ */
 export function getOrgId(): string {
-  return ORG_ID
+  if (cachedOrgId && Date.now() - cachedAt < CACHE_TTL_MS) {
+    return cachedOrgId
+  }
+  return FALLBACK_ORG_ID
+}
+
+/**
+ * Async getter que resuelve dinámicamente la primera organization
+ * disponible usando service-role.  Las nuevas APIs deben usar esta versión.
+ * Las APIs legacy pueden llamarla puntualmente para calentar el cache.
+ */
+export async function getOrgIdAsync(): Promise<string> {
+  if (cachedOrgId && Date.now() - cachedAt < CACHE_TTL_MS) {
+    return cachedOrgId
+  }
+  try {
+    const supabase = createServiceClient()
+    const { data, error } = await supabase
+      .from('organizations')
+      .select('id')
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle()
+    if (error || !data?.id) return FALLBACK_ORG_ID
+    cachedOrgId = data.id
+    cachedAt = Date.now()
+    return data.id
+  } catch {
+    return FALLBACK_ORG_ID
+  }
+}
+
+/**
+ * Permite que el flow de onboarding inyecte el org_id recién creado al
+ * cache para que las APIs legacy lo recojan inmediatamente.
+ */
+export function setActiveOrgId(orgId: string) {
+  cachedOrgId = orgId
+  cachedAt = Date.now()
 }


### PR DESCRIPTION
## Sprint 3 · S6 · Bug bash + fix crítico de `getOrgId()` post-wipe

### Contexto

Tras el wipe operativo del Sprint 3 / S1 (PR #5), la organization Mateos `ed4308c7-2bdb-46f2-be69-7c59674838e2` fue eliminada. Sin embargo, las ~73 APIs legacy (`/api/units`, `/api/contracts`, `/api/payments`, `/api/tasks`, `/api/notifications`, `/api/whatsapp/*`, etc.) seguían apuntando a esa UUID hardcoded en `src/lib/api-auth.ts`. Resultado: cualquier journey post-onboarding rompía silenciosamente.

### Cambios

#### `src/lib/api-auth.ts`
- Eliminada la constante `ORG_ID = 'ed4308c7-...'`.
- `getOrgId()` ahora usa cache con TTL de 60s. Devuelve la última org resuelta o el fallback de env (`BAW_FALLBACK_ORG_ID`).
- Nuevo `getOrgIdAsync()` que resuelve dinámicamente la primera organization disponible vía service-role.
- Nuevo `setActiveOrgId(orgId)` para que el flow de onboarding caliente el cache inmediatamente.

#### `src/app/api/onboarding/route.ts`
- Tras crear la `organization` en el paso 1, llama `setActiveOrgId(org.id)`. Esto hace que cualquier API legacy llamada inmediatamente después (Mission Control, /units, /contracts, etc.) opere contra la org recién creada sin esperar el TTL del cache.

#### `BUG_BASH_S6.md` (nuevo)
- Reporte completo del bug bash: 7 journeys recorridos, 3 bugs identificados (1 blocker parcheado, 1 ya resuelto en S3, 1 deuda documentada).
- Decisión humana pendiente para Fran: refactor real para leer `org_id` del JWT (vía middleware o cookies()) — el parche de hoy es best-effort, no multi-tenant safe.

### Limitaciones del parche

- En multi-tenant real con múltiples orgs, el cache devuelve la primera org creada — no respeta el JWT del usuario actual.
- Cualquier nuevo PM Company creado en una segunda sesión no es visible para las APIs legacy hasta que el cache expire (60s) o reinicies el server.

Estas limitaciones quedan documentadas en `BUG_BASH_S6.md` con tres opciones de refactor real para decisión humana al despertar.

### Verificación

- `npx tsc --noEmit` ✅
- `npx next build` ✅ (30+ rutas, sin warnings nuevos)
- Onboarding journey verificado por código: contrato wizard ↔ API alineado, `setActiveOrgId` se ejecuta tras crear org.

### Notion log

Avance documentado en https://www.notion.so/baw-os/Sprint-Nocturno-Log-de-avances-351169373e72813c9f8cd10f3e35d232
