### PR TITLE
Sprint 3 · S7 · Hotfixes bug bash humano (theme + sidebar + multi-bulk + Frontier Bay)

### DIFF
--- a/BUG_BASH_S6.md
+++ b/BUG_BASH_S6.md
@@ -1,0 +1,60 @@
+# Bug Bash · Sprint 3 / S6
+
+**Fecha:** 2026-04-29 04:30–05:30 CST
+**Operador:** Perplexity Personal Computer (autónomo)
+
+## Journeys recorridos
+
+1. ✅ Onboarding desde cero (`/onboarding`) — wizard de 4 pasos verificado por código contra el API v2 (S3). Contrato body↔handler alineado, RLS service-role bypass funcional, rollback en cascada presente.
+2. ✅ Mission Control empty state (`/`) — empty state honesto cuando no hay unidades+contratos.
+3. ⚠️ Alta de unidad (`/units` + UnitModal) — depende de `getOrgId()` legacy. **Ver Bug #1**.
+4. ⚠️ Alta de contrato (`/contracts/new`) — depende de `getOrgId()` legacy. **Ver Bug #1**.
+5. ⚠️ Registro de pago (`/payments` + `/cobros`) — depende de `getOrgId()` legacy. **Ver Bug #1**.
+6. ⚠️ Owner portal (`/owner/[token]`, `/portal/[token]`, `/tenant/[token]`) — usa tokens, debería estar OK.
+7. ⚠️ Settings (`/settings`) — depende de `getOrgId()` legacy. **Ver Bug #1**.
+
+## Bugs encontrados
+
+### Bug #1 (BLOCKER, parche temporal aplicado)
+
+**Síntoma:** tras el wipe operativo de S1, todas las APIs legacy (~73 archivos: `/api/units`, `/api/contracts`, `/api/payments`, `/api/tasks`, `/api/notifications`, `/api/whatsapp/*`, etc.) seguían apuntando a `ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'` (la UUID Mateos eliminada en S1). Resultado esperado: cualquier query legacy retorna 0 filas o error de FK contra una org inexistente.
+
+**Causa raíz:** `src/lib/api-auth.ts` definía `ORG_ID` como constante hardcoded.
+
+**Parche aplicado en S6 (PR #9):**
+- `getOrgId()` ahora usa cache con TTL (60s) que se rellena dinámicamente con la primera organization disponible.
+- Nuevo `getOrgIdAsync()` para usar en APIs nuevas — resuelve via service-role la primera org en `organizations` ordenada por `created_at`.
+- Nuevo `setActiveOrgId(orgId)` que el onboarding llama tras crear la nueva PM Company para calentar el cache inmediatamente.
+- Soporta env var `BAW_FALLBACK_ORG_ID` para casos edge.
+
+**Limitaciones del parche:**
+- Best-effort, no es seguro en multi-tenant real (la primera org gana).
+- Cualquier nuevo PM Company creado en una segunda sesión **no** será visible para las APIs legacy hasta que el cache expire (60s) o reinicies el server.
+- No respeta el principio "el org_id debe venir del JWT del usuario actual".
+
+**Decisión humana pendiente (Fran):** refactor real para leer `org_id` del JWT del usuario en cada API legacy. Opciones:
+1. Middleware Next.js que inyecta header `x-baw-org-id` en cada request server-side.
+2. Cada API recibe `cookies()` y lee `org_id` del JWT directamente.
+3. Migrar las 73 APIs a `getOrgIdAsync()` con `await` (atómico pero requiere tocar todos los handlers).
+
+### Bug #2 (resuelto en S3, no en este sprint)
+
+**Síntoma histórico:** el API onboarding pre-S3 insertaba `occupants.type = 'tenant'` que viola el CHECK constraint `IN ('ltr', 'str', 'both')`. Causaba 500 al onboarding inicial.
+
+**Causa raíz:** mismatch entre el código TypeScript y el schema real de `occupants.type` (es TEXT con CHECK, no enum).
+
+**Estado:** corregido en PR #6 (Sprint 3 / S3) cuando se reescribió el API completo. El nuevo wizard no crea occupants en el onboarding (los crea cuando se firma el primer contrato).
+
+### Bug #3 (no crítico, deuda documentada)
+
+**Síntoma:** 206 referencias HEX/`rgba()` directas en componentes individuales (`Sidebar.tsx`, `AppShell.tsx`, `ui/status.tsx`, etc.) siguen vivas tras la migración a tokens canónicos OKLCH del PR #8 (S5).
+
+**Estado:** no bloquea el rendering — los aliases `--baw-*` migran automáticamente todos los consumidores via CSS. Migrar las 206 ocurrencias a `var(--brand-*)`/`var(--agent-*)`/`var(--green-*)`/etc. mejora consistencia visual en wide-gamut pero no afecta funcionalidad.
+
+**Recomendación:** sprint posterior dedicado, idealmente con visual regression tests.
+
+## Recomendación al despertar
+
+1. Revisar PRs #5, #6, #7, #8, #9 en orden de dependencia.
+2. Decidir camino del refactor `getOrgId` (Bug #1 sigue siendo deuda crítica).
+3. Probar onboarding E2E en preview de Vercel del PR #9 antes de merge a main.

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,92 +1,204 @@
-// BaW OS — Onboarding Wizard API
-import { NextRequest } from 'next/server'
-import { createServiceClient, getOrgId, apiOk, apiError } from '@/lib/api-auth'
+// BaW OS — Onboarding Wizard v2 API (Sprint 3 / S3)
+// Crea PM Company → org_member (pm_owner) → Building → Units → Property Owner → ownership_stake
+// en un único request. Usa service-role para bypass de RLS y se hace best-effort de rollback.
 
-interface OnboardingBody {
-  building: { name: string; address: string; city: string }
-  units: Array<{ number: string; type: 'STR' | 'MTR' | 'LTR'; floor: number }>
-  tenants: Array<{
+import { NextRequest } from 'next/server'
+import { createServiceClient, apiOk, apiError } from '@/lib/api-auth'
+
+interface UnitInput {
+  number: string
+  type: 'STR' | 'MTR' | 'LTR'
+  floor: number
+}
+
+interface OwnerInput {
+  full_name: string
+  email: string | null
+  phone: string | null
+  rfc: string | null
+  percentage: number
+  user_id: string | null
+}
+
+interface OnboardingV2Body {
+  user_id: string
+  pm: { name: string; slug: string }
+  building: {
     name: string
-    phone?: string
-    unit_number: string
-    monthly_amount: number
-    start_date: string
-  }>
+    address: string | null
+    city: string
+    state: string | null
+    country: string
+    postal_code: string | null
+  }
+  units: UnitInput[]
+  owner_mode: 'self' | 'client' | 'skip'
+  owner: OwnerInput | null
 }
 
 export async function POST(request: NextRequest) {
+  let createdOrgId: string | null = null
   try {
-    const body = (await request.json()) as OnboardingBody
-    const supabase = createServiceClient()
-    const orgId = getOrgId()
+    const body = (await request.json()) as OnboardingV2Body
 
-    if (!body.units || body.units.length === 0) {
+    // Validaciones mínimas
+    if (!body.user_id) return apiError('user_id es obligatorio', 400)
+    if (!body.pm?.name || !body.pm?.slug)
+      return apiError('PM Company name y slug son obligatorios', 400)
+    if (!body.building?.name || !body.building?.city)
+      return apiError('Edificio: name y city son obligatorios', 400)
+    if (!body.units || body.units.length === 0)
       return apiError('Se requiere al menos una unidad', 400)
+
+    const supabase = createServiceClient()
+
+    // 1) PM Company (organizations)
+    const { data: org, error: orgErr } = await supabase
+      .from('organizations')
+      .insert({
+        name: body.pm.name,
+        slug: body.pm.slug,
+        settings: { onboarded_at: new Date().toISOString() },
+      })
+      .select('id')
+      .single()
+
+    if (orgErr || !org) {
+      // 23505 = unique violation
+      const msg =
+        orgErr?.code === '23505'
+          ? `El slug "${body.pm.slug}" ya existe. Cambia el nombre o slug.`
+          : `Error creando PM Company: ${orgErr?.message ?? 'desconocido'}`
+      return apiError(msg, 400)
+    }
+    createdOrgId = org.id
+
+    // 2) org_member del usuario actual como pm_owner
+    const { error: memberErr } = await supabase.from('org_members').insert({
+      org_id: org.id,
+      user_id: body.user_id,
+      role: 'pm_owner',
+    })
+    if (memberErr) {
+      await rollback(supabase, createdOrgId!)
+      return apiError(`Error creando membresía: ${memberErr.message}`, 500)
     }
 
-    // 1. Crear unidades
+    // 3) Building
+    const { data: bld, error: bldErr } = await supabase
+      .from('buildings')
+      .insert({
+        org_id: org.id,
+        name: body.building.name,
+        address: body.building.address,
+        city: body.building.city,
+        state: body.building.state,
+        country: body.building.country || 'MX',
+        postal_code: body.building.postal_code,
+      })
+      .select('id')
+      .single()
+    if (bldErr || !bld) {
+      await rollback(supabase, createdOrgId!)
+      return apiError(`Error creando edificio: ${bldErr?.message}`, 500)
+    }
+
+    // 4) Units (bulk insert)
     const unitInserts = body.units.map((u) => ({
-      org_id: orgId,
+      org_id: org.id,
+      building_id: bld.id,
       number: u.number,
       type: u.type,
       floor: u.floor,
       status: 'available',
-      notes: `Creada via onboarding — ${body.building.name}`,
     }))
-
     const { data: createdUnits, error: unitsErr } = await supabase
       .from('units')
       .insert(unitInserts)
-      .select('id, number')
-
-    if (unitsErr) return apiError(`Error creando unidades: ${unitsErr.message}`, 500)
-
-    // Mapa número → id para enlazar inquilinos
-    const unitMap = new Map<string, string>()
-    for (const u of createdUnits || []) {
-      unitMap.set(u.number, u.id)
+      .select('id')
+    if (unitsErr) {
+      await rollback(supabase, createdOrgId!)
+      return apiError(`Error creando unidades: ${unitsErr.message}`, 500)
     }
 
-    // 2. Crear inquilinos y contratos
-    let contractsCreated = 0
-    for (const t of body.tenants || []) {
-      const unitId = unitMap.get(t.unit_number)
-      if (!unitId || !t.name) continue
-
-      // Crear occupant
-      const { data: occ, error: occErr } = await supabase
-        .from('occupants')
-        .insert({
-          org_id: orgId,
-          name: t.name,
-          phone: t.phone || null,
-          type: 'tenant',
-        })
+    // 5) Property Owner + ownership_stake (si aplica)
+    let ownerId: string | null = null
+    if (body.owner_mode !== 'skip' && body.owner) {
+      const ownerData = {
+        org_id: org.id,
+        user_id: body.owner.user_id, // null en modo client, user actual en modo self
+        full_name: body.owner.full_name,
+        email: body.owner.email,
+        phone: body.owner.phone,
+        rfc: body.owner.rfc,
+      }
+      const { data: po, error: poErr } = await supabase
+        .from('property_owners')
+        .insert(ownerData)
         .select('id')
         .single()
+      if (poErr || !po) {
+        await rollback(supabase, createdOrgId!)
+        return apiError(
+          `Error creando Property Owner: ${poErr?.message}`,
+          500,
+        )
+      }
+      ownerId = po.id
 
-      if (occErr || !occ) continue
-
-      // Crear contrato activo
-      const { error: cErr } = await supabase.from('contracts').insert({
-        org_id: orgId,
-        unit_id: unitId,
-        occupant_id: occ.id,
-        monthly_amount: t.monthly_amount,
-        payment_day: 1,
-        start_date: t.start_date,
-        status: 'active',
+      const pct = clampPercentage(body.owner.percentage, body.owner_mode)
+      const { error: stakeErr } = await supabase.from('ownership_stakes').insert({
+        org_id: org.id,
+        building_id: bld.id,
+        property_owner_id: po.id,
+        percentage: pct,
+        starts_on: new Date().toISOString().slice(0, 10),
       })
-
-      if (!cErr) {
-        contractsCreated++
-        // Marcar unidad como ocupada
-        await supabase.from('units').update({ status: 'occupied' }).eq('id', unitId)
+      if (stakeErr) {
+        await rollback(supabase, createdOrgId!)
+        return apiError(
+          `Error creando ownership stake: ${stakeErr.message}`,
+          500,
+        )
       }
     }
 
-    return apiOk({ units_created: createdUnits?.length || 0, contracts_created: contractsCreated })
+    return apiOk({
+      org_id: org.id,
+      building_id: bld.id,
+      units_created: createdUnits?.length ?? 0,
+      property_owner_id: ownerId,
+    })
   } catch (err) {
-    return apiError(err instanceof Error ? err.message : 'Error interno', 500)
+    if (createdOrgId) {
+      try {
+        const supabase = createServiceClient()
+        await rollback(supabase, createdOrgId!)
+      } catch {
+        // best-effort
+      }
+    }
+    return apiError(
+      err instanceof Error ? err.message : 'Error interno',
+      500,
+    )
   }
+}
+
+// Rollback best-effort cuando algún paso falla. Confía en CASCADE de FK.
+async function rollback(
+  supabase: ReturnType<typeof createServiceClient>,
+  orgId: string,
+) {
+  // Buildings, units, property_owners, ownership_stakes, org_members tienen
+  // ON DELETE CASCADE desde organizations.
+  await supabase.from('organizations').delete().eq('id', orgId)
+}
+
+function clampPercentage(v: number, mode: 'self' | 'client' | 'skip'): number {
+  if (mode === 'self') return 100
+  const n = Number(v)
+  if (!Number.isFinite(n) || n <= 0) return 100
+  if (n > 100) return 100
+  return Math.round(n * 100) / 100
 }

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -3,7 +3,7 @@
 // en un único request. Usa service-role para bypass de RLS y se hace best-effort de rollback.
 
 import { NextRequest } from 'next/server'
-import { createServiceClient, apiOk, apiError } from '@/lib/api-auth'
+import { createServiceClient, apiOk, apiError, setActiveOrgId } from '@/lib/api-auth'
 
 interface UnitInput {
   number: string
@@ -72,6 +72,10 @@ export async function POST(request: NextRequest) {
       return apiError(msg, 400)
     }
     createdOrgId = org.id
+    // Sprint 3 / S6: caliente el cache de org_id legacy para que las APIs
+    // existentes (que usan getOrgId() síncrono) operen contra la org recién
+    // creada sin necesidad de un refresh manual.
+    setActiveOrgId(org.id)
 
     // 2) org_member del usuario actual como pm_owner
     const { error: memberErr } = await supabase.from('org_members').insert({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,48 +3,106 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --baw-bg: #0F0F12;
-  --baw-surface: #17171C;
-  --baw-elevated: #1E1E24;
-  --baw-border: #2A2A32;
-  --baw-text: #E8E8EC;
-  --baw-muted: #A0A0AB;
-  --baw-faint: #6E6E78;
-  --baw-primary: #3B82F6;
-  --baw-agent: #8B5CF6;
-  --baw-agent-subtle: rgba(139, 92, 246, 0.1);
-  --baw-human-subtle: rgba(59, 130, 246, 0.1);
-  --baw-success: #22C55E;
-  --baw-warning: #F59E0B;
-  --baw-danger: #EF4444;
+/* ════════════════════════════════════════════════════════════════════════
+   BaW OS — globals.css (Sprint 3 / S5)
+   ────────────────────────────────────────────────────────────────────────
+   Migración a tokens canónicos OKLCH del submódulo `design/baw-design/`.
+
+   Estrategia:
+   - Activar el scope canónico (--bg, --surface, --text, --brand-*, --agent-*,
+     --green-*, --amber-*, --red-*, --blue-*) según el modo light/dark
+     que ya gestiona Tailwind via `html.dark` / `html.light`.
+   - Mantener los aliases legacy `--baw-*` para que los ~50 componentes que
+     todavía leen `var(--baw-*)` sigan funcionando, pero apuntando ahora a
+     los tokens canónicos.  De esa forma migramos visualmente todo el OS
+     sin tocar 206 ocurrencias en este sprint.
+   - HEX directos restantes en componentes (206 ocurrencias) son deuda
+     documentada para un sprint posterior tras S6.
+   ──────────────────────────────────────────────────────────────────────── */
+
+/* ── Modo dark (default) ─────────────────────────────────────────────── */
+:root,
+html.dark {
+  /* Activamos el scope canónico --dark como variables semánticas */
+  --bg:        var(--d-bg);
+  --surface:   var(--d-surface);
+  --surface-2: var(--d-surface-2);
+  --surface-3: var(--d-surface-3);
+  --line:      var(--d-line);
+  --line-2:    var(--d-line-2);
+  --text:      var(--d-text);
+  --text-2:    var(--d-text-2);
+  --text-3:    var(--d-text-3);
+  --text-4:    var(--d-text-4);
+
+  --red-fill:   color-mix(in oklch, var(--red-d-fill)   55%, transparent);
+  --amber-fill: color-mix(in oklch, var(--amber-d-fill) 55%, transparent);
+  --green-fill: color-mix(in oklch, var(--green-d-fill) 55%, transparent);
+  --blue-fill:  color-mix(in oklch, var(--blue-d-fill)  55%, transparent);
+  --agent-fill: color-mix(in oklch, var(--agent-d-fill) 55%, transparent);
+  --brand-fill: color-mix(in oklch, var(--brand-d-fill) 55%, transparent);
+
+  /* ── Aliases legacy --baw-* → tokens canónicos ────────────────────── */
+  --baw-bg:           var(--bg);
+  --baw-surface:      var(--surface);
+  --baw-elevated:     var(--surface-2);
+  --baw-border:       var(--line);
+  --baw-text:         var(--text);
+  --baw-muted:        var(--text-2);
+  --baw-faint:        var(--text-3);
+  --baw-primary:      var(--brand-500);
+  --baw-agent:        var(--agent-500);
+  --baw-agent-subtle: var(--agent-fill);
+  --baw-human-subtle: var(--brand-fill);
+  --baw-success:      var(--green-500);
+  --baw-warning:      var(--amber-500);
+  --baw-danger:       var(--red-500);
 }
 
+/* ── Modo light ─────────────────────────────────────────────────────── */
 html.light {
-  --baw-bg: #F7F7F8;
-  --baw-surface: #FFFFFF;
-  --baw-elevated: #F3F4F6;
-  --baw-border: #E5E7EB;
-  --baw-text: #111827;
-  --baw-muted: #6B7280;
-  --baw-faint: #9CA3AF;
+  --bg:        var(--l-bg);
+  --surface:   var(--l-surface);
+  --surface-2: var(--l-surface-2);
+  --surface-3: var(--l-surface-3);
+  --line:      var(--l-line);
+  --line-2:    var(--l-line-2);
+  --text:      var(--l-text);
+  --text-2:    var(--l-text-2);
+  --text-3:    var(--l-text-3);
+  --text-4:    var(--l-text-4);
+
+  --red-fill:   var(--red-100);
+  --amber-fill: var(--amber-100);
+  --green-fill: var(--green-100);
+  --blue-fill:  var(--blue-100);
+  --agent-fill: var(--agent-100);
+  --brand-fill: var(--brand-100);
+
+  /* aliases también se actualizan en light por el cambio en --bg/--text/etc.
+     pero re-declaramos los semánticos críticos para legibilidad */
+  --baw-bg:           var(--bg);
+  --baw-surface:      var(--surface);
+  --baw-elevated:     var(--surface-2);
+  --baw-border:       var(--line);
+  --baw-text:         var(--text);
+  --baw-muted:        var(--text-2);
+  --baw-faint:        var(--text-3);
 }
 
-/* Sidebar keeps its dark chrome regardless of app theme, so any element
-   inside it that consumes --baw-* tokens renders legibly on the dark surface. */
+/* Sidebar mantiene su chrome oscuro independiente del tema de la app:
+   los aliases --baw-* dentro del sidebar siguen apuntando al scope dark. */
 aside[data-sidebar] {
-  --baw-bg: #0F0F12;
-  --baw-surface: #17171C;
-  --baw-elevated: #1E1E24;
-  --baw-border: #2A2A32;
-  --baw-text: #E8E8EC;
-  --baw-muted: #A0A0AB;
-  --baw-faint: #6E6E78;
+  --baw-bg:       var(--d-bg);
+  --baw-surface:  var(--d-surface);
+  --baw-elevated: var(--d-surface-2);
+  --baw-border:   var(--d-line);
+  --baw-text:     var(--d-text);
+  --baw-muted:    var(--d-text-2);
+  --baw-faint:    var(--d-text-3);
 }
 
-/* Page-level h1 headings: always use the design-system text color.
-   Placed outside @layer so it overrides Tailwind utility classes
-   like text-gray-900 / dark:text-white that some pages still carry. */
+/* H1 de página: siempre usa el color de texto del design system */
 main h1 {
   color: var(--baw-text);
 }
@@ -60,10 +118,9 @@ main h1 {
     font-variant-numeric: tabular-nums;
   }
   html.light body {
-    background-color: #F7F7F8;
-    color: #1A1A1F;
+    background-color: var(--l-bg);
+    color: var(--l-text);
   }
-  /* Numeric tabular by default in tables */
   table, td, th, tbody, input, .num {
     font-variant-numeric: tabular-nums;
   }
@@ -76,11 +133,11 @@ main h1 {
     border-color: var(--baw-border);
   }
   html.light .card {
-    background-color: #FFFFFF;
-    border-color: #E5E7EB;
+    background-color: var(--l-surface);
+    border-color: var(--l-line);
   }
 
-  /* Accent borders for actor attribution */
+  /* Accent borders para actor attribution */
   .agent-border {
     border-left: 2px solid var(--baw-agent);
   }
@@ -93,74 +150,74 @@ main h1 {
 
   .agent-badge {
     @apply inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: var(--baw-agent-subtle);
-    color: var(--baw-agent);
-    border: 1px solid rgba(139, 92, 246, 0.3);
+    background-color: var(--agent-fill);
+    color: var(--agent-500);
+    border: 1px solid color-mix(in oklch, var(--agent-500) 30%, transparent);
   }
 
-  /* ---- Badges ---- */
+  /* ── Badges (todas migradas a tokens canónicos) ── */
   .badge-available {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(34, 197, 94, 0.1);
-    color: #4ADE80;
-    border: 1px solid rgba(34, 197, 94, 0.25);
+    background-color: var(--green-fill);
+    color: var(--green-400);
+    border: 1px solid color-mix(in oklch, var(--green-500) 25%, transparent);
   }
   .badge-occupied {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(59, 130, 246, 0.1);
-    color: #60A5FA;
-    border: 1px solid rgba(59, 130, 246, 0.25);
+    background-color: var(--blue-fill);
+    color: var(--blue-400);
+    border: 1px solid color-mix(in oklch, var(--blue-500) 25%, transparent);
   }
   .badge-maintenance {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(245, 158, 11, 0.1);
-    color: #FBBF24;
-    border: 1px solid rgba(245, 158, 11, 0.25);
+    background-color: var(--amber-fill);
+    color: var(--amber-400);
+    border: 1px solid color-mix(in oklch, var(--amber-500) 25%, transparent);
   }
   .badge-reserved {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(139, 92, 246, 0.1);
-    color: #A78BFA;
-    border: 1px solid rgba(139, 92, 246, 0.25);
+    background-color: var(--agent-fill);
+    color: var(--agent-400);
+    border: 1px solid color-mix(in oklch, var(--agent-500) 25%, transparent);
   }
   .badge-paid {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(34, 197, 94, 0.1);
-    color: #4ADE80;
-    border: 1px solid rgba(34, 197, 94, 0.25);
+    background-color: var(--green-fill);
+    color: var(--green-400);
+    border: 1px solid color-mix(in oklch, var(--green-500) 25%, transparent);
   }
   .badge-pending {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(245, 158, 11, 0.1);
-    color: #FBBF24;
-    border: 1px solid rgba(245, 158, 11, 0.25);
+    background-color: var(--amber-fill);
+    color: var(--amber-400);
+    border: 1px solid color-mix(in oklch, var(--amber-500) 25%, transparent);
   }
   .badge-late {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(239, 68, 68, 0.1);
-    color: #F87171;
-    border: 1px solid rgba(239, 68, 68, 0.25);
+    background-color: var(--red-fill);
+    color: var(--red-400);
+    border: 1px solid color-mix(in oklch, var(--red-500) 25%, transparent);
   }
   .badge-active {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(34, 197, 94, 0.1);
-    color: #4ADE80;
-    border: 1px solid rgba(34, 197, 94, 0.25);
+    background-color: var(--green-fill);
+    color: var(--green-400);
+    border: 1px solid color-mix(in oklch, var(--green-500) 25%, transparent);
   }
   .badge-expired {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(139, 139, 149, 0.08);
-    color: #A0A0AB;
-    border: 1px solid rgba(139, 139, 149, 0.2);
+    background-color: color-mix(in oklch, var(--text-3) 8%, transparent);
+    color: var(--text-3);
+    border: 1px solid color-mix(in oklch, var(--text-3) 20%, transparent);
   }
   .badge-en-renovacion {
     @apply inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium;
-    background-color: rgba(59, 130, 246, 0.1);
-    color: #60A5FA;
-    border: 1px solid rgba(59, 130, 246, 0.25);
+    background-color: var(--blue-fill);
+    color: var(--blue-400);
+    border: 1px solid color-mix(in oklch, var(--blue-500) 25%, transparent);
   }
 
-  /* ---- Tables (denser, operational) ---- */
+  /* ── Tablas ── */
   .table-header {
     background-color: var(--baw-surface);
     color: var(--baw-muted);
@@ -175,10 +232,10 @@ main h1 {
     @apply transition-colors;
   }
   .table-row:hover {
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: color-mix(in oklch, var(--text) 4%, transparent);
   }
   html.light .table-row:hover {
-    background-color: rgba(0, 0, 0, 0.03);
+    background-color: color-mix(in oklch, var(--l-text) 4%, transparent);
   }
   .table-row td {
     @apply py-2 px-3 text-[13px];
@@ -186,16 +243,16 @@ main h1 {
     color: var(--baw-text);
   }
   html.light .table-header {
-    background-color: #F3F4F6;
-    color: #4B5563;
+    background-color: var(--l-surface-3);
+    color: var(--l-text-2);
   }
   html.light .table-header th,
   html.light .table-header td,
   html.light .table-row td {
-    border-bottom: 1px solid #E5E7EB;
+    border-bottom: 1px solid var(--l-line);
   }
   html.light .table-row td {
-    color: #111827;
+    color: var(--l-text);
   }
 
   /* Toast animation */
@@ -222,7 +279,7 @@ main h1 {
     animation: pulse-soft 1.6s ease-in-out infinite;
   }
 
-  /* Print styles for PDF export */
+  /* Print styles para PDF export */
   @media print {
     body * {
       visibility: hidden;
@@ -241,7 +298,7 @@ main h1 {
     }
   }
 
-  /* ---- Form inputs ---- */
+  /* ── Form inputs ── */
   .input-field {
     @apply w-full rounded-md px-3 py-2 text-[13px] transition-colors;
     background-color: var(--baw-surface);
@@ -251,21 +308,21 @@ main h1 {
   .input-field:focus {
     outline: none;
     border-color: var(--baw-primary);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+    box-shadow: 0 0 0 2px color-mix(in oklch, var(--brand-500) 25%, transparent);
   }
   html.light .input-field {
-    background-color: #FFFFFF;
-    border-color: #D1D5DB;
-    color: #111827;
+    background-color: var(--l-surface);
+    border-color: var(--l-line-2);
+    color: var(--l-text);
   }
 
   .btn-primary {
     @apply inline-flex items-center justify-center rounded-md px-3.5 py-2 text-[13px] font-medium transition-colors;
     background-color: var(--baw-primary);
-    color: #FFFFFF;
+    color: var(--l-surface);
   }
   .btn-primary:hover {
-    background-color: #2563EB;
+    background-color: var(--brand-600);
   }
 
   .btn-secondary {
@@ -276,23 +333,23 @@ main h1 {
   }
   .btn-secondary:hover {
     border-color: var(--baw-muted);
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: color-mix(in oklch, var(--text) 4%, transparent);
   }
   html.light .btn-secondary {
-    border-color: #D1D5DB;
-    color: #111827;
+    border-color: var(--l-line-2);
+    color: var(--l-text);
   }
   html.light .btn-secondary:hover {
-    background-color: #F3F4F6;
+    background-color: var(--l-surface-3);
   }
 
   .btn-danger {
     @apply inline-flex items-center justify-center rounded-md px-3.5 py-2 text-[13px] font-medium transition-colors;
     background-color: var(--baw-danger);
-    color: #FFFFFF;
+    color: var(--l-surface);
   }
   .btn-danger:hover {
-    background-color: #DC2626;
+    background-color: color-mix(in oklch, var(--red-500) 88%, black);
   }
 
   .page-title {
@@ -300,7 +357,7 @@ main h1 {
     color: var(--baw-text);
   }
   html.light .page-title {
-    color: #111827;
+    color: var(--l-text);
   }
 
   .page-subtitle {
@@ -308,7 +365,7 @@ main h1 {
     color: var(--baw-muted);
   }
   html.light .page-subtitle {
-    color: #6B7280;
+    color: var(--l-text-2);
   }
 
   .section-title {
@@ -316,7 +373,7 @@ main h1 {
     color: var(--baw-text);
   }
   html.light .section-title {
-    color: #111827;
+    color: var(--l-text);
   }
 
   .field-label {
@@ -324,13 +381,13 @@ main h1 {
     color: var(--baw-muted);
   }
   html.light .field-label {
-    color: #6B7280;
+    color: var(--l-text-2);
   }
 
   .muted-text {
     color: var(--baw-muted);
   }
   html.light .muted-text {
-    color: #6B7280;
+    color: var(--l-text-2);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,14 +20,27 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="es" className={`dark ${inter.variable}`} suppressHydrationWarning>
+    <html lang="es" className={inter.variable} suppressHydrationWarning>
       <head>
         <script
           dangerouslySetInnerHTML={{
             __html: `
               (function() {
-                var t = localStorage.getItem('baw-theme');
-                if (t === 'light') document.documentElement.classList.remove('dark');
+                try {
+                  var t = localStorage.getItem('baw:theme');
+                  if (t !== 'light' && t !== 'dark' && t !== 'system') t = 'dark';
+                  var effective = t;
+                  if (t === 'system') {
+                    effective = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                  }
+                  var root = document.documentElement;
+                  root.classList.toggle('dark', effective === 'dark');
+                  root.classList.toggle('light', effective === 'light');
+                  root.dataset.theme = effective;
+                } catch (e) {
+                  document.documentElement.classList.add('dark');
+                  document.documentElement.dataset.theme = 'dark';
+                }
               })();
             `,
           }}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -105,11 +105,14 @@ export default function OnboardingWizardV2() {
   })
 
   // Paso 3 — Unidades (bulk)
+  // Sprint 3 / S7: campos numéricos guardados como string para permitir
+  // edición libre (vaciar el campo, borrar y reescribir).  Se coercen a number
+  // sólo en el momento de generar.
   const [unitConfig, setUnitConfig] = useState({
-    count: 4,
+    count: '4',
     prefix: '',
-    startNumber: 101,
-    floors: 4,
+    startNumber: '101',
+    floors: '4',
     type: 'LTR' as UnitRow['type'],
   })
   const [units, setUnits] = useState<UnitRow[]>([])
@@ -210,16 +213,35 @@ export default function OnboardingWizardV2() {
   // Generación de unidades en bulk
   // ---------------------------------------------------------------------------
 
+  // Sprint 3 / S7 — Bug #4 fix: en lugar de REEMPLAZAR la lista de unidades,
+  // ahora hacemos APPEND con deduplicación por `number`.  Permite ejecutar
+  // múltiples bulks (p.ej. 101-104, 201-204, 301-304) en sesiones distintas
+  // del mismo paso.
   function generateUnits() {
     const rows: UnitRow[] = []
-    const { count, prefix, startNumber, floors, type } = unitConfig
-    const perFloor = floors > 0 ? Math.ceil(count / floors) : count
+    const count = Math.max(1, Number(unitConfig.count) || 0)
+    const startNumber = Number(unitConfig.startNumber) || 101
+    const floors = Math.max(1, Number(unitConfig.floors) || 1)
+    const { prefix, type } = unitConfig
+    const perFloor = Math.ceil(count / floors)
     for (let i = 0; i < count; i++) {
       const floor = Math.min(floors, Math.floor(i / perFloor) + 1)
       const num = `${prefix}${startNumber + i}`
       rows.push({ number: num, type, floor })
     }
-    setUnits(rows)
+    // Deduplicar por number: las nuevas filas ganan sobre las existentes
+    const byNumber = new Map<string, UnitRow>()
+    for (const u of units) byNumber.set(u.number, u)
+    for (const u of rows) byNumber.set(u.number, u)
+    setUnits(Array.from(byNumber.values()))
+
+    // Auto-sugerir el siguiente piso/secuencia para el siguiente bulk
+    // (p.ej. tras generar 101-104, deja 201 listo para el siguiente).
+    const nextStart = startNumber + 100
+    setUnitConfig({
+      ...unitConfig,
+      startNumber: String(nextStart),
+    })
   }
 
   function addUnit() {
@@ -672,10 +694,10 @@ function StepUnits({
   updateUnit,
 }: {
   unitConfig: {
-    count: number
+    count: string
     prefix: string
-    startNumber: number
-    floors: number
+    startNumber: string
+    floors: string
     type: UnitRow['type']
   }
   setUnitConfig: (c: typeof unitConfig) => void
@@ -706,16 +728,15 @@ function StepUnits({
       >
         <Field label="Cantidad">
           <input
-            type="number"
-            min={1}
-            max={500}
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
             value={unitConfig.count}
-            onChange={(e) =>
-              setUnitConfig({
-                ...unitConfig,
-                count: Math.max(1, Number(e.target.value) || 1),
-              })
-            }
+            onChange={(e) => {
+              const v = e.target.value.replace(/[^0-9]/g, '')
+              setUnitConfig({ ...unitConfig, count: v })
+            }}
+            placeholder="4"
             className="w-full"
             style={inputStyle}
           />
@@ -734,30 +755,30 @@ function StepUnits({
         </Field>
         <Field label="Empezar en">
           <input
-            type="number"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
             value={unitConfig.startNumber}
-            onChange={(e) =>
-              setUnitConfig({
-                ...unitConfig,
-                startNumber: Number(e.target.value) || 101,
-              })
-            }
+            onChange={(e) => {
+              const v = e.target.value.replace(/[^0-9]/g, '')
+              setUnitConfig({ ...unitConfig, startNumber: v })
+            }}
+            placeholder="101"
             className="w-full"
             style={inputStyle}
           />
         </Field>
         <Field label="Pisos">
           <input
-            type="number"
-            min={1}
-            max={50}
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
             value={unitConfig.floors}
-            onChange={(e) =>
-              setUnitConfig({
-                ...unitConfig,
-                floors: Math.max(1, Number(e.target.value) || 1),
-              })
-            }
+            onChange={(e) => {
+              const v = e.target.value.replace(/[^0-9]/g, '')
+              setUnitConfig({ ...unitConfig, floors: v })
+            }}
+            placeholder="1"
             className="w-full"
             style={inputStyle}
           />
@@ -780,18 +801,28 @@ function StepUnits({
           </select>
         </Field>
       </div>
-      <button
-        type="button"
-        onClick={generateUnits}
-        className="px-4 py-2 rounded-md text-[13px]"
-        style={{
-          backgroundColor: 'var(--baw-bg)',
-          border: '1px solid var(--baw-border)',
-          color: 'var(--baw-text)',
-        }}
-      >
-        Generar {unitConfig.count} unidades
-      </button>
+      <div className="flex items-center gap-3 flex-wrap">
+        <button
+          type="button"
+          onClick={generateUnits}
+          className="px-4 py-2 rounded-md text-[13px]"
+          style={{
+            backgroundColor: 'var(--baw-bg)',
+            border: '1px solid var(--baw-border)',
+            color: 'var(--baw-text)',
+          }}
+        >
+          {units.length > 0
+            ? `Agregar ${unitConfig.count || 0} unidades más`
+            : `Generar ${unitConfig.count || 0} unidades`}
+        </button>
+        {units.length > 0 && (
+          <span className="text-[12px] muted-text">
+            Puedes ejecutar varios bulks (101–104, 201–204, etc.) y se irán
+            sumando.
+          </span>
+        )}
+      </div>
 
       {/* Lista editable */}
       {units.length > 0 && (

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,15 +1,41 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { Building2, Plus, Trash2, CheckCircle, ArrowLeft, ArrowRight, SkipForward } from 'lucide-react'
+// BaW OS — Onboarding Wizard v2 (Sprint 3 / S3)
+// Modelo de 5 capas: PM Company → PM Users → Buildings → Units → Property Owners
+// 4 pasos: PM Company · Edificio · Unidades · Property Owner
 
-// Tipos del wizard
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import {
+  Building2,
+  Briefcase,
+  Home,
+  UserCog,
+  CheckCircle2,
+  ArrowLeft,
+  ArrowRight,
+  Plus,
+  Trash2,
+  AlertTriangle,
+} from 'lucide-react'
+
+// -----------------------------------------------------------------------------
+// Tipos
+// -----------------------------------------------------------------------------
+
+interface PMCompanyData {
+  name: string
+  slug: string
+}
+
 interface BuildingData {
   name: string
   address: string
   city: string
-  total_units: number
+  state: string
+  country: string
+  postal_code: string
 }
 
 interface UnitRow {
@@ -18,53 +44,182 @@ interface UnitRow {
   floor: number
 }
 
-interface TenantRow {
-  name: string
+type OwnerMode = 'self' | 'client' | 'skip'
+
+interface OwnerData {
+  full_name: string
+  email: string
   phone: string
-  unit_number: string
-  monthly_amount: number
-  start_date: string
+  rfc: string
+  percentage: number
 }
 
-const STEPS = ['Edificio', 'Unidades', 'Inquilinos', 'Listo']
+const STEPS = [
+  { key: 'pm', label: 'PM Company', icon: Briefcase },
+  { key: 'building', label: 'Edificio', icon: Building2 },
+  { key: 'units', label: 'Unidades', icon: Home },
+  { key: 'owner', label: 'Property Owner', icon: UserCog },
+]
 
-export default function OnboardingWizard() {
+// -----------------------------------------------------------------------------
+// Utils
+// -----------------------------------------------------------------------------
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 60)
+}
+
+// -----------------------------------------------------------------------------
+// Componente principal
+// -----------------------------------------------------------------------------
+
+export default function OnboardingWizardV2() {
   const router = useRouter()
   const [step, setStep] = useState(0)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [result, setResult] = useState<{ units_created: number; contracts_created: number } | null>(null)
+  const [authChecked, setAuthChecked] = useState(false)
+  const [userId, setUserId] = useState<string | null>(null)
+  const [userEmail, setUserEmail] = useState<string | null>(null)
 
-  // Paso 1 — Edificio
+  // Paso 1 — PM Company (pre-poblado)
+  const [pm, setPM] = useState<PMCompanyData>({
+    name: 'BaW Operations',
+    slug: 'baw-operations',
+  })
+
+  // Paso 2 — Edificio
   const [building, setBuilding] = useState<BuildingData>({
     name: '',
     address: '',
     city: '',
-    total_units: 4,
+    state: '',
+    country: 'MX',
+    postal_code: '',
   })
 
-  // Paso 2 — Unidades
+  // Paso 3 — Unidades (bulk)
+  const [unitConfig, setUnitConfig] = useState({
+    count: 4,
+    prefix: '',
+    startNumber: 101,
+    floors: 4,
+    type: 'LTR' as UnitRow['type'],
+  })
   const [units, setUnits] = useState<UnitRow[]>([])
 
-  // Paso 3 — Inquilinos
-  const [tenants, setTenants] = useState<TenantRow[]>([])
+  // Paso 4 — Property Owner
+  const [ownerMode, setOwnerMode] = useState<OwnerMode>('self')
+  const [owner, setOwner] = useState<OwnerData>({
+    full_name: '',
+    email: '',
+    phone: '',
+    rfc: '',
+    percentage: 100,
+  })
 
-  // Al avanzar del paso 1 al 2, precarga filas vacías
-  function goToStep2() {
-    if (!building.name || !building.address || !building.city || building.total_units < 1) {
-      setError('Completa todos los campos antes de continuar.')
+  // Resultado final
+  const [result, setResult] = useState<{
+    org_id: string
+    building_id: string
+    units_created: number
+  } | null>(null)
+
+  // Auth gate (client-side: requiere usuario autenticado)
+  useEffect(() => {
+    async function checkAuth() {
+      const { data } = await supabase.auth.getSession()
+      const session = data.session
+      if (!session) {
+        router.replace('/login?redirect=/onboarding')
+        return
+      }
+      setUserId(session.user.id)
+      setUserEmail(session.user.email ?? null)
+      // Pre-poblar email del owner si modo "self"
+      setOwner((o) => ({ ...o, email: session.user.email ?? '' }))
+      setAuthChecked(true)
+    }
+    checkAuth()
+  }, [router])
+
+  // Mantener slug sincronizado mientras el usuario teclea el name
+  useEffect(() => {
+    setPM((p) => ({ ...p, slug: slugify(p.name) }))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pm.name])
+
+  // ---------------------------------------------------------------------------
+  // Handlers de navegación
+  // ---------------------------------------------------------------------------
+
+  function validateStep(idx: number): string | null {
+    if (idx === 0) {
+      if (!pm.name.trim()) return 'El nombre del PM Company es obligatorio.'
+      if (!pm.slug.trim()) return 'El slug es obligatorio (se genera automáticamente).'
+      return null
+    }
+    if (idx === 1) {
+      if (!building.name.trim()) return 'El nombre del edificio es obligatorio.'
+      if (!building.city.trim()) return 'La ciudad es obligatoria.'
+      return null
+    }
+    if (idx === 2) {
+      if (units.length === 0)
+        return 'Genera o agrega al menos una unidad antes de continuar.'
+      const numbers = units.map((u) => u.number.trim())
+      if (numbers.some((n) => !n)) return 'Todas las unidades deben tener número.'
+      const dup = numbers.find((n, i) => numbers.indexOf(n) !== i)
+      if (dup) return `Hay números duplicados: ${dup}`
+      return null
+    }
+    if (idx === 3) {
+      if (ownerMode === 'self') return null
+      if (ownerMode === 'skip') return null
+      if (!owner.full_name.trim())
+        return 'El nombre del propietario es obligatorio.'
+      if (owner.percentage <= 0 || owner.percentage > 100)
+        return 'El porcentaje debe estar entre 1 y 100.'
+      return null
+    }
+    return null
+  }
+
+  function next() {
+    const err = validateStep(step)
+    if (err) {
+      setError(err)
       return
     }
     setError(null)
-    if (units.length === 0) {
-      const rows: UnitRow[] = Array.from({ length: building.total_units }, (_, i) => ({
-        number: String(i + 1),
-        type: 'LTR',
-        floor: 1,
-      }))
-      setUnits(rows)
+    setStep(step + 1)
+  }
+
+  function back() {
+    setError(null)
+    if (step > 0) setStep(step - 1)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Generación de unidades en bulk
+  // ---------------------------------------------------------------------------
+
+  function generateUnits() {
+    const rows: UnitRow[] = []
+    const { count, prefix, startNumber, floors, type } = unitConfig
+    const perFloor = floors > 0 ? Math.ceil(count / floors) : count
+    for (let i = 0; i < count; i++) {
+      const floor = Math.min(floors, Math.floor(i / perFloor) + 1)
+      const num = `${prefix}${startNumber + i}`
+      rows.push({ number: num, type, floor })
     }
-    setStep(1)
+    setUnits(rows)
   }
 
   function addUnit() {
@@ -81,388 +236,920 @@ export default function OnboardingWizard() {
     setUnits(copy)
   }
 
-  function addTenant() {
-    setTenants([...tenants, { name: '', phone: '', unit_number: '', monthly_amount: 0, start_date: '' }])
-  }
+  // ---------------------------------------------------------------------------
+  // Submit final
+  // ---------------------------------------------------------------------------
 
-  function removeTenant(idx: number) {
-    setTenants(tenants.filter((_, i) => i !== idx))
-  }
-
-  function updateTenant(idx: number, field: keyof TenantRow, value: string | number) {
-    const copy = [...tenants]
-    copy[idx] = { ...copy[idx], [field]: value }
-    setTenants(copy)
-  }
-
-  // Enviar todo al API en el paso final
   async function handleSubmit() {
+    const err = validateStep(3)
+    if (err) {
+      setError(err)
+      return
+    }
+    if (!userId) {
+      setError('Sesión expirada. Vuelve a iniciar sesión.')
+      return
+    }
     setSubmitting(true)
     setError(null)
     try {
+      const payload = {
+        user_id: userId,
+        pm: { name: pm.name.trim(), slug: pm.slug.trim() },
+        building: {
+          name: building.name.trim(),
+          address: building.address.trim() || null,
+          city: building.city.trim(),
+          state: building.state.trim() || null,
+          country: building.country.trim() || 'MX',
+          postal_code: building.postal_code.trim() || null,
+        },
+        units: units.map((u) => ({
+          number: u.number.trim(),
+          type: u.type,
+          floor: Number(u.floor) || 1,
+        })),
+        owner_mode: ownerMode,
+        owner:
+          ownerMode === 'self'
+            ? {
+                full_name: pm.name,
+                email: userEmail,
+                phone: null,
+                rfc: null,
+                percentage: 100,
+                user_id: userId,
+              }
+            : ownerMode === 'client'
+            ? {
+                full_name: owner.full_name.trim(),
+                email: owner.email.trim() || null,
+                phone: owner.phone.trim() || null,
+                rfc: owner.rfc.trim() || null,
+                percentage: Number(owner.percentage),
+                user_id: null,
+              }
+            : null,
+      }
+
       const res = await fetch('/api/onboarding', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          building: { name: building.name, address: building.address, city: building.city },
-          units: units.map((u) => ({ number: u.number, type: u.type, floor: u.floor })),
-          tenants: tenants.filter((t) => t.name && t.unit_number),
-        }),
+        body: JSON.stringify(payload),
       })
-      const data = await res.json()
-      if (!res.ok || !data.success) throw new Error(data.error || 'Error al guardar')
-      setResult(data.data)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Error desconocido')
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        throw new Error(json.error || `HTTP ${res.status}`)
+      }
+      setResult(json.data)
+      // Mover al paso 5 (resumen)
+      setStep(4)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error inesperado.')
     } finally {
       setSubmitting(false)
     }
   }
 
-  // Validaciones por paso
-  const step1Valid = building.name && building.address && building.city && building.total_units >= 1
-  const step2Valid = units.length >= 1 && units.every((u) => u.number)
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  if (!authChecked) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <span className="muted-text text-[13px]">Cargando sesión…</span>
+      </div>
+    )
+  }
 
   return (
-    <div className="min-h-screen flex items-start justify-center pt-12 px-4 bg-black">
-      <div className="w-full max-w-2xl">
-        {/* Regresar al dashboard */}
-        <button
-          onClick={() => router.push('/')}
-          className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-white transition-colors mb-6"
+    <div
+      className="min-h-screen px-4 py-10"
+      style={{ backgroundColor: 'var(--baw-bg)', color: 'var(--baw-text)' }}
+    >
+      <div className="max-w-3xl mx-auto">
+        {/* Header */}
+        <header className="mb-8 text-center">
+          <h1 className="text-[28px] font-semibold tracking-tight">
+            Bienvenido a BaW OS
+          </h1>
+          <p className="muted-text text-[14px] mt-2">
+            Configura tu PM Company en cuatro pasos. BaW empieza a operar contigo
+            desde el primer edificio.
+          </p>
+        </header>
+
+        {/* Stepper */}
+        <Stepper currentStep={step} />
+
+        {/* Error banner */}
+        {error && (
+          <div
+            className="mt-6 px-4 py-3 rounded-md flex items-start gap-2 text-[13px]"
+            style={{
+              backgroundColor: 'rgba(248, 113, 113, 0.08)',
+              border: '1px solid rgba(248, 113, 113, 0.3)',
+              color: '#fca5a5',
+            }}
+          >
+            <AlertTriangle size={16} className="mt-0.5 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Step content */}
+        <div
+          className="mt-6 rounded-lg p-6"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
         >
-          <ArrowLeft className="w-4 h-4" /> Regresar al dashboard
-        </button>
-
-        {/* Progress bar */}
-        <div className="flex items-center justify-between mb-8">
-          {STEPS.map((label, i) => (
-            <div key={label} className="flex items-center gap-2 flex-1">
-              <div
-                className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold shrink-0 transition-colors ${
-                  i < step
-                    ? 'bg-emerald-500 text-white'
-                    : i === step
-                    ? 'bg-white text-black'
-                    : 'bg-gray-700 text-gray-400'
-                }`}
-              >
-                {i < step ? <CheckCircle className="w-4 h-4" /> : i + 1}
-              </div>
-              <span
-                className={`text-xs font-medium hidden sm:block ${
-                  i <= step ? 'text-white' : 'text-gray-500'
-                }`}
-              >
-                {label}
-              </span>
-              {i < STEPS.length - 1 && (
-                <div
-                  className={`flex-1 h-0.5 mx-2 rounded ${
-                    i < step ? 'bg-emerald-500' : 'bg-gray-700'
-                  }`}
-                />
-              )}
-            </div>
-          ))}
-        </div>
-
-        {/* Card principal */}
-        <div className="bg-[#111] border border-[#333] rounded-xl p-6">
-          {/* ── Paso 1: Edificio ── */}
-          {step === 0 && (
-            <div className="space-y-6">
-              <div className="text-center">
-                <Building2 className="w-10 h-10 text-gray-400 mx-auto mb-3" />
-                <h2 className="text-xl font-bold text-white">Bienvenido a BaW OS</h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  Configura tu propiedad en BaW OS en menos de 5 minutos.
-                </p>
-              </div>
-
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">Nombre del edificio</label>
-                  <input
-                    className="input-field"
-                    placeholder="Ej: ALM809P"
-                    value={building.name}
-                    onChange={(e) => setBuilding({ ...building, name: e.target.value })}
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">Dirección completa</label>
-                  <input
-                    className="input-field"
-                    placeholder="Calle, número, colonia, CP"
-                    value={building.address}
-                    onChange={(e) => setBuilding({ ...building, address: e.target.value })}
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">Ciudad</label>
-                  <input
-                    className="input-field"
-                    placeholder="Tu ciudad"
-                    value={building.city}
-                    onChange={(e) => setBuilding({ ...building, city: e.target.value })}
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">Número total de unidades</label>
-                  <input
-                    className="input-field"
-                    type="number"
-                    min={1}
-                    value={building.total_units}
-                    onChange={(e) => setBuilding({ ...building, total_units: parseInt(e.target.value) || 1 })}
-                  />
-                </div>
-              </div>
-
-              <div className="flex justify-end">
-                <button
-                  disabled={!step1Valid}
-                  onClick={goToStep2}
-                  className="flex items-center gap-2 px-5 py-2.5 bg-white hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed text-black text-sm font-medium rounded-lg transition-colors"
-                >
-                  Continuar <ArrowRight className="w-4 h-4" />
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* ── Paso 2: Unidades ── */}
+          {step === 0 && <StepPMCompany pm={pm} setPM={setPM} />}
           {step === 1 && (
-            <div className="space-y-6">
-              <div>
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Agregar unidades</h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  Define las unidades de tu propiedad. Puedes ajustar el número, tipo y piso.
-                </p>
-              </div>
-
-              <div className="space-y-3 max-h-[400px] overflow-y-auto pr-1">
-                {units.map((u, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <input
-                      className="input-field w-24"
-                      placeholder="No."
-                      value={u.number}
-                      onChange={(e) => updateUnit(i, 'number', e.target.value)}
-                    />
-                    <select
-                      className="input-field w-28"
-                      value={u.type}
-                      onChange={(e) => updateUnit(i, 'type', e.target.value)}
-                    >
-                      <option value="LTR">LTR</option>
-                      <option value="MTR">MTR</option>
-                      <option value="STR">STR</option>
-                    </select>
-                    <input
-                      className="input-field w-20"
-                      type="number"
-                      min={0}
-                      placeholder="Piso"
-                      value={u.floor}
-                      onChange={(e) => updateUnit(i, 'floor', parseInt(e.target.value) || 0)}
-                    />
-                    <button
-                      onClick={() => removeUnit(i)}
-                      className="p-2 text-red-400 hover:text-red-300 transition-colors shrink-0"
-                      title="Eliminar unidad"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  </div>
-                ))}
-              </div>
-
-              <button
-                onClick={addUnit}
-                className="flex items-center gap-2 text-sm text-gray-400 hover:text-white font-medium transition-colors"
-              >
-                <Plus className="w-4 h-4" /> Agregar unidad
-              </button>
-
-              <div className="flex justify-between">
-                <button
-                  onClick={() => setStep(0)}
-                  className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-400 hover:text-white transition-colors"
-                >
-                  <ArrowLeft className="w-4 h-4" /> Atrás
-                </button>
-                <button
-                  disabled={!step2Valid}
-                  onClick={() => setStep(2)}
-                  className="flex items-center gap-2 px-5 py-2.5 bg-white hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed text-black text-sm font-medium rounded-lg transition-colors"
-                >
-                  Continuar <ArrowRight className="w-4 h-4" />
-                </button>
-              </div>
-            </div>
+            <StepBuilding building={building} setBuilding={setBuilding} />
           )}
-
-          {/* ── Paso 3: Inquilinos (opcional) ── */}
           {step === 2 && (
-            <div className="space-y-6">
-              <div>
-                <h2 className="text-xl font-bold text-gray-900 dark:text-white">Agregar inquilinos</h2>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  Agrega tus inquilinos actuales. Puedes hacerlo después desde Contratos.
-                </p>
-              </div>
-
-              <div className="space-y-4 max-h-[400px] overflow-y-auto pr-1">
-                {tenants.map((t, i) => (
-                  <div key={i} className="p-3 rounded-lg bg-gray-800/50 space-y-2">
-                    <div className="flex items-center gap-2">
-                      <input
-                        className="input-field flex-1"
-                        placeholder="Nombre del inquilino"
-                        value={t.name}
-                        onChange={(e) => updateTenant(i, 'name', e.target.value)}
-                      />
-                      <button
-                        onClick={() => removeTenant(i)}
-                        className="p-2 text-red-400 hover:text-red-300 transition-colors shrink-0"
-                        title="Eliminar inquilino"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      <input
-                        className="input-field"
-                        placeholder="Teléfono (opcional)"
-                        value={t.phone}
-                        onChange={(e) => updateTenant(i, 'phone', e.target.value)}
-                      />
-                      <select
-                        className="input-field"
-                        value={t.unit_number}
-                        onChange={(e) => updateTenant(i, 'unit_number', e.target.value)}
-                      >
-                        <option value="">Seleccionar unidad</option>
-                        {units.map((u) => (
-                          <option key={u.number} value={u.number}>
-                            Unidad {u.number}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      <input
-                        className="input-field"
-                        type="number"
-                        min={0}
-                        placeholder="Renta mensual"
-                        value={t.monthly_amount || ''}
-                        onChange={(e) => updateTenant(i, 'monthly_amount', parseFloat(e.target.value) || 0)}
-                      />
-                      <input
-                        className="input-field"
-                        type="date"
-                        value={t.start_date}
-                        onChange={(e) => updateTenant(i, 'start_date', e.target.value)}
-                      />
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              <button
-                onClick={addTenant}
-                className="flex items-center gap-2 text-sm text-gray-400 hover:text-white font-medium transition-colors"
-              >
-                <Plus className="w-4 h-4" /> Agregar inquilino
-              </button>
-
-              <div className="flex justify-between">
-                <button
-                  onClick={() => setStep(1)}
-                  className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-400 hover:text-white transition-colors"
-                >
-                  <ArrowLeft className="w-4 h-4" /> Atrás
-                </button>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => { setTenants([]); setStep(3); handleSubmit() }}
-                    className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-400 hover:text-white transition-colors"
-                  >
-                    <SkipForward className="w-4 h-4" /> Omitir por ahora
-                  </button>
-                  <button
-                    onClick={() => { setStep(3); handleSubmit() }}
-                    className="flex items-center gap-2 px-5 py-2.5 bg-white hover:bg-gray-100 text-black text-sm font-medium rounded-lg transition-colors"
-                  >
-                    Continuar <ArrowRight className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-            </div>
+            <StepUnits
+              unitConfig={unitConfig}
+              setUnitConfig={setUnitConfig}
+              units={units}
+              setUnits={setUnits}
+              generateUnits={generateUnits}
+              addUnit={addUnit}
+              removeUnit={removeUnit}
+              updateUnit={updateUnit}
+            />
           )}
-
-          {/* ── Paso 4: Listo ── */}
           {step === 3 && (
-            <div className="space-y-6 text-center py-4">
-              {submitting && (
-                <div className="space-y-3">
-                  <div className="w-12 h-12 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin mx-auto" />
-                  <p className="text-sm text-gray-400">Guardando configuración...</p>
-                </div>
-              )}
-
-              {error && (
-                <div className="space-y-4">
-                  <div className="w-14 h-14 rounded-full bg-red-500/20 flex items-center justify-center mx-auto">
-                    <span className="text-2xl">!</span>
-                  </div>
-                  <h2 className="text-xl font-bold text-red-400">Error al guardar</h2>
-                  <p className="text-sm text-gray-400">{error}</p>
-                  <button
-                    onClick={handleSubmit}
-                    className="px-5 py-2.5 bg-white hover:bg-gray-100 text-black text-sm font-medium rounded-lg transition-colors"
-                  >
-                    Reintentar
-                  </button>
-                </div>
-              )}
-
-              {result && (
-                <div className="space-y-4">
-                  <div className="w-16 h-16 rounded-full bg-emerald-500/20 flex items-center justify-center mx-auto">
-                    <CheckCircle className="w-8 h-8 text-emerald-400" />
-                  </div>
-                  <h2 className="text-xl font-bold text-gray-900 dark:text-white">
-                    Tu propiedad está configurada
-                  </h2>
-                  <div className="flex justify-center gap-4 text-sm text-gray-400">
-                    <span>{result.units_created} unidades creadas</span>
-                    <span>·</span>
-                    <span>{result.contracts_created} contratos creados</span>
-                  </div>
-                  <div className="flex flex-col sm:flex-row justify-center gap-3 pt-2">
-                    <button
-                      onClick={() => router.push('/')}
-                      className="px-6 py-2.5 bg-white hover:bg-gray-100 text-black text-sm font-medium rounded-lg transition-colors"
-                    >
-                      Ir al Dashboard →
-                    </button>
-                    <button
-                      onClick={() => router.push('/units')}
-                      className="px-6 py-2.5 border border-gray-700 text-gray-300 hover:text-white text-sm font-medium rounded-lg transition-colors"
-                    >
-                      Ver mis unidades
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
+            <StepOwner
+              ownerMode={ownerMode}
+              setOwnerMode={setOwnerMode}
+              owner={owner}
+              setOwner={setOwner}
+              userEmail={userEmail}
+              pmName={pm.name}
+            />
+          )}
+          {step === 4 && result && (
+            <StepDone
+              pmName={pm.name}
+              buildingName={building.name}
+              unitsCreated={result.units_created}
+              ownerMode={ownerMode}
+              onContinue={() => router.replace('/')}
+            />
           )}
         </div>
+
+        {/* Nav */}
+        {step < 4 && (
+          <div className="mt-6 flex justify-between">
+            <button
+              type="button"
+              onClick={back}
+              disabled={step === 0 || submitting}
+              className="flex items-center gap-2 px-4 py-2 rounded-md text-[13px]"
+              style={{
+                color: 'var(--baw-muted)',
+                border: '1px solid var(--baw-border)',
+                opacity: step === 0 || submitting ? 0.4 : 1,
+                cursor: step === 0 || submitting ? 'not-allowed' : 'pointer',
+              }}
+            >
+              <ArrowLeft size={14} />
+              Atrás
+            </button>
+            {step < 3 ? (
+              <button
+                type="button"
+                onClick={next}
+                className="flex items-center gap-2 px-5 py-2 rounded-md text-[13px] font-medium"
+                style={{
+                  backgroundColor: 'var(--baw-primary)',
+                  color: '#fff',
+                }}
+              >
+                Continuar
+                <ArrowRight size={14} />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={submitting}
+                className="flex items-center gap-2 px-5 py-2 rounded-md text-[13px] font-medium"
+                style={{
+                  backgroundColor: 'var(--baw-primary)',
+                  color: '#fff',
+                  opacity: submitting ? 0.6 : 1,
+                  cursor: submitting ? 'wait' : 'pointer',
+                }}
+              >
+                {submitting ? 'Creando…' : 'Crear PM Company'}
+                <CheckCircle2 size={14} />
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Stepper
+// -----------------------------------------------------------------------------
+
+function Stepper({ currentStep }: { currentStep: number }) {
+  return (
+    <ol className="flex items-center justify-between gap-2 max-w-xl mx-auto">
+      {STEPS.map((s, idx) => {
+        const Icon = s.icon
+        const active = idx === currentStep
+        const done = idx < currentStep || currentStep === 4
+        return (
+          <li key={s.key} className="flex-1 flex flex-col items-center">
+            <div
+              className="w-9 h-9 rounded-full flex items-center justify-center"
+              style={{
+                backgroundColor: active
+                  ? 'var(--baw-primary)'
+                  : done
+                  ? 'rgba(74, 222, 128, 0.15)'
+                  : 'var(--baw-surface)',
+                border: '1px solid var(--baw-border)',
+                color: active ? '#fff' : done ? '#86efac' : 'var(--baw-muted)',
+              }}
+            >
+              {done ? <CheckCircle2 size={16} /> : <Icon size={16} />}
+            </div>
+            <span
+              className="text-[11px] mt-2 text-center"
+              style={{
+                color: active ? 'var(--baw-text)' : 'var(--baw-muted)',
+                fontWeight: active ? 600 : 400,
+              }}
+            >
+              {s.label}
+            </span>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso 1 — PM Company
+// -----------------------------------------------------------------------------
+
+function StepPMCompany({
+  pm,
+  setPM,
+}: {
+  pm: PMCompanyData
+  setPM: (p: PMCompanyData) => void
+}) {
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-[18px] font-semibold">¿Quién opera este sistema?</h2>
+        <p className="muted-text text-[13px] mt-1">
+          La PM Company es la organización administradora que va a usar BaW. Si
+          eres administrador independiente, puedes dejar el nombre por defecto.
+        </p>
+      </div>
+      <Field label="Nombre del PM Company" required>
+        <input
+          type="text"
+          value={pm.name}
+          onChange={(e) => setPM({ ...pm, name: e.target.value })}
+          placeholder="BaW Operations"
+          className="w-full"
+          style={inputStyle}
+        />
+      </Field>
+      <Field
+        label="Slug (identificador URL)"
+        hint="Se genera automáticamente del nombre. Lo verás en URLs internas."
+      >
+        <input
+          type="text"
+          value={pm.slug}
+          onChange={(e) => setPM({ ...pm, slug: slugify(e.target.value) })}
+          placeholder="baw-operations"
+          className="w-full font-mono"
+          style={inputStyle}
+        />
+      </Field>
+      <p
+        className="text-[12px] px-3 py-2 rounded-md"
+        style={{
+          backgroundColor: 'rgba(59, 130, 246, 0.08)',
+          color: 'var(--baw-muted)',
+        }}
+      >
+        Quedarás registrado como{' '}
+        <strong style={{ color: 'var(--baw-text)' }}>pm_owner</strong> de esta
+        organización. Podrás invitar a tu equipo más adelante con roles{' '}
+        <code>pm_admin</code>, <code>pm_operator</code> o <code>pm_viewer</code>.
+      </p>
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso 2 — Edificio
+// -----------------------------------------------------------------------------
+
+function StepBuilding({
+  building,
+  setBuilding,
+}: {
+  building: BuildingData
+  setBuilding: (b: BuildingData) => void
+}) {
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-[18px] font-semibold">Tu primer edificio</h2>
+        <p className="muted-text text-[13px] mt-1">
+          BaW administra activos físicos. Necesitamos al menos un edificio para
+          empezar. Podrás agregar más después.
+        </p>
+      </div>
+      <Field label="Nombre del edificio" required>
+        <input
+          type="text"
+          value={building.name}
+          onChange={(e) => setBuilding({ ...building, name: e.target.value })}
+          placeholder="Mateos 809"
+          className="w-full"
+          style={inputStyle}
+        />
+      </Field>
+      <Field label="Dirección">
+        <input
+          type="text"
+          value={building.address}
+          onChange={(e) =>
+            setBuilding({ ...building, address: e.target.value })
+          }
+          placeholder="Adolfo López Mateos 809"
+          className="w-full"
+          style={inputStyle}
+        />
+      </Field>
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Ciudad" required>
+          <input
+            type="text"
+            value={building.city}
+            onChange={(e) => setBuilding({ ...building, city: e.target.value })}
+            placeholder="CDMX"
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Estado">
+          <input
+            type="text"
+            value={building.state}
+            onChange={(e) =>
+              setBuilding({ ...building, state: e.target.value })
+            }
+            placeholder="Ciudad de México"
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="País">
+          <input
+            type="text"
+            value={building.country}
+            onChange={(e) =>
+              setBuilding({ ...building, country: e.target.value.toUpperCase() })
+            }
+            placeholder="MX"
+            maxLength={2}
+            className="w-full font-mono"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Código postal">
+          <input
+            type="text"
+            value={building.postal_code}
+            onChange={(e) =>
+              setBuilding({ ...building, postal_code: e.target.value })
+            }
+            placeholder="03100"
+            className="w-full font-mono"
+            style={inputStyle}
+          />
+        </Field>
+      </div>
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso 3 — Unidades
+// -----------------------------------------------------------------------------
+
+function StepUnits({
+  unitConfig,
+  setUnitConfig,
+  units,
+  setUnits,
+  generateUnits,
+  addUnit,
+  removeUnit,
+  updateUnit,
+}: {
+  unitConfig: {
+    count: number
+    prefix: string
+    startNumber: number
+    floors: number
+    type: UnitRow['type']
+  }
+  setUnitConfig: (c: typeof unitConfig) => void
+  units: UnitRow[]
+  setUnits: (u: UnitRow[]) => void
+  generateUnits: () => void
+  addUnit: () => void
+  removeUnit: (i: number) => void
+  updateUnit: (i: number, f: keyof UnitRow, v: string | number) => void
+}) {
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-[18px] font-semibold">Estructura de unidades</h2>
+        <p className="muted-text text-[13px] mt-1">
+          Genera las unidades en bulk con el patrón típico (101–404) o agrégalas
+          una por una. Podrás editarlas después.
+        </p>
+      </div>
+
+      {/* Generador bulk */}
+      <div
+        className="rounded-md p-4 grid grid-cols-2 md:grid-cols-5 gap-3"
+        style={{
+          backgroundColor: 'var(--baw-bg)',
+          border: '1px solid var(--baw-border)',
+        }}
+      >
+        <Field label="Cantidad">
+          <input
+            type="number"
+            min={1}
+            max={500}
+            value={unitConfig.count}
+            onChange={(e) =>
+              setUnitConfig({
+                ...unitConfig,
+                count: Math.max(1, Number(e.target.value) || 1),
+              })
+            }
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Prefijo">
+          <input
+            type="text"
+            value={unitConfig.prefix}
+            onChange={(e) =>
+              setUnitConfig({ ...unitConfig, prefix: e.target.value })
+            }
+            placeholder="(opcional)"
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Empezar en">
+          <input
+            type="number"
+            value={unitConfig.startNumber}
+            onChange={(e) =>
+              setUnitConfig({
+                ...unitConfig,
+                startNumber: Number(e.target.value) || 101,
+              })
+            }
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Pisos">
+          <input
+            type="number"
+            min={1}
+            max={50}
+            value={unitConfig.floors}
+            onChange={(e) =>
+              setUnitConfig({
+                ...unitConfig,
+                floors: Math.max(1, Number(e.target.value) || 1),
+              })
+            }
+            className="w-full"
+            style={inputStyle}
+          />
+        </Field>
+        <Field label="Tipo">
+          <select
+            value={unitConfig.type}
+            onChange={(e) =>
+              setUnitConfig({
+                ...unitConfig,
+                type: e.target.value as UnitRow['type'],
+              })
+            }
+            className="w-full"
+            style={inputStyle}
+          >
+            <option value="LTR">LTR</option>
+            <option value="MTR">MTR</option>
+            <option value="STR">STR</option>
+          </select>
+        </Field>
+      </div>
+      <button
+        type="button"
+        onClick={generateUnits}
+        className="px-4 py-2 rounded-md text-[13px]"
+        style={{
+          backgroundColor: 'var(--baw-bg)',
+          border: '1px solid var(--baw-border)',
+          color: 'var(--baw-text)',
+        }}
+      >
+        Generar {unitConfig.count} unidades
+      </button>
+
+      {/* Lista editable */}
+      {units.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-[13px] font-medium">
+              {units.length} unidades
+            </span>
+            <button
+              type="button"
+              onClick={addUnit}
+              className="flex items-center gap-1 text-[12px]"
+              style={{ color: 'var(--baw-primary)' }}
+            >
+              <Plus size={12} /> Agregar
+            </button>
+          </div>
+          <div
+            className="rounded-md overflow-hidden"
+            style={{ border: '1px solid var(--baw-border)' }}
+          >
+            <table className="w-full text-[12px]">
+              <thead
+                style={{
+                  backgroundColor: 'var(--baw-bg)',
+                  color: 'var(--baw-muted)',
+                }}
+              >
+                <tr>
+                  <th className="text-left px-3 py-2">Número</th>
+                  <th className="text-left px-3 py-2">Tipo</th>
+                  <th className="text-left px-3 py-2">Piso</th>
+                  <th className="px-3 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {units.map((u, idx) => (
+                  <tr
+                    key={idx}
+                    style={{ borderTop: '1px solid var(--baw-border)' }}
+                  >
+                    <td className="px-3 py-1.5">
+                      <input
+                        type="text"
+                        value={u.number}
+                        onChange={(e) =>
+                          updateUnit(idx, 'number', e.target.value)
+                        }
+                        className="w-full font-mono"
+                        style={{ ...inputStyle, padding: '4px 8px' }}
+                      />
+                    </td>
+                    <td className="px-3 py-1.5">
+                      <select
+                        value={u.type}
+                        onChange={(e) =>
+                          updateUnit(idx, 'type', e.target.value)
+                        }
+                        style={{ ...inputStyle, padding: '4px 8px' }}
+                      >
+                        <option value="LTR">LTR</option>
+                        <option value="MTR">MTR</option>
+                        <option value="STR">STR</option>
+                      </select>
+                    </td>
+                    <td className="px-3 py-1.5">
+                      <input
+                        type="number"
+                        value={u.floor}
+                        onChange={(e) =>
+                          updateUnit(idx, 'floor', Number(e.target.value) || 1)
+                        }
+                        className="w-20"
+                        style={{ ...inputStyle, padding: '4px 8px' }}
+                      />
+                    </td>
+                    <td className="px-3 py-1.5 text-right">
+                      <button
+                        type="button"
+                        onClick={() => removeUnit(idx)}
+                        style={{ color: '#f87171' }}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso 4 — Property Owner
+// -----------------------------------------------------------------------------
+
+function StepOwner({
+  ownerMode,
+  setOwnerMode,
+  owner,
+  setOwner,
+  userEmail,
+  pmName,
+}: {
+  ownerMode: OwnerMode
+  setOwnerMode: (m: OwnerMode) => void
+  owner: OwnerData
+  setOwner: (o: OwnerData) => void
+  userEmail: string | null
+  pmName: string
+}) {
+  const options: Array<{ key: OwnerMode; title: string; desc: string }> = [
+    {
+      key: 'self',
+      title: 'Yo soy el dueño',
+      desc: `${pmName} administra su propio edificio. Quedarás registrado como Property Owner con 100% del building.`,
+    },
+    {
+      key: 'client',
+      title: 'Es de un cliente',
+      desc: 'Administras este edificio para un tercero. Captura los datos del propietario y se le creará portal de acceso.',
+    },
+    {
+      key: 'skip',
+      title: 'Configurarlo más tarde',
+      desc: 'El edificio queda sin Property Owner. Podrás asignarlo después en la pestaña de Configuración.',
+    },
+  ]
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-[18px] font-semibold">¿De quién es este edificio?</h2>
+        <p className="muted-text text-[13px] mt-1">
+          La capa de Property Owners distingue entre quien opera (PM Company) y
+          quien posee el inmueble. Esto define cuentas claras y portales
+          separados.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3">
+        {options.map((opt) => {
+          const active = ownerMode === opt.key
+          return (
+            <button
+              type="button"
+              key={opt.key}
+              onClick={() => setOwnerMode(opt.key)}
+              className="text-left rounded-md p-4 transition"
+              style={{
+                backgroundColor: active
+                  ? 'rgba(59, 130, 246, 0.08)'
+                  : 'var(--baw-bg)',
+                border: active
+                  ? '1px solid var(--baw-primary)'
+                  : '1px solid var(--baw-border)',
+              }}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div
+                    className="text-[14px] font-semibold"
+                    style={{ color: 'var(--baw-text)' }}
+                  >
+                    {opt.title}
+                  </div>
+                  <div className="muted-text text-[12px] mt-1">{opt.desc}</div>
+                </div>
+                <div
+                  className="w-4 h-4 rounded-full flex-shrink-0 mt-1"
+                  style={{
+                    backgroundColor: active ? 'var(--baw-primary)' : 'transparent',
+                    border: active
+                      ? '2px solid var(--baw-primary)'
+                      : '2px solid var(--baw-border)',
+                  }}
+                />
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      {ownerMode === 'self' && (
+        <div
+          className="text-[12px] px-3 py-2 rounded-md"
+          style={{
+            backgroundColor: 'rgba(74, 222, 128, 0.08)',
+            color: 'var(--baw-muted)',
+          }}
+        >
+          Se creará un Property Owner con tu email{' '}
+          <code style={{ color: 'var(--baw-text)' }}>{userEmail}</code> y un
+          ownership stake del 100% sobre el edificio.
+        </div>
+      )}
+
+      {ownerMode === 'client' && (
+        <div className="space-y-4 pt-2">
+          <Field label="Nombre completo del propietario" required>
+            <input
+              type="text"
+              value={owner.full_name}
+              onChange={(e) =>
+                setOwner({ ...owner, full_name: e.target.value })
+              }
+              placeholder="Juan Pérez García"
+              className="w-full"
+              style={inputStyle}
+            />
+          </Field>
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Email">
+              <input
+                type="email"
+                value={owner.email}
+                onChange={(e) => setOwner({ ...owner, email: e.target.value })}
+                placeholder="cliente@ejemplo.com"
+                className="w-full"
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="Teléfono">
+              <input
+                type="tel"
+                value={owner.phone}
+                onChange={(e) => setOwner({ ...owner, phone: e.target.value })}
+                placeholder="+52 55..."
+                className="w-full"
+                style={inputStyle}
+              />
+            </Field>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="RFC (opcional)">
+              <input
+                type="text"
+                value={owner.rfc}
+                onChange={(e) =>
+                  setOwner({ ...owner, rfc: e.target.value.toUpperCase() })
+                }
+                placeholder="XAXX010101000"
+                maxLength={13}
+                className="w-full font-mono"
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="% del building" hint="Entre 1 y 100">
+              <input
+                type="number"
+                min={1}
+                max={100}
+                value={owner.percentage}
+                onChange={(e) =>
+                  setOwner({ ...owner, percentage: Number(e.target.value) || 0 })
+                }
+                className="w-full tabular-nums"
+                style={inputStyle}
+              />
+            </Field>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Paso final — Done
+// -----------------------------------------------------------------------------
+
+function StepDone({
+  pmName,
+  buildingName,
+  unitsCreated,
+  ownerMode,
+  onContinue,
+}: {
+  pmName: string
+  buildingName: string
+  unitsCreated: number
+  ownerMode: OwnerMode
+  onContinue: () => void
+}) {
+  return (
+    <div className="text-center py-6">
+      <div
+        className="w-14 h-14 rounded-full mx-auto flex items-center justify-center mb-4"
+        style={{
+          backgroundColor: 'rgba(74, 222, 128, 0.15)',
+          color: '#86efac',
+        }}
+      >
+        <CheckCircle2 size={28} />
+      </div>
+      <h2 className="text-[20px] font-semibold">¡Listo!</h2>
+      <p className="muted-text text-[13px] mt-2 max-w-md mx-auto">
+        BaW Operations ha registrado a <strong>{pmName}</strong> con el edificio{' '}
+        <strong>{buildingName}</strong> y <strong>{unitsCreated}</strong>{' '}
+        unidades. Property Owner:{' '}
+        {ownerMode === 'self'
+          ? 'tú mismo, 100%'
+          : ownerMode === 'client'
+          ? 'cliente capturado'
+          : 'pendiente de configurar'}
+        .
+      </p>
+      <button
+        type="button"
+        onClick={onContinue}
+        className="mt-6 px-5 py-2 rounded-md text-[13px] font-medium"
+        style={{ backgroundColor: 'var(--baw-primary)', color: '#fff' }}
+      >
+        Ir a Mission Control
+      </button>
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Helpers UI
+// -----------------------------------------------------------------------------
+
+const inputStyle: React.CSSProperties = {
+  backgroundColor: 'var(--baw-bg)',
+  border: '1px solid var(--baw-border)',
+  color: 'var(--baw-text)',
+  borderRadius: '6px',
+  padding: '8px 12px',
+  fontSize: '13px',
+  outline: 'none',
+}
+
+function Field({
+  label,
+  required,
+  hint,
+  children,
+}: {
+  label: string
+  required?: boolean
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="block">
+      <span className="text-[12px] font-medium block mb-1.5">
+        {label}
+        {required && <span style={{ color: '#f87171' }}> *</span>}
+      </span>
+      {children}
+      {hint && (
+        <span className="muted-text text-[11px] mt-1 block">{hint}</span>
+      )}
+    </label>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import { Sparkles } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { formatCurrency, daysUntil } from '@/lib/utils'
 import {
@@ -59,6 +60,7 @@ export default function MissionControl() {
   const [collections, setCollections] = useState<CollectionRow[]>([])
   const [maintenance, setMaintenance] = useState<MaintRow[]>([])
   const [loading, setLoading] = useState(true)
+  const [needsOnboarding, setNeedsOnboarding] = useState(false)
 
   useEffect(() => {
     async function fetchDashboard() {
@@ -92,6 +94,11 @@ export default function MissionControl() {
         const contracts = contractsRes.data || []
         const payments = paymentsRes.data || []
         const tickets = maintRes.data || []
+
+        // Detectar empty state global: sin unidades ni contratos
+        if (units.length === 0 && contracts.length === 0) {
+          setNeedsOnboarding(true)
+        }
 
         const totalUnits = units.length
         const occupiedUnits = units.filter(
@@ -172,6 +179,43 @@ export default function MissionControl() {
     metrics.totalUnits > 0
       ? ((metrics.occupiedUnits / metrics.totalUnits) * 100).toFixed(1)
       : '0.0'
+
+  // Empty state honesto: si no hay datos, ofrecer el onboarding como CTA principal
+  if (!loading && needsOnboarding) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <div
+          className="max-w-lg w-full rounded-lg p-8 text-center"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          <div
+            className="w-12 h-12 rounded-full mx-auto flex items-center justify-center mb-4"
+            style={{
+              backgroundColor: 'rgba(59, 130, 246, 0.12)',
+              color: 'var(--baw-primary)',
+            }}
+          >
+            <Sparkles size={22} />
+          </div>
+          <h1 className="text-[22px] font-semibold">BaW está listo para arrancar</h1>
+          <p className="muted-text text-[13px] mt-2 max-w-md mx-auto">
+            Aún no hay un PM Company configurado. Tarda dos minutos: registra tu
+            organización, tu primer edificio, las unidades y el Property Owner.
+          </p>
+          <Link
+            href="/onboarding"
+            className="inline-block mt-6 px-5 py-2 rounded-md text-[13px] font-medium"
+            style={{ backgroundColor: 'var(--baw-primary)', color: '#fff' }}
+          >
+            Empezar onboarding
+          </Link>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
   type StatusKind,
 } from '@/components/ui/status'
 import ContractAlertsBanner from '@/components/ContractAlertsBanner'
+import { useActiveContext } from '@/lib/useActiveContext'
 
 interface CollectionRow {
   id: string
@@ -222,9 +223,7 @@ export default function MissionControl() {
       <div className="flex items-end justify-between">
         <div>
           <h1 className="text-[22px] font-semibold">Mission Control</h1>
-          <p className="text-[13px] muted-text mt-0.5">
-            Frontier Bay · Operación en vivo
-          </p>
+          <MissionControlSubtitle />
         </div>
       </div>
 
@@ -425,5 +424,27 @@ export default function MissionControl() {
         </section>
       </div>
     </div>
+  )
+}
+
+// Sprint 3 / S7: Subtítulo dinámico de Mission Control
+// Antes hardcoded "Frontier Bay · Operación en vivo"; ahora lee la org y
+// building activos del contexto compartido y cae en un placeholder neutro
+// si todavía no hay onboarding completo.
+function MissionControlSubtitle() {
+  const { orgs, buildings, activeOrgId, activeBuildingId, loading } =
+    useActiveContext()
+  if (loading) return <p className="text-[13px] muted-text mt-0.5">···</p>
+  const activeOrg = orgs.find((o) => o.id === activeOrgId)
+  const activeBuilding = buildings.find((b) => b.id === activeBuildingId)
+  const orgName = activeOrg?.name?.trim()
+  const buildingName = activeBuilding?.name?.trim()
+  const label = buildingName
+    ? `${buildingName}${orgName ? ` · ${orgName}` : ''}`
+    : orgName || 'Workspace sin configurar'
+  return (
+    <p className="text-[13px] muted-text mt-0.5">
+      {label} · Operación en vivo
+    </p>
   )
 }

--- a/src/components/AgentsList.tsx
+++ b/src/components/AgentsList.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+// BaW OS — AgentsList (Sprint 3 / S4)
+// Sección "Agentes" en el sidebar con los 11 agentes del workforce v0.2:
+// 1 coordinador (BaW) + 10 especialistas. Status placeholder (idle/running/paused).
+// Sin links activos todavía — la página individual de cada agente vendrá en sprints
+// posteriores. Hoy solo muestra presencia visual y prepara la jerarquía mental.
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, Bot, Circle } from 'lucide-react'
+
+type AgentStatus = 'idle' | 'running' | 'paused' | 'planned'
+
+interface Agent {
+  key: string
+  name: string
+  role: 'coordinator' | 'core' | 'experience' | 'intelligence'
+  status: AgentStatus
+}
+
+const AGENTS: Agent[] = [
+  // Coordinador (no se prefija con "Agente")
+  { key: 'baw', name: 'BaW', role: 'coordinator', status: 'idle' },
+  // Operaciones Core
+  { key: 'cobranza', name: 'Agente Cobranza', role: 'core', status: 'planned' },
+  { key: 'facturacion', name: 'Agente Facturación', role: 'core', status: 'planned' },
+  { key: 'mantenimiento', name: 'Agente Mantenimiento', role: 'core', status: 'planned' },
+  // Experiencia
+  { key: 'atencion', name: 'Agente Atención', role: 'experience', status: 'planned' },
+  { key: 'reservas', name: 'Agente Reservas', role: 'experience', status: 'planned' },
+  { key: 'tarifas', name: 'Agente Tarifas', role: 'experience', status: 'planned' },
+  { key: 'renovaciones', name: 'Agente Renovaciones', role: 'experience', status: 'planned' },
+  // Inteligencia
+  { key: 'reportes', name: 'Agente Reportes', role: 'intelligence', status: 'planned' },
+  { key: 'auditoria', name: 'Agente Auditoría', role: 'intelligence', status: 'planned' },
+  { key: 'fiscal', name: 'Agente Fiscal', role: 'intelligence', status: 'planned' },
+]
+
+const ROLE_LABEL: Record<Agent['role'], string> = {
+  coordinator: 'Coordinador',
+  core: 'Operaciones Core',
+  experience: 'Experiencia',
+  intelligence: 'Inteligencia',
+}
+
+const STATUS_DOT: Record<AgentStatus, { color: string; label: string }> = {
+  idle: { color: '#86efac', label: 'Activo' },
+  running: { color: '#60a5fa', label: 'Corriendo' },
+  paused: { color: '#fbbf24', label: 'Pausado' },
+  planned: { color: '#52525b', label: 'Planeado' },
+}
+
+interface Props {
+  expanded: boolean
+}
+
+export default function AgentsList({ expanded }: Props) {
+  const [open, setOpen] = useState(false)
+
+  if (!expanded) {
+    // Modo colapsado: un solo ícono que indica que hay sección de agentes
+    return (
+      <button
+        type="button"
+        title="Agentes"
+        className="flex items-center justify-center h-9 w-[40px] mx-2 rounded-md hover:bg-white/5"
+        style={{ color: 'var(--baw-muted)' }}
+      >
+        <Bot className="w-[18px] h-[18px]" />
+      </button>
+    )
+  }
+
+  // Agrupar por rol
+  const groups: Array<{ label: string; agents: Agent[] }> = [
+    {
+      label: ROLE_LABEL.coordinator,
+      agents: AGENTS.filter((a) => a.role === 'coordinator'),
+    },
+    {
+      label: ROLE_LABEL.core,
+      agents: AGENTS.filter((a) => a.role === 'core'),
+    },
+    {
+      label: ROLE_LABEL.experience,
+      agents: AGENTS.filter((a) => a.role === 'experience'),
+    },
+    {
+      label: ROLE_LABEL.intelligence,
+      agents: AGENTS.filter((a) => a.role === 'intelligence'),
+    },
+  ]
+
+  return (
+    <div className="mx-2 mb-2">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between h-7 px-3 rounded-md text-[10px] uppercase tracking-wider hover:bg-white/5"
+        style={{ color: 'var(--baw-muted)' }}
+      >
+        <span className="flex items-center gap-1.5">
+          <Bot size={11} />
+          Agentes ({AGENTS.length})
+        </span>
+        {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+      </button>
+
+      {open && (
+        <ul className="mt-1 space-y-0.5">
+          {groups.map((g) => (
+            <li key={g.label} className="mt-1.5">
+              <div
+                className="px-3 pt-1 pb-0.5 text-[9px] uppercase tracking-wider"
+                style={{ color: 'var(--baw-muted)', opacity: 0.7 }}
+              >
+                {g.label}
+              </div>
+              <ul>
+                {g.agents.map((a) => {
+                  const dot = STATUS_DOT[a.status]
+                  return (
+                    <li key={a.key}>
+                      <div
+                        className="flex items-center justify-between gap-2 px-3 py-1 rounded-md hover:bg-white/5 cursor-default"
+                        title={`${a.name} · ${dot.label}`}
+                      >
+                        <span
+                          className="text-[11.5px] truncate"
+                          style={{
+                            color:
+                              a.status === 'planned'
+                                ? 'var(--baw-muted)'
+                                : 'var(--baw-text)',
+                          }}
+                        >
+                          {a.name}
+                        </span>
+                        <Circle
+                          size={6}
+                          fill={dot.color}
+                          stroke={dot.color}
+                          aria-label={dot.label}
+                        />
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -69,7 +69,7 @@ function GlobalHeader({ pathname }: { pathname: string }) {
 
   return (
     <header
-      className="sticky top-0 z-30 pl-16 pr-4 md:pl-6 md:pr-6"
+      className="sticky top-0 z-30 pl-16 pr-4 md:pl-4 md:pr-6"
       style={{
         backgroundColor: 'var(--baw-bg)',
         borderBottom: '1px solid var(--baw-border)',
@@ -170,16 +170,24 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       <ToastProvider>
         <AuthGuard>
           <Sidebar />
+          {/*
+            Sprint 3 / S7: el `paddingLeft` del main lee el CSS var
+            `--sidebar-effective-width` que el Sidebar mantiene actualizado.
+            Cuando está pinned el contenido se empuja a 240px y queda visible.
+            Cuando solo es hover, el sidebar se expande sobre el contenido
+            sin reflowear (overlay) para no causar layout shift cada vez que
+            el cursor lo toca.
+          */}
           <main
             className="min-h-screen transition-[padding] duration-200"
-            style={{ paddingLeft: 0 }}
+            style={{
+              paddingLeft: 'var(--sidebar-effective-width, 0px)',
+            }}
           >
-            <div className="md:pl-14">
-              <GlobalHeader pathname={pathname} />
-              <div className="p-4 md:p-6 space-y-4">
-                {pathname !== '/' && <ContractAlertsBanner />}
-                {children}
-              </div>
+            <GlobalHeader pathname={pathname} />
+            <div className="p-4 md:p-6 space-y-4">
+              {pathname !== '/' && <ContractAlertsBanner />}
+              {children}
             </div>
           </main>
         </AuthGuard>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { Search, Bell } from 'lucide-react'
 import Sidebar from '@/components/Sidebar'
 import AuthGuard from '@/components/AuthGuard'
+import ProfileMenu from '@/components/ProfileMenu'
 import ThemeProvider from '@/components/ThemeProvider'
 import { ToastProvider } from '@/components/Toast'
 import ContractAlertsBanner from '@/components/ContractAlertsBanner'
@@ -148,18 +149,8 @@ function GlobalHeader({ pathname }: { pathname: string }) {
             )}
           </Link>
 
-          {/* User avatar */}
-          <div
-            className="inline-flex items-center justify-center w-8 h-8 rounded-full text-[12px] font-semibold"
-            style={{
-              backgroundColor: 'rgba(59, 130, 246, 0.15)',
-              color: '#60A5FA',
-              border: '1px solid rgba(59, 130, 246, 0.3)',
-            }}
-            title="Account"
-          >
-            MR
-          </div>
+          {/* User avatar / profile menu (sprint S4) */}
+          <ProfileMenu />
         </div>
       </div>
     </header>

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+// BaW OS — ProfileMenu (Sprint 3 / S4)
+// Reemplaza el <div>MR</div> hardcoded en AppShell.
+// Lee user_profiles para nombre/avatar; muestra menú con perfil, tema y logout.
+
+import { useEffect, useState, useRef } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { User, LogOut, Settings, Sun, Moon, Monitor } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+
+type ThemePref = 'light' | 'dark' | 'system'
+
+interface UserBasics {
+  id: string
+  email: string | null
+  full_name: string | null
+  avatar_url: string | null
+}
+
+function getInitials(nameOrEmail: string | null): string {
+  if (!nameOrEmail) return '·'
+  const cleaned = nameOrEmail.trim()
+  if (!cleaned) return '·'
+  // Si es email, usar primera letra del local-part
+  if (cleaned.includes('@')) {
+    return cleaned[0].toUpperCase()
+  }
+  const parts = cleaned.split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return '·'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+export default function ProfileMenu() {
+  const router = useRouter()
+  const [user, setUser] = useState<UserBasics | null>(null)
+  const [open, setOpen] = useState(false)
+  const [theme, setTheme] = useState<ThemePref>('dark')
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    async function load() {
+      const { data: sd } = await supabase.auth.getSession()
+      const session = sd.session
+      if (!session) {
+        setUser(null)
+        return
+      }
+      // Intentar leer user_profiles; si no existe, fallback al auth user
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('full_name, avatar_url')
+        .eq('user_id', session.user.id)
+        .maybeSingle()
+      setUser({
+        id: session.user.id,
+        email: session.user.email ?? null,
+        full_name: profile?.full_name ?? null,
+        avatar_url: profile?.avatar_url ?? null,
+      })
+    }
+    load()
+
+    // Tema inicial desde localStorage
+    try {
+      const t = localStorage.getItem('baw:theme') as ThemePref | null
+      if (t === 'light' || t === 'dark' || t === 'system') {
+        setTheme(t)
+        applyTheme(t)
+      }
+    } catch {
+      // ignore
+    }
+
+    function onClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [])
+
+  function applyTheme(t: ThemePref) {
+    const root = document.documentElement
+    if (t === 'system') {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      root.classList.toggle('dark', prefersDark)
+    } else {
+      root.classList.toggle('dark', t === 'dark')
+    }
+  }
+
+  function changeTheme(t: ThemePref) {
+    setTheme(t)
+    try {
+      localStorage.setItem('baw:theme', t)
+    } catch {
+      // ignore
+    }
+    applyTheme(t)
+  }
+
+  async function handleLogout() {
+    await supabase.auth.signOut()
+    router.replace('/login')
+  }
+
+  const displayName = user?.full_name || user?.email || 'Cuenta'
+  const initials = getInitials(user?.full_name || user?.email || null)
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center justify-center w-8 h-8 rounded-full text-[12px] font-semibold overflow-hidden"
+        style={{
+          backgroundColor: 'rgba(59, 130, 246, 0.15)',
+          color: '#60A5FA',
+          border: '1px solid rgba(59, 130, 246, 0.3)',
+        }}
+        title={displayName}
+        aria-label="Abrir menú de cuenta"
+      >
+        {user?.avatar_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={user.avatar_url}
+            alt={displayName}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          initials
+        )}
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-2 w-60 rounded-md shadow-lg z-50 overflow-hidden"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          {/* Header */}
+          <div
+            className="px-3 py-2.5"
+            style={{ borderBottom: '1px solid var(--baw-border)' }}
+          >
+            <div
+              className="text-[12px] font-medium truncate"
+              style={{ color: 'var(--baw-text)' }}
+            >
+              {displayName}
+            </div>
+            {user?.email && user.email !== displayName && (
+              <div
+                className="text-[11px] truncate"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                {user.email}
+              </div>
+            )}
+          </div>
+
+          {/* Items */}
+          <ul>
+            <li>
+              <Link
+                href="/settings"
+                onClick={() => setOpen(false)}
+                className="flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
+                style={{ color: 'var(--baw-text)' }}
+              >
+                <User size={14} />
+                Mi perfil
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/settings"
+                onClick={() => setOpen(false)}
+                className="flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
+                style={{ color: 'var(--baw-text)' }}
+              >
+                <Settings size={14} />
+                Configuración
+              </Link>
+            </li>
+          </ul>
+
+          <div
+            className="border-t"
+            style={{ borderColor: 'var(--baw-border)' }}
+          />
+
+          {/* Theme picker */}
+          <div className="px-3 py-2">
+            <div
+              className="text-[10px] uppercase tracking-wider mb-1.5"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              Tema
+            </div>
+            <div className="flex gap-1">
+              <ThemeButton
+                active={theme === 'light'}
+                onClick={() => changeTheme('light')}
+                icon={<Sun size={13} />}
+                label="Claro"
+              />
+              <ThemeButton
+                active={theme === 'dark'}
+                onClick={() => changeTheme('dark')}
+                icon={<Moon size={13} />}
+                label="Oscuro"
+              />
+              <ThemeButton
+                active={theme === 'system'}
+                onClick={() => changeTheme('system')}
+                icon={<Monitor size={13} />}
+                label="Auto"
+              />
+            </div>
+          </div>
+
+          <div
+            className="border-t"
+            style={{ borderColor: 'var(--baw-border)' }}
+          />
+
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="w-full flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
+            style={{ color: 'var(--baw-muted)' }}
+          >
+            <LogOut size={14} />
+            Cerrar sesión
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ThemeButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex-1 flex flex-col items-center gap-0.5 py-1.5 rounded-md text-[10px]"
+      style={{
+        backgroundColor: active ? 'rgba(59,130,246,0.12)' : 'transparent',
+        border: active
+          ? '1px solid var(--baw-primary)'
+          : '1px solid var(--baw-border)',
+        color: active ? 'var(--baw-primary)' : 'var(--baw-muted)',
+      }}
+    >
+      {icon}
+      {label}
+    </button>
+  )
+}

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -85,12 +85,20 @@ export default function ProfileMenu() {
 
   function applyTheme(t: ThemePref) {
     const root = document.documentElement
+    let effective: 'dark' | 'light'
     if (t === 'system') {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-      root.classList.toggle('dark', prefersDark)
+      effective = window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light'
     } else {
-      root.classList.toggle('dark', t === 'dark')
+      effective = t
     }
+    // Sprint 3 / S7: el sistema canónico de tokens (S5/globals.css) lee
+    // tanto `html.dark` como `html.light` para alternar entre escalas OKLCH.
+    // Aseguramos las dos clases de forma exclusiva, no solo togglear `dark`.
+    root.classList.toggle('dark', effective === 'dark')
+    root.classList.toggle('light', effective === 'light')
+    root.dataset.theme = effective
   }
 
   function changeTheme(t: ThemePref) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -126,6 +126,20 @@ export default function Sidebar() {
 
   const width = expanded ? EXPANDED_WIDTH : COLLAPSED_WIDTH
 
+  // Sprint 3 / S7: el contenido principal debe "empujarse" cuando el sidebar
+  // está PINNED (sticky), pero seguir siendo overlay cuando el usuario solo
+  // hace hover.  Exponemos el ancho efectivo para layout via CSS variable
+  // global, que AppShell lee con `paddingLeft: var(--sidebar-effective-width)`.
+  useEffect(() => {
+    const root = document.documentElement
+    const layoutWidth = pinned ? EXPANDED_WIDTH : COLLAPSED_WIDTH
+    root.style.setProperty('--sidebar-effective-width', `${layoutWidth}px`)
+    root.style.setProperty('--sidebar-rendered-width', `${width}px`)
+    return () => {
+      // Cleanup al desmontar
+    }
+  }, [pinned, width])
+
   return (
     <>
       {/* Mobile hamburger */}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,7 +7,6 @@ import {
   Building2,
   FileText,
   LayoutDashboard,
-  LogOut,
   Menu,
   X,
   Wrench,
@@ -29,6 +28,8 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { supabase } from '@/lib/supabase'
+import WorkspaceSwitcher from '@/components/WorkspaceSwitcher'
+import AgentsList from '@/components/AgentsList'
 
 type NavItem = {
   name: string
@@ -116,12 +117,6 @@ export default function Sidebar() {
     try {
       window.localStorage.setItem('baw-sidebar-pinned', next ? '1' : '0')
     } catch {}
-  }
-
-  async function handleLogout() {
-    await supabase.auth.signOut()
-    router.push('/login')
-    router.refresh()
   }
 
   function badgeFor(item: NavItem) {
@@ -297,46 +292,20 @@ export default function Sidebar() {
           })}
         </nav>
 
-        {/* Footer: building selector + logout */}
+        {/* Agentes (sprint S4) */}
+        <div
+          className="shrink-0 pt-2"
+          style={{ borderTop: '1px solid #2A2A32' }}
+        >
+          <AgentsList expanded={expanded} />
+        </div>
+
+        {/* Footer: workspace switcher real (sprint S4). Logout movido a ProfileMenu. */}
         <div
           className="shrink-0 py-2"
           style={{ borderTop: '1px solid #2A2A32' }}
         >
-          <button
-            type="button"
-            className="flex items-center h-9 mx-2 rounded-md transition-colors hover:bg-white/5 w-[calc(100%-16px)]"
-            style={{ color: 'var(--baw-text)' }}
-            title={!expanded ? 'Frontier Bay' : undefined}
-          >
-            <span className="flex items-center justify-center w-[40px] shrink-0">
-              <Building2 className="w-[18px] h-[18px]" style={{ color: 'var(--baw-muted)' }} />
-            </span>
-            {expanded && (
-              <span className="flex items-center justify-between flex-1 min-w-0 pr-3">
-                <span className="flex flex-col items-start min-w-0">
-                  <span className="text-[12px] font-medium truncate">Frontier Bay</span>
-                  <span className="text-[10px]" style={{ color: 'var(--baw-muted)' }}>
-                    Mateos 809, CDMX
-                  </span>
-                </span>
-                <ChevronRight className="w-3.5 h-3.5" style={{ color: 'var(--baw-muted)' }} />
-              </span>
-            )}
-          </button>
-
-          <button
-            onClick={handleLogout}
-            className="flex items-center h-9 mx-2 rounded-md transition-colors hover:bg-white/5 w-[calc(100%-16px)]"
-            style={{ color: 'var(--baw-muted)' }}
-            title={!expanded ? 'Cerrar sesión' : undefined}
-          >
-            <span className="flex items-center justify-center w-[40px] shrink-0">
-              <LogOut className="w-[18px] h-[18px]" />
-            </span>
-            {expanded && (
-              <span className="text-[13px] font-medium">Cerrar sesión</span>
-            )}
-          </button>
+          <WorkspaceSwitcher expanded={expanded} />
         </div>
       </aside>
     </>

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+// BaW OS — WorkspaceSwitcher (Sprint 3 / S4)
+// Reemplaza el chip "Frontier Bay" hardcoded en Sidebar.
+// Lee organizations + buildings reales del usuario via useActiveContext.
+
+import { useState, useRef, useEffect } from 'react'
+import { Building2, ChevronRight, Check, Plus } from 'lucide-react'
+import Link from 'next/link'
+import { useActiveContext } from '@/lib/useActiveContext'
+
+interface Props {
+  expanded: boolean
+}
+
+export default function WorkspaceSwitcher({ expanded }: Props) {
+  const {
+    loading,
+    orgs,
+    buildings,
+    activeOrgId,
+    activeBuildingId,
+    setActiveOrgId,
+    setActiveBuildingId,
+  } = useActiveContext()
+
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [])
+
+  const activeOrg = orgs.find((o) => o.id === activeOrgId)
+  const activeBuilding = buildings.find((b) => b.id === activeBuildingId)
+  const buildingsForActiveOrg = buildings.filter(
+    (b) => b.org_id === activeOrgId,
+  )
+
+  // Estados sin datos
+  const isEmpty = !loading && orgs.length === 0
+  const titleText = isEmpty
+    ? 'Sin PM Company'
+    : activeOrg?.name ?? '—'
+  const subText = isEmpty
+    ? 'Empezar onboarding'
+    : activeBuilding
+    ? `${activeBuilding.name}${activeBuilding.city ? `, ${activeBuilding.city}` : ''}`
+    : 'Sin edificio'
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => !isEmpty && setOpen((o) => !o)}
+        className="flex items-center h-9 mx-2 rounded-md transition-colors hover:bg-white/5 w-[calc(100%-16px)]"
+        style={{ color: 'var(--baw-text)' }}
+        title={!expanded ? titleText : undefined}
+      >
+        <span className="flex items-center justify-center w-[40px] shrink-0">
+          <Building2
+            className="w-[18px] h-[18px]"
+            style={{ color: 'var(--baw-muted)' }}
+          />
+        </span>
+        {expanded && (
+          <span className="flex items-center justify-between flex-1 min-w-0 pr-3">
+            <span className="flex flex-col items-start min-w-0">
+              <span className="text-[12px] font-medium truncate">
+                {titleText}
+              </span>
+              <span
+                className="text-[10px] truncate"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                {subText}
+              </span>
+            </span>
+            {!isEmpty && (
+              <ChevronRight
+                className="w-3.5 h-3.5"
+                style={{ color: 'var(--baw-muted)' }}
+              />
+            )}
+          </span>
+        )}
+      </button>
+
+      {open && expanded && !isEmpty && (
+        <div
+          className="absolute left-2 right-2 bottom-full mb-2 rounded-md shadow-lg z-50 overflow-hidden"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          {orgs.length > 1 && (
+            <>
+              <div
+                className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                PM Company
+              </div>
+              <ul>
+                {orgs.map((org) => (
+                  <li key={org.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setActiveOrgId(org.id)
+                      }}
+                      className="w-full flex items-center justify-between gap-2 px-3 py-1.5 text-[12px] hover:bg-white/5"
+                      style={{ color: 'var(--baw-text)' }}
+                    >
+                      <span className="truncate">{org.name}</span>
+                      {org.id === activeOrgId && (
+                        <Check
+                          size={12}
+                          style={{ color: 'var(--baw-primary)' }}
+                        />
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <div
+                className="border-t my-1"
+                style={{ borderColor: 'var(--baw-border)' }}
+              />
+            </>
+          )}
+
+          <div
+            className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider"
+            style={{ color: 'var(--baw-muted)' }}
+          >
+            Edificio
+          </div>
+          {buildingsForActiveOrg.length === 0 ? (
+            <div
+              className="px-3 py-2 text-[12px]"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              Esta organización aún no tiene edificios.
+            </div>
+          ) : (
+            <ul>
+              {buildingsForActiveOrg.map((b) => (
+                <li key={b.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setActiveBuildingId(b.id)
+                      setOpen(false)
+                    }}
+                    className="w-full flex items-center justify-between gap-2 px-3 py-1.5 text-[12px] hover:bg-white/5"
+                    style={{ color: 'var(--baw-text)' }}
+                  >
+                    <span className="flex flex-col items-start min-w-0">
+                      <span className="truncate">{b.name}</span>
+                      {b.city && (
+                        <span
+                          className="text-[10px] truncate"
+                          style={{ color: 'var(--baw-muted)' }}
+                        >
+                          {b.city}
+                        </span>
+                      )}
+                    </span>
+                    {b.id === activeBuildingId && (
+                      <Check
+                        size={12}
+                        style={{ color: 'var(--baw-primary)' }}
+                      />
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div
+            className="border-t mt-1"
+            style={{ borderColor: 'var(--baw-border)' }}
+          />
+          <Link
+            href="/onboarding"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
+            style={{ color: 'var(--baw-primary)' }}
+          >
+            <Plus size={12} />
+            Agregar edificio
+          </Link>
+        </div>
+      )}
+
+      {/* CTA cuando no hay nada */}
+      {isEmpty && expanded && (
+        <Link
+          href="/onboarding"
+          className="absolute inset-0 flex items-center"
+          aria-label="Empezar onboarding"
+        />
+      )}
+    </div>
+  )
+}

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -10,7 +10,23 @@ export function createServiceClient() {
   )
 }
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
+// ────────────────────────────────────────────────────────────────────────────
+// Sprint 3 / S6: getOrgId() legacy ya NO debe retornar la UUID Mateos hardcoded
+// porque esa organization fue eliminada en el wipe operativo de S1.
+//
+// Solución temporal: cache con TTL que resuelve dinámicamente la primera
+// organization disponible (best-effort) usando service-role.  Esto destraba
+// las ~73 APIs legacy tras el onboarding sin migrarlas todas a async/JWT.
+//
+// Pendiente decisión humana (Fran): refactor real para leer `org_id` del JWT
+// del usuario (server-side via cookies()) o de un header inyectado por
+// middleware.  Ver `BUG_BASH_S6.md`.
+// ────────────────────────────────────────────────────────────────────────────
+
+const FALLBACK_ORG_ID = process.env.BAW_FALLBACK_ORG_ID || ''
+let cachedOrgId: string | null = null
+let cachedAt = 0
+const CACHE_TTL_MS = 60_000
 
 export function unauthorized(message = 'Unauthorized') {
   return NextResponse.json(
@@ -37,6 +53,50 @@ export function validateApiKey(request: NextRequest): boolean {
   return apiKey === expected
 }
 
+/**
+ * Sync getter usado por las APIs legacy.  Devuelve el último org_id
+ * resuelto en cache, o el fallback de env si está vacío.  La primera vez
+ * que el proceso arranca regresa el fallback hasta que getOrgIdAsync()
+ * caliente el cache.
+ */
 export function getOrgId(): string {
-  return ORG_ID
+  if (cachedOrgId && Date.now() - cachedAt < CACHE_TTL_MS) {
+    return cachedOrgId
+  }
+  return FALLBACK_ORG_ID
+}
+
+/**
+ * Async getter que resuelve dinámicamente la primera organization
+ * disponible usando service-role.  Las nuevas APIs deben usar esta versión.
+ * Las APIs legacy pueden llamarla puntualmente para calentar el cache.
+ */
+export async function getOrgIdAsync(): Promise<string> {
+  if (cachedOrgId && Date.now() - cachedAt < CACHE_TTL_MS) {
+    return cachedOrgId
+  }
+  try {
+    const supabase = createServiceClient()
+    const { data, error } = await supabase
+      .from('organizations')
+      .select('id')
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle()
+    if (error || !data?.id) return FALLBACK_ORG_ID
+    cachedOrgId = data.id
+    cachedAt = Date.now()
+    return data.id
+  } catch {
+    return FALLBACK_ORG_ID
+  }
+}
+
+/**
+ * Permite que el flow de onboarding inyecte el org_id recién creado al
+ * cache para que las APIs legacy lo recojan inmediatamente.
+ */
+export function setActiveOrgId(orgId: string) {
+  cachedOrgId = orgId
+  cachedAt = Date.now()
 }

--- a/src/lib/useActiveContext.ts
+++ b/src/lib/useActiveContext.ts
@@ -1,0 +1,199 @@
+'use client'
+
+// BaW OS — useActiveContext (Sprint 3 / S4)
+// Hook compartido que mantiene la PM Company y el Building activos.
+// Persiste la selección en localStorage. Se hidrata desde Supabase la primera
+// vez que se monta tras login. Lee `org_members` para saber a qué orgs
+// pertenece el usuario y `buildings` para listarlos por org.
+
+import { useEffect, useState, useCallback } from 'react'
+import { supabase } from '@/lib/supabase'
+
+const STORAGE_KEY_ORG = 'baw:active_org_id'
+const STORAGE_KEY_BUILDING = 'baw:active_building_id'
+
+export interface OrgOption {
+  id: string
+  name: string
+  slug: string
+}
+
+export interface BuildingOption {
+  id: string
+  org_id: string
+  name: string
+  city: string | null
+}
+
+export interface ActiveContext {
+  loading: boolean
+  userId: string | null
+  userEmail: string | null
+  orgs: OrgOption[]
+  buildings: BuildingOption[]
+  activeOrgId: string | null
+  activeBuildingId: string | null
+  setActiveOrgId: (id: string) => void
+  setActiveBuildingId: (id: string) => void
+  refresh: () => Promise<void>
+}
+
+export function useActiveContext(): ActiveContext {
+  const [loading, setLoading] = useState(true)
+  const [userId, setUserId] = useState<string | null>(null)
+  const [userEmail, setUserEmail] = useState<string | null>(null)
+  const [orgs, setOrgs] = useState<OrgOption[]>([])
+  const [buildings, setBuildings] = useState<BuildingOption[]>([])
+  const [activeOrgId, setActiveOrgIdState] = useState<string | null>(null)
+  const [activeBuildingId, setActiveBuildingIdState] = useState<string | null>(
+    null,
+  )
+
+  const setActiveOrgId = useCallback((id: string) => {
+    setActiveOrgIdState(id)
+    try {
+      localStorage.setItem(STORAGE_KEY_ORG, id)
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const setActiveBuildingId = useCallback((id: string) => {
+    setActiveBuildingIdState(id)
+    try {
+      localStorage.setItem(STORAGE_KEY_BUILDING, id)
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const { data: sessionData } = await supabase.auth.getSession()
+      const session = sessionData.session
+      if (!session) {
+        setUserId(null)
+        setUserEmail(null)
+        setOrgs([])
+        setBuildings([])
+        return
+      }
+      setUserId(session.user.id)
+      setUserEmail(session.user.email ?? null)
+
+      // Memberships del usuario
+      const { data: members } = await supabase
+        .from('org_members')
+        .select('org_id, organizations(id, name, slug)')
+        .eq('user_id', session.user.id)
+
+      const orgList: OrgOption[] = (members || [])
+        .map((m: any) => {
+          const org = Array.isArray(m.organizations)
+            ? m.organizations[0]
+            : m.organizations
+          return org
+            ? { id: org.id, name: org.name, slug: org.slug }
+            : null
+        })
+        .filter(Boolean) as OrgOption[]
+
+      setOrgs(orgList)
+
+      // Determinar org activa
+      let nextActiveOrg: string | null = null
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY_ORG)
+        if (stored && orgList.some((o) => o.id === stored)) {
+          nextActiveOrg = stored
+        }
+      } catch {
+        // ignore
+      }
+      if (!nextActiveOrg && orgList.length > 0) {
+        nextActiveOrg = orgList[0].id
+      }
+      setActiveOrgIdState(nextActiveOrg)
+
+      // Buildings de todas las orgs del usuario
+      if (orgList.length > 0) {
+        const { data: bldgs } = await supabase
+          .from('buildings')
+          .select('id, org_id, name, city')
+          .in(
+            'org_id',
+            orgList.map((o) => o.id),
+          )
+          .order('name', { ascending: true })
+
+        const bldList: BuildingOption[] = (bldgs as any[]) || []
+        setBuildings(bldList)
+
+        let nextActiveBld: string | null = null
+        try {
+          const stored = localStorage.getItem(STORAGE_KEY_BUILDING)
+          if (
+            stored &&
+            bldList.some(
+              (b) => b.id === stored && b.org_id === nextActiveOrg,
+            )
+          ) {
+            nextActiveBld = stored
+          }
+        } catch {
+          // ignore
+        }
+        if (!nextActiveBld && nextActiveOrg) {
+          const first = bldList.find((b) => b.org_id === nextActiveOrg)
+          nextActiveBld = first?.id ?? null
+        }
+        setActiveBuildingIdState(nextActiveBld)
+      } else {
+        setBuildings([])
+        setActiveBuildingIdState(null)
+      }
+    } catch (e) {
+      // soft-fail: el componente que consume el hook decide qué mostrar
+      // eslint-disable-next-line no-console
+      console.error('useActiveContext refresh error', e)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  // Si cambia la org activa, ajustar el building activo si pertenece a otra org
+  useEffect(() => {
+    if (!activeOrgId) return
+    if (activeBuildingId) {
+      const current = buildings.find((b) => b.id === activeBuildingId)
+      if (current && current.org_id === activeOrgId) return
+    }
+    const first = buildings.find((b) => b.org_id === activeOrgId)
+    setActiveBuildingIdState(first?.id ?? null)
+    if (first) {
+      try {
+        localStorage.setItem(STORAGE_KEY_BUILDING, first.id)
+      } catch {
+        // ignore
+      }
+    }
+  }, [activeOrgId, activeBuildingId, buildings])
+
+  return {
+    loading,
+    userId,
+    userEmail,
+    orgs,
+    buildings,
+    activeOrgId,
+    activeBuildingId,
+    setActiveOrgId,
+    setActiveBuildingId,
+    refresh,
+  }
+}

--- a/supabase/migrations/20260429_01_member_role_pm_values.sql
+++ b/supabase/migrations/20260429_01_member_role_pm_values.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Sprint 3 · S1 — Parte 1/2 — Agregar valores pm_* al enum member_role
+-- =============================================================================
+-- Postgres no permite usar un enum value recién agregado en la misma transacción
+-- donde se hizo ADD VALUE. Por eso esta migración va separada de la siguiente.
+--
+-- Los valores antiguos (owner, admin, operator, viewer, agent) quedan en el
+-- enum sin uso post-wipe (deuda menor aceptable; PG no permite DROP VALUE).
+-- =============================================================================
+
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'pm_owner';
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'pm_admin';
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'pm_operator';
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'pm_viewer';
+ALTER TYPE member_role ADD VALUE IF NOT EXISTS 'client';

--- a/supabase/migrations/20260429_02_multitenancy_v2.sql
+++ b/supabase/migrations/20260429_02_multitenancy_v2.sql
@@ -1,0 +1,282 @@
+-- =============================================================================
+-- Sprint 3 · S1 — Parte 2/2 — Multitenancy v2 + wipe operativo
+-- =============================================================================
+-- Objetivo:
+--   1. Wipe de tablas operativas (preserva auth.users; vacía organizations y
+--      org_members para que el onboarding de BaW Operations arranque de cero).
+--   2. Capa Buildings entre Organizations y Units.
+--   3. Capa Property Owners + ownership_stakes (validación sum<=100 por building).
+--   4. RLS endurecido por org_id en todas las tablas nuevas usando los roles
+--      pm_* (declarados en la migración 20260429_01).
+--
+-- Pre-requisito: la migración 20260429_01_member_role_pm_values.sql debe haberse
+-- aplicado antes (los valores pm_* del enum no pueden usarse en la misma tx
+-- donde se agregaron).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1) WIPE de tablas operativas
+-- -----------------------------------------------------------------------------
+
+TRUNCATE TABLE
+  public.payment_ledger,
+  public.payments,
+  public.contracts,
+  public.reservations,
+  public.tenant_applications,
+  public.occupants,
+  public.unit_prices,
+  public.pricing_config,
+  public.str_seasons,
+  public.expenses,
+  public.incidents,
+  public.tasks,
+  public.escalation_rules,
+  public.audit_log,
+  public.webhook_events,
+  public.whatsapp_notifications,
+  public.units
+RESTART IDENTITY CASCADE;
+
+DELETE FROM public.org_members;
+DELETE FROM public.organizations;
+
+-- -----------------------------------------------------------------------------
+-- 2) Tabla buildings
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.buildings (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id      uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  name        text NOT NULL,
+  address     text,
+  city        text,
+  state       text,
+  country     text NOT NULL DEFAULT 'MX',
+  postal_code text,
+  notes       text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT buildings_name_per_org_unique UNIQUE (org_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS buildings_org_id_idx ON public.buildings(org_id);
+
+ALTER TABLE public.buildings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS buildings_select ON public.buildings;
+DROP POLICY IF EXISTS buildings_insert ON public.buildings;
+DROP POLICY IF EXISTS buildings_update ON public.buildings;
+DROP POLICY IF EXISTS buildings_delete ON public.buildings;
+
+CREATE POLICY buildings_select ON public.buildings
+  FOR SELECT USING (
+    org_id IN (SELECT om.org_id FROM public.org_members om WHERE om.user_id = auth.uid())
+  );
+
+CREATE POLICY buildings_insert ON public.buildings
+  FOR INSERT WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY buildings_update ON public.buildings
+  FOR UPDATE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY buildings_delete ON public.buildings
+  FOR DELETE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin')
+    )
+  );
+
+-- -----------------------------------------------------------------------------
+-- 3) Units — agregar building_id NOT NULL (tabla está vacía post-wipe)
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE public.units
+  ADD COLUMN IF NOT EXISTS building_id uuid REFERENCES public.buildings(id) ON DELETE CASCADE;
+
+ALTER TABLE public.units
+  ALTER COLUMN building_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS units_building_id_idx ON public.units(building_id);
+
+ALTER TABLE public.units
+  DROP CONSTRAINT IF EXISTS units_org_id_number_key;
+
+ALTER TABLE public.units
+  DROP CONSTRAINT IF EXISTS units_building_id_number_key;
+
+ALTER TABLE public.units
+  ADD CONSTRAINT units_building_id_number_key UNIQUE (building_id, number);
+
+-- -----------------------------------------------------------------------------
+-- 4) Tabla property_owners
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.property_owners (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id        uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  user_id       uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  full_name     text NOT NULL,
+  email         text,
+  phone         text,
+  rfc           text,
+  bank_info     jsonb,
+  notes         text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS property_owners_org_id_idx  ON public.property_owners(org_id);
+CREATE INDEX IF NOT EXISTS property_owners_user_id_idx ON public.property_owners(user_id);
+
+ALTER TABLE public.property_owners ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS property_owners_select ON public.property_owners;
+DROP POLICY IF EXISTS property_owners_insert ON public.property_owners;
+DROP POLICY IF EXISTS property_owners_update ON public.property_owners;
+DROP POLICY IF EXISTS property_owners_delete ON public.property_owners;
+
+CREATE POLICY property_owners_select ON public.property_owners
+  FOR SELECT USING (
+    org_id IN (SELECT om.org_id FROM public.org_members om WHERE om.user_id = auth.uid())
+    OR user_id = auth.uid()
+  );
+
+CREATE POLICY property_owners_insert ON public.property_owners
+  FOR INSERT WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY property_owners_update ON public.property_owners
+  FOR UPDATE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+    OR user_id = auth.uid()
+  );
+
+CREATE POLICY property_owners_delete ON public.property_owners
+  FOR DELETE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin')
+    )
+  );
+
+-- -----------------------------------------------------------------------------
+-- 5) Tabla ownership_stakes (M:N building↔property_owner)
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.ownership_stakes (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id              uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  building_id         uuid NOT NULL REFERENCES public.buildings(id) ON DELETE CASCADE,
+  property_owner_id   uuid NOT NULL REFERENCES public.property_owners(id) ON DELETE CASCADE,
+  percentage          numeric(5,2) NOT NULL CHECK (percentage > 0 AND percentage <= 100),
+  starts_on           date,
+  ends_on             date,
+  notes               text,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ownership_stakes_unique UNIQUE (building_id, property_owner_id)
+);
+
+CREATE INDEX IF NOT EXISTS ownership_stakes_org_id_idx      ON public.ownership_stakes(org_id);
+CREATE INDEX IF NOT EXISTS ownership_stakes_building_id_idx ON public.ownership_stakes(building_id);
+CREATE INDEX IF NOT EXISTS ownership_stakes_owner_id_idx    ON public.ownership_stakes(property_owner_id);
+
+CREATE OR REPLACE FUNCTION public.check_ownership_stakes_sum()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  total numeric;
+BEGIN
+  SELECT COALESCE(SUM(percentage), 0) INTO total
+  FROM public.ownership_stakes
+  WHERE building_id = NEW.building_id
+    AND id <> COALESCE(NEW.id, '00000000-0000-0000-0000-000000000000'::uuid);
+  IF total + NEW.percentage > 100 THEN
+    RAISE EXCEPTION 'Suma de ownership stakes para building % excede 100%% (intentado: %)',
+      NEW.building_id, total + NEW.percentage;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ownership_stakes_sum_check ON public.ownership_stakes;
+CREATE TRIGGER ownership_stakes_sum_check
+  BEFORE INSERT OR UPDATE ON public.ownership_stakes
+  FOR EACH ROW EXECUTE FUNCTION public.check_ownership_stakes_sum();
+
+ALTER TABLE public.ownership_stakes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS ownership_stakes_select ON public.ownership_stakes;
+DROP POLICY IF EXISTS ownership_stakes_insert ON public.ownership_stakes;
+DROP POLICY IF EXISTS ownership_stakes_update ON public.ownership_stakes;
+DROP POLICY IF EXISTS ownership_stakes_delete ON public.ownership_stakes;
+
+CREATE POLICY ownership_stakes_select ON public.ownership_stakes
+  FOR SELECT USING (
+    org_id IN (SELECT om.org_id FROM public.org_members om WHERE om.user_id = auth.uid())
+    OR property_owner_id IN (SELECT po.id FROM public.property_owners po WHERE po.user_id = auth.uid())
+  );
+
+CREATE POLICY ownership_stakes_insert ON public.ownership_stakes
+  FOR INSERT WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY ownership_stakes_update ON public.ownership_stakes
+  FOR UPDATE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin','pm_operator')
+    )
+  );
+
+CREATE POLICY ownership_stakes_delete ON public.ownership_stakes
+  FOR DELETE USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner','pm_admin')
+    )
+  );
+
+-- -----------------------------------------------------------------------------
+-- 6) Comentarios documentales
+-- -----------------------------------------------------------------------------
+
+COMMENT ON TABLE public.buildings        IS 'Sprint 3 v2: capa edificio entre organizations y units. Una org puede gestionar múltiples buildings.';
+COMMENT ON TABLE public.property_owners  IS 'Sprint 3 v2: dueños del inmueble (no tenants). Pueden ligarse a auth.users vía portal Property Owner.';
+COMMENT ON TABLE public.ownership_stakes IS 'Sprint 3 v2: relación M:N building↔property_owner con porcentaje de propiedad. Trigger valida sum<=100 por building.';
+COMMENT ON COLUMN public.units.building_id IS 'Sprint 3 v2: FK a buildings. NOT NULL — toda unit pertenece a un building.';
+
+-- =============================================================================
+-- FIN — multitenancy v2
+-- =============================================================================

--- a/supabase/seed-examples/README.md
+++ b/supabase/seed-examples/README.md
@@ -1,0 +1,29 @@
+# Seed Examples
+
+Esta carpeta contiene **seeds de referencia históricos**, NO migraciones que deban
+correrse contra la base.
+
+Los seeds aquí se preservan como ejemplos de cómo poblar BaW OS para desarrollo
+local o testing, pero el flujo canónico de creación de datos en producción es el
+**onboarding wizard** (`/onboarding`), no SQL directo.
+
+## Archivos
+
+- `mateos-809.sql` — Seed original del MVP Mateos (Sprint 2, Org `ed4308c7-2bdb-46f2-be69-7c59674838e2`).
+  Estructura pre-Sprint 3: usa `units.org_id` directo (sin `building_id`),
+  enum `member_role` con `owner/admin/operator/viewer/agent`. **NO se puede correr
+  tal cual en BaW OS post-Sprint 3** porque el schema cambió (units ahora requiere
+  `building_id NOT NULL` y los roles canónicos son `pm_*`).
+
+  Para reactivar en local, primero sembrar un `building` y mapear los `org_id`
+  → `building_id` correspondientes.
+
+## Por qué se preserva
+
+Como el wipe operativo del Sprint 3 borró la data Mateos en producción, este
+archivo es la única referencia escrita de la configuración inicial usada para
+validar el sistema durante Sprint 1–2 (16 unidades, 9 contracts, 21 incidents,
+3 payments).
+
+Sirve como **fixture de referencia** para tests futuros y como evidencia
+auditoria del estado pre-multitenancy v2.

--- a/supabase/seed-examples/mateos-809.sql
+++ b/supabase/seed-examples/mateos-809.sql
@@ -1,0 +1,156 @@
+-- BaW OS — Seed Mateos 809P (corte 26-abr-2026)
+-- Idempotente: usa funciones helper que UPDATE si existe, INSERT si no.
+-- No depende de UNIQUE constraints específicos.
+-- Datos vivos del Notion "BaW Mateos 809P — Estado Operativo Vivo".
+-- Org Mateos: ed4308c7-2bdb-46f2-be69-7c59674838e2 (preexistente).
+
+-- ============================================================
+-- HELPER FUNCTIONS (idempotentes, scope: este seed)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION pg_temp.seed_unit(
+  p_org_id uuid, p_number text, p_type text, p_floor int, p_status text, p_notes text
+) RETURNS uuid LANGUAGE plpgsql AS $fn$
+DECLARE v_id uuid;
+BEGIN
+  SELECT id INTO v_id FROM units WHERE org_id = p_org_id AND number = p_number LIMIT 1;
+  IF v_id IS NULL THEN
+    INSERT INTO units (org_id, number, type, floor, status, notes)
+    VALUES (p_org_id, p_number, p_type, p_floor, p_status, p_notes)
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE units
+    SET type = p_type, floor = p_floor, status = p_status, notes = p_notes
+    WHERE id = v_id;
+  END IF;
+  RETURN v_id;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION pg_temp.seed_occupant(
+  p_org_id uuid, p_name text, p_phone text, p_type text
+) RETURNS uuid LANGUAGE plpgsql AS $fn$
+DECLARE v_id uuid;
+BEGIN
+  SELECT id INTO v_id FROM occupants WHERE org_id = p_org_id AND name = p_name LIMIT 1;
+  IF v_id IS NULL THEN
+    INSERT INTO occupants (org_id, name, phone, type)
+    VALUES (p_org_id, p_name, p_phone, p_type)
+    RETURNING id INTO v_id;
+  END IF;
+  RETURN v_id;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION pg_temp.seed_contract(
+  p_org_id uuid, p_unit_id uuid, p_occ_id uuid,
+  p_amount numeric, p_payment_day int, p_start date, p_end date, p_status text
+) RETURNS uuid LANGUAGE plpgsql AS $fn$
+DECLARE v_id uuid;
+BEGIN
+  SELECT id INTO v_id FROM contracts
+   WHERE unit_id = p_unit_id AND occupant_id = p_occ_id
+   ORDER BY created_at DESC LIMIT 1;
+  IF v_id IS NULL THEN
+    INSERT INTO contracts (org_id, unit_id, occupant_id, monthly_amount, payment_day, start_date, end_date, status)
+    VALUES (p_org_id, p_unit_id, p_occ_id, p_amount, p_payment_day, p_start, p_end, p_status)
+    RETURNING id INTO v_id;
+  END IF;
+  RETURN v_id;
+END $fn$;
+
+CREATE OR REPLACE FUNCTION pg_temp.seed_payment(
+  p_org_id uuid, p_contract_id uuid,
+  p_amount numeric, p_rent numeric, p_water numeric,
+  p_due date, p_status text, p_paid date
+) RETURNS uuid LANGUAGE plpgsql AS $fn$
+DECLARE v_id uuid;
+BEGIN
+  IF p_contract_id IS NULL THEN RETURN NULL; END IF;
+  SELECT id INTO v_id FROM payments
+   WHERE contract_id = p_contract_id
+     AND due_date >= date_trunc('month', p_due)::date
+     AND due_date < (date_trunc('month', p_due) + interval '1 month')::date
+   LIMIT 1;
+  IF v_id IS NULL THEN
+    IF p_paid IS NOT NULL THEN
+      INSERT INTO payments (org_id, contract_id, amount, rent_amount, water_fee, due_date, status, paid_date)
+      VALUES (p_org_id, p_contract_id, p_amount, p_rent, p_water, p_due, p_status, p_paid)
+      RETURNING id INTO v_id;
+    ELSE
+      INSERT INTO payments (org_id, contract_id, amount, rent_amount, water_fee, due_date, status)
+      VALUES (p_org_id, p_contract_id, p_amount, p_rent, p_water, p_due, p_status)
+      RETURNING id INTO v_id;
+    END IF;
+  END IF;
+  RETURN v_id;
+END $fn$;
+
+-- ============================================================
+-- SEED PRINCIPAL
+-- ============================================================
+
+DO $$
+DECLARE
+  v_org uuid := 'ed4308c7-2bdb-46f2-be69-7c59674838e2';
+  u_d102 uuid; u_d202 uuid; u_d203 uuid; u_d204 uuid;
+  u_d301 uuid; u_d302 uuid; u_d401 uuid; u_d402 uuid; u_d404 uuid;
+  o_erik uuid; o_pat uuid; o_let uuid; o_jose uuid; o_humb uuid;
+  o_jorge uuid; o_arturo uuid; o_martin uuid; o_d202 uuid;
+  c_d102 uuid; c_d203 uuid; c_d204 uuid; c_d301 uuid; c_d302 uuid;
+  c_d401 uuid; c_d402 uuid; c_d404 uuid; c_d202 uuid;
+BEGIN
+  -- 1. UNIDADES (16)
+  PERFORM pg_temp.seed_unit(v_org, 'D101', 'STR', 1, 'available', 'Tipo 01 Básico 102m². Drenaje recurrente. Mantenimiento pendiente.');
+  u_d102 := pg_temp.seed_unit(v_org, 'D102', 'LTR', 1, 'occupied',  'Tipo 02 Confort 122m². Erik Mauricio Núñez Rivera.');
+  PERFORM pg_temp.seed_unit(v_org, 'D103', 'STR', 1, 'available', 'Tipo 03 Clásico 131m². Requiere remodelación profunda.');
+  PERFORM pg_temp.seed_unit(v_org, 'D104', 'STR', 1, 'available', 'Tipo 04 Superior 149m². Baño y cocina urgentes.');
+  PERFORM pg_temp.seed_unit(v_org, 'D201', 'MTR', 2, 'available', 'Tipo 01 Básico. Acuerdo Natturaly $2,000/persona, mín verbal $6,000. Pendiente confirmar.');
+  u_d202 := pg_temp.seed_unit(v_org, 'D202', 'MTR', 2, 'occupied',  'Tipo 02 Confort. 1 mujer hoy, pagó $2,000 abril. Mover a D303 en mayo, liberar D202.');
+  u_d203 := pg_temp.seed_unit(v_org, 'D203', 'LTR', 2, 'occupied',  'Tipo 03 Clásico. Patricia Hernández. Contrato vencido — renovación pendiente.');
+  u_d204 := pg_temp.seed_unit(v_org, 'D204', 'LTR', 2, 'occupied',  'Tipo 04 Superior. Leticia (Felipe Gómez paga). Contrato vencido.');
+  u_d301 := pg_temp.seed_unit(v_org, 'D301', 'LTR', 3, 'occupied',  'Tipo 01 Básico. José Luis Bautista (Misioneros SUD). Boiler dañado, medidor CFE pendiente.');
+  u_d302 := pg_temp.seed_unit(v_org, 'D302', 'LTR', 3, 'occupied',  'Tipo 02 Confort. Humberto Ortiz. MOROSO ~$32K. Decisión legal/cobranza requerida.');
+  PERFORM pg_temp.seed_unit(v_org, 'D303', 'MTR', 3, 'reserved',  'Tipo 03 Clásico. Reservada para renta variable mayo (recibirá ocupante actual de D202).');
+  PERFORM pg_temp.seed_unit(v_org, 'D304', 'STR', 3, 'available', 'Tipo 04 Superior. Vacante.');
+  u_d401 := pg_temp.seed_unit(v_org, 'D401', 'LTR', 4, 'occupied',  'Tipo 01 Básico. Jorge Alberto Álvarez. Contrato vencido ago-2024.');
+  u_d402 := pg_temp.seed_unit(v_org, 'D402', 'LTR', 4, 'occupied',  'Tipo 02 Confort. Arturo Osornio. MOROSO ~$80K. CASO CRÍTICO.');
+  PERFORM pg_temp.seed_unit(v_org, 'D403', 'STR', 4, 'available', 'Tipo 03 Clásico. VACANTE — Daniel Mercado no cerró.');
+  u_d404 := pg_temp.seed_unit(v_org, 'D404', 'LTR', 4, 'occupied',  'Tipo 04 Superior. Martín Briones (colaborador mantenimiento). Contrato vencido ene-2025.');
+
+  -- 2. OCCUPANTS
+  o_erik   := pg_temp.seed_occupant(v_org, 'Erik Mauricio Núñez Rivera',         NULL, 'ltr');
+  o_pat    := pg_temp.seed_occupant(v_org, 'Patricia Hernández',                  NULL, 'ltr');
+  o_let    := pg_temp.seed_occupant(v_org, 'Leticia (Felipe Gómez paga)',         NULL, 'ltr');
+  o_jose   := pg_temp.seed_occupant(v_org, 'José Luis Bautista (Misioneros SUD)', NULL, 'ltr');
+  o_humb   := pg_temp.seed_occupant(v_org, 'Humberto Ortiz',                      NULL, 'ltr');
+  o_jorge  := pg_temp.seed_occupant(v_org, 'Jorge Alberto Álvarez',               NULL, 'ltr');
+  o_arturo := pg_temp.seed_occupant(v_org, 'Arturo Osornio',                      NULL, 'ltr');
+  o_martin := pg_temp.seed_occupant(v_org, 'Martín Briones',                      NULL, 'ltr');
+  o_d202   := pg_temp.seed_occupant(v_org, 'Ocupante D202 (renta variable abr-2026)', NULL, 'both');
+
+  -- 3. CONTRACTS
+  c_d102 := pg_temp.seed_contract(v_org, u_d102, o_erik,   8250, 1, '2025-09-01', NULL,         'active');
+  c_d203 := pg_temp.seed_contract(v_org, u_d203, o_pat,    5050, 1, '2024-01-01', '2025-12-31', 'en_renovacion');
+  c_d204 := pg_temp.seed_contract(v_org, u_d204, o_let,    5050, 1, '2024-01-01', '2025-12-31', 'en_renovacion');
+  c_d301 := pg_temp.seed_contract(v_org, u_d301, o_jose,   7450, 1, '2025-06-01', NULL,         'active');
+  c_d302 := pg_temp.seed_contract(v_org, u_d302, o_humb,   4750, 1, '2024-03-01', NULL,         'active');
+  c_d401 := pg_temp.seed_contract(v_org, u_d401, o_jorge,  4750, 1, '2023-08-01', '2024-08-31', 'en_renovacion');
+  c_d402 := pg_temp.seed_contract(v_org, u_d402, o_arturo, 3800, 1, '2023-01-01', NULL,         'active');
+  c_d404 := pg_temp.seed_contract(v_org, u_d404, o_martin, 5550, 1, '2024-01-01', '2025-01-31', 'en_renovacion');
+  c_d202 := pg_temp.seed_contract(v_org, u_d202, o_d202,   2000, 1, '2026-04-01', '2026-04-30', 'active');
+
+  -- 4. PAYMENTS — estados puntuales abril 2026
+  -- D202 — pagó $2,000 abril
+  PERFORM pg_temp.seed_payment(v_org, c_d202, 2000, 2000, 0,   '2026-04-01', 'paid', '2026-04-15');
+  -- D302 — Humberto Ortiz — late (parte de mora ~$32K)
+  PERFORM pg_temp.seed_payment(v_org, c_d302, 5000, 4750, 250, '2026-04-01', 'late', NULL);
+  -- D402 — Arturo Osornio — late (parte de mora ~$80K)
+  PERFORM pg_temp.seed_payment(v_org, c_d402, 4050, 3800, 250, '2026-04-01', 'late', NULL);
+
+END $$;
+
+-- Comentarios operativos (no se almacenan, solo para reviewers):
+-- - Ingreso nominal estimado: ~$46,650/mes incluyendo morosos (D102 8250 + D203/D204 5050x2 + D301 7450 + D302 4750 + D401 4750 + D402 3800 + D404 5550 + D202 2000).
+-- - Conservador: ~$38,100/mes excluyendo D302 y D402.
+-- - D403 vacante (Daniel Mercado no cerró).
+-- - D303 reservada para renta variable mayo (recibirá ocupante de D202).
+-- - Locales y bodegas rooftop NO modeladas en `units` — pendiente de Sprint 3.


### PR DESCRIPTION
## Sprint 3 · S7 · Hotfixes del bug bash humano

Esta rama consolida los 5 PRs anteriores (#5, #6, #7, #8, #9) y aplica encima los fixes detectados por Fran al probar las preview URLs en navegador real. Es la rama recomendada para mergear a `main` (incluye todo el sprint nocturno + estos fixes).

### Bugs corregidos

#### #1 · Theme picker no aplicaba el tema (BLOCKER, PR #7)
**Síntoma:** activar Claro/Oscuro/Auto en el ProfileMenu no producía ningún cambio visual.

**Causa raíz:** `applyTheme` en `ProfileMenu.tsx` solo togglea la clase `dark`, pero el sistema canónico de tokens (S5/`globals.css`) lee tanto `html.dark` como `html.light` para alternar entre escalas OKLCH. Sin la clase `light` explícita, no había estilos que aplicar.

**Plus:** la clave de localStorage estaba desincronizada — `layout.tsx` usaba `baw-theme` y `ProfileMenu.tsx` usaba `baw:theme`. El tema persistido nunca cargaba correctamente.

**Fix:** `applyTheme` ahora añade/quita ambas clases (`dark` y `light`) de forma exclusiva y setea `data-theme`. Script inline de `layout.tsx` reescrito para hacer lo mismo y leer la clave correcta `baw:theme`. La inicialización default ya no fuerza `dark` en el SSR; lo decide el script inline a partir de la preferencia del usuario.

#### #2 · "Frontier Bay" hardcoded en Mission Control (PR #6)
**Síntoma:** el subtítulo de Mission Control mostraba "Frontier Bay · Operación en vivo" incluso para PMs nuevos sin ese building.

**Causa raíz:** texto hardcoded en `src/app/page.tsx:226`.

**Fix:** nuevo componente `MissionControlSubtitle` que lee `useActiveContext` y muestra `${building.name} · ${org.name}` o el placeholder neutro `Workspace sin configurar` cuando no hay onboarding completo.

#### #3 · Input "Cantidad" del onboarding rompía edición de 1 dígito (PR #6)
**Síntoma:** al borrar el `1` para escribir `2`, el campo se pegaba en `1`. Solo se podía editar agregando un segundo dígito y luego retroceder.

**Causa raíz:** `value={unitConfig.count}` (number) + `onChange` con `Math.max(1, Number(e.target.value) || 1)` forzaba el valor a 1 al vaciar el campo.

**Fix:** los campos numéricos del config bulk (`count`, `startNumber`, `floors`) ahora se almacenan como string en el state. Permite vaciar el campo libremente. Se coercen a número solo al ejecutar `generateUnits()`. Los inputs cambiaron de `type="number"` a `type="text"` con `inputMode="numeric"` y filtro por regex para mantener teclado numérico en mobile.

#### #4 · Bulk de unidades borraba los previos (FUNCIONAL, PR #6)
**Síntoma:** ejecutar un segundo bulk (p.ej. para agregar 201–204 después de 101–104) borraba el primer bulk completo.

**Causa raíz:** `generateUnits()` hacía `setUnits(rows)` que reemplazaba la lista entera.

**Fix:** ahora hace APPEND con deduplicación por `number` usando un `Map`. Permite ejecutar múltiples bulks (p.ej. 101–104, 201–204, 301–304, 401–404) en el mismo paso. Bonus: tras cada bulk, el campo "Empezar en" se auto-incrementa en +100 para sugerir el siguiente piso. El botón cambia su label de "Generar X unidades" a "Agregar X unidades más" cuando ya hay unidades, con un hint visible ("Puedes ejecutar varios bulks y se irán sumando").

#### #5 · Sidebar tapaba el contenido al expandirse (UX)
**Síntoma:** al fijar el sidebar, ocupaba 240px sobre el contenido principal sin mover nada — quedaba imposible interactuar con la página hasta contraer el menú.

**Causa raíz:** `AppShell` tenía `md:pl-14` (56px) fijo en `<main>`. El sidebar se expandía a 240px sin notificar al layout.

**Fix:** el Sidebar ahora expone una CSS custom property `--sidebar-effective-width` en `<html>` que vale 56px cuando está colapsado y 240px cuando está pinned. AppShell la lee con `paddingLeft: var(--sidebar-effective-width)`. Resultado:
- Pinned → empuja el contenido (no overlay) ✅
- Hover-only (no pinned) → sigue siendo overlay, no causa layout shift cada vez que el cursor lo toca ✅

#### #6 · PR #8 (tokens OKLCH) no se podía probar
**Causa:** dependía del Bug #1 (sin theme picker funcional, no había modo claro para validar).

**Estado:** el fix de #1 lo destraba.

### Verificación

- `npx tsc --noEmit` ✅
- `npx next build` ✅ (30+ rutas, sin warnings)

### Estrategia de merge recomendada

Esta rama (`sprint3/s7-hotfixes-bugbash`) **contiene todos los PRs del sprint nocturno mergeados localmente** (S1, S3, S4, S5, S6) más los hotfixes encima.

Hay dos caminos:
1. **Mergear esta sola PR a main** (recomendado) — entra todo el sprint en un solo merge limpio. Cierra los PRs #5, #6, #7, #8, #9 sin mergear (ya contenidos aquí).
2. Mergear los 5 PRs uno por uno como originalmente y luego este S7 al final.

Recomiendo opción 1 — más limpio y los 5 PRs ya pasaron CI y revisión humana parcial vía las preview URLs.
