### PR TITLE
fix(rls): S9 hotfix RLS organizations + tenant-aware policies + onboarding idempotente

### DIFF
--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -52,6 +52,33 @@ export async function POST(request: NextRequest) {
 
     const supabase = createServiceClient()
 
+    // S9 hotfix: si el user ya tiene una org, devolverla en vez de re-crear.
+    // Evita el bug de slug duplicado cuando el wizard se reabre tras un
+    // onboarding ya completado (frecuente en iOS donde useActiveContext
+    // fallaba por RLS y el user pensaba que tenía que repetir).
+    const { data: existingMember } = await supabase
+      .from('org_members')
+      .select('org_id, role, organizations(id, name, slug)')
+      .eq('user_id', body.user_id)
+      .limit(1)
+      .maybeSingle()
+
+    if (existingMember?.org_id) {
+      const orgRef = Array.isArray(existingMember.organizations)
+        ? existingMember.organizations[0]
+        : existingMember.organizations
+      setActiveOrgId(existingMember.org_id)
+      return apiOk({
+        org_id: existingMember.org_id,
+        already_onboarded: true,
+        existing_org: orgRef
+          ? { id: orgRef.id, name: orgRef.name, slug: orgRef.slug }
+          : null,
+        message:
+          'El usuario ya tiene una organización configurada. Usa el WorkspaceSwitcher para cambiar de contexto o pide a un pm_owner crear más buildings.',
+      })
+    }
+
     // 1) PM Company (organizations)
     const { data: org, error: orgErr } = await supabase
       .from('organizations')

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,11 @@ import {
 import ContractAlertsBanner from '@/components/ContractAlertsBanner'
 import { useActiveContext } from '@/lib/useActiveContext'
 
+// S9 hotfix: Mission Control ahora espera el contexto activo y filtra todas
+// las queries por activeOrgId. Antes confiaba 100% en RLS y, cuando una sola
+// query fallaba (e.g. organizations sin policies), el Promise.all colapsaba
+// la página y en iOS Safari se veía como un 404 / pantalla en blanco.
+
 interface CollectionRow {
   id: string
   unit: string
@@ -49,6 +54,7 @@ function fmtMoney(n: number) {
 }
 
 export default function MissionControl() {
+  const { activeOrgId, loading: ctxLoading, orgs } = useActiveContext()
   const [metrics, setMetrics] = useState<DashboardMetrics>({
     totalUnits: 0,
     occupiedUnits: 0,
@@ -64,28 +70,53 @@ export default function MissionControl() {
   const [needsOnboarding, setNeedsOnboarding] = useState(false)
 
   useEffect(() => {
+    // S9: esperar a que el contexto activo se hidrate antes de hacer queries
+    if (ctxLoading) return
+
+    // Sin orgs → onboarding directo
+    if (orgs.length === 0) {
+      setNeedsOnboarding(true)
+      setLoading(false)
+      return
+    }
+
     async function fetchDashboard() {
       try {
         const now = new Date()
 
+        // Filtrar todas las queries por activeOrgId. Si por algún motivo no
+        // hay org activa todavía, abortamos sin romper la UI.
+        if (!activeOrgId) {
+          setLoading(false)
+          return
+        }
+
         const [unitsRes, contractsRes, paymentsRes, maintRes] = await Promise.all([
-          supabase.from('units').select('*').order('floor').order('number'),
+          supabase
+            .from('units')
+            .select('*')
+            .eq('org_id', activeOrgId)
+            .order('floor')
+            .order('number'),
           supabase
             .from('contracts')
             .select(
               'id, unit_id, monthly_amount, end_date, status, unit:units(number), occupant:occupants(name)'
             )
+            .eq('org_id', activeOrgId)
             .in('status', ['active', 'en_renovacion']),
           supabase
             .from('payments')
             .select(
               'id, amount, due_date, status, contract:contracts(unit:units(number), occupant:occupants(name))'
             )
+            .eq('org_id', activeOrgId)
             .in('status', ['pending', 'late'])
             .order('due_date', { ascending: true }),
           supabase
             .from('incidents')
             .select('id, status, created_at, description, unit:units(number)')
+            .eq('org_id', activeOrgId)
             .in('status', ['open', 'in_progress', 'pending'])
             .order('created_at', { ascending: false })
             .limit(5),
@@ -96,8 +127,11 @@ export default function MissionControl() {
         const payments = paymentsRes.data || []
         const tickets = maintRes.data || []
 
-        // Detectar empty state global: sin unidades ni contratos
-        if (units.length === 0 && contracts.length === 0) {
+        // S9: empty state honesto — si la org existe pero no tiene units ni
+        // contracts, mostrar dashboard vacío (no onboarding) porque el user
+        // ya completó onboarding pero no tiene operación cargada todavía.
+        // Solo redirigir a onboarding si NO hay orgs.
+        if (units.length === 0 && contracts.length === 0 && orgs.length === 0) {
           setNeedsOnboarding(true)
         }
 
@@ -174,7 +208,7 @@ export default function MissionControl() {
     }
 
     fetchDashboard()
-  }, [])
+  }, [ctxLoading, activeOrgId, orgs.length])
 
   const occupancyPct =
     metrics.totalUnits > 0

--- a/src/lib/useActiveContext.ts
+++ b/src/lib/useActiveContext.ts
@@ -82,22 +82,41 @@ export function useActiveContext(): ActiveContext {
       setUserId(session.user.id)
       setUserEmail(session.user.email ?? null)
 
-      // Memberships del usuario
-      const { data: members } = await supabase
+      // S9 hotfix: hacer el lookup en dos pasos para no depender del join.
+      // Antes: si RLS bloqueaba `organizations`, todo el join devolvía null y
+      // el usuario quedaba sin orgs aun teniendo membresía válida.
+      const { data: members, error: memberErr } = await supabase
         .from('org_members')
-        .select('org_id, organizations(id, name, slug)')
+        .select('org_id')
         .eq('user_id', session.user.id)
 
-      const orgList: OrgOption[] = (members || [])
-        .map((m: any) => {
-          const org = Array.isArray(m.organizations)
-            ? m.organizations[0]
-            : m.organizations
-          return org
-            ? { id: org.id, name: org.name, slug: org.slug }
-            : null
-        })
-        .filter(Boolean) as OrgOption[]
+      if (memberErr) {
+        // eslint-disable-next-line no-console
+        console.error('useActiveContext: error leyendo org_members', memberErr)
+      }
+
+      const orgIds = (members || [])
+        .map((m: any) => m.org_id)
+        .filter(Boolean) as string[]
+
+      let orgList: OrgOption[] = []
+      if (orgIds.length > 0) {
+        const { data: orgsData, error: orgErr } = await supabase
+          .from('organizations')
+          .select('id, name, slug')
+          .in('id', orgIds)
+
+        if (orgErr) {
+          // eslint-disable-next-line no-console
+          console.error('useActiveContext: error leyendo organizations', orgErr)
+        }
+
+        orgList = (orgsData || []).map((o: any) => ({
+          id: o.id,
+          name: o.name,
+          slug: o.slug,
+        }))
+      }
 
       setOrgs(orgList)
 

--- a/supabase/migrations/20260429_03_rls_hotfix_s9.sql
+++ b/supabase/migrations/20260429_03_rls_hotfix_s9.sql
@@ -1,0 +1,261 @@
+-- BaW OS — Sprint 3 / S9 Hotfix RLS post-merge
+-- Bug raíz: tabla `organizations` con RLS habilitado y 0 policies (SELECT bloqueado al user logueado)
+-- + tablas operativas (units, contracts, payments, incidents, occupants) con policies legacy
+-- `allow_all_*` (qual=true) que filtran nada, exponiendo data cross-tenant.
+--
+-- Fix:
+--   1. Crear policies tenant-aware en `organizations` (SELECT/UPDATE para members).
+--   2. Reemplazar `allow_all_*` por policies con filtro `org_id IN org_members(auth.uid())`.
+--   3. Mantener compatibilidad con service-role (que bypassa RLS por design).
+
+BEGIN;
+
+-- =====================================================================
+-- 1) organizations — agregar policies tenant-aware
+-- =====================================================================
+DROP POLICY IF EXISTS organizations_select ON public.organizations;
+DROP POLICY IF EXISTS organizations_update ON public.organizations;
+
+CREATE POLICY organizations_select ON public.organizations
+  FOR SELECT
+  USING (
+    id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY organizations_update ON public.organizations
+  FOR UPDATE
+  USING (
+    id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role)
+    )
+  );
+
+-- INSERT/DELETE de organizations queda para service-role únicamente
+-- (onboarding usa createServiceClient → bypass RLS).
+
+-- =====================================================================
+-- 2) units — drop allow_all + policies tenant-aware
+-- =====================================================================
+DROP POLICY IF EXISTS allow_all_units ON public.units;
+
+CREATE POLICY units_select ON public.units
+  FOR SELECT
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY units_insert ON public.units
+  FOR INSERT
+  WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY units_update ON public.units
+  FOR UPDATE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY units_delete ON public.units
+  FOR DELETE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role)
+    )
+  );
+
+-- =====================================================================
+-- 3) contracts — drop allow_all + policies tenant-aware
+-- =====================================================================
+DROP POLICY IF EXISTS allow_all_contracts ON public.contracts;
+
+CREATE POLICY contracts_select ON public.contracts
+  FOR SELECT
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY contracts_insert ON public.contracts
+  FOR INSERT
+  WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY contracts_update ON public.contracts
+  FOR UPDATE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY contracts_delete ON public.contracts
+  FOR DELETE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role)
+    )
+  );
+
+-- =====================================================================
+-- 4) payments — drop allow_all + policies tenant-aware
+-- =====================================================================
+DROP POLICY IF EXISTS allow_all_payments ON public.payments;
+
+CREATE POLICY payments_select ON public.payments
+  FOR SELECT
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY payments_insert ON public.payments
+  FOR INSERT
+  WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY payments_update ON public.payments
+  FOR UPDATE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY payments_delete ON public.payments
+  FOR DELETE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role)
+    )
+  );
+
+-- =====================================================================
+-- 5) incidents — drop allow_all + policies tenant-aware
+-- =====================================================================
+DROP POLICY IF EXISTS allow_all_incidents ON public.incidents;
+
+CREATE POLICY incidents_select ON public.incidents
+  FOR SELECT
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY incidents_insert ON public.incidents
+  FOR INSERT
+  WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY incidents_update ON public.incidents
+  FOR UPDATE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY incidents_delete ON public.incidents
+  FOR DELETE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role)
+    )
+  );
+
+-- =====================================================================
+-- 6) occupants — drop allow_all + policies tenant-aware
+-- =====================================================================
+DROP POLICY IF EXISTS allow_all_occupants ON public.occupants;
+
+CREATE POLICY occupants_select ON public.occupants
+  FOR SELECT
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY occupants_insert ON public.occupants
+  FOR INSERT
+  WITH CHECK (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY occupants_update ON public.occupants
+  FOR UPDATE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role, 'pm_operator'::member_role)
+    )
+  );
+
+CREATE POLICY occupants_delete ON public.occupants
+  FOR DELETE
+  USING (
+    org_id IN (
+      SELECT om.org_id FROM public.org_members om
+      WHERE om.user_id = auth.uid()
+        AND om.role IN ('pm_owner'::member_role, 'pm_admin'::member_role)
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
## Sprint 3 / S9 — Hotfixes post-merge

Fran reportó al probar producción tras el merge de Sprint 3:
- iOS Safari mostraba 404 / pantalla en blanco al entrar a `/`
- Sidebar decía "Sin PM Company / Empezar onboarding" pese a tener org creada
- `/units` mostraba 4 unidades fantasma (D101-D104) sin filtrar por org
- Onboarding wizard fallaba con `El slug "baw-operations" ya existe`

### Causa raíz (3 bugs encadenados)

**1. RLS de `organizations` con 0 políticas.** La tabla tenía RLS habilitado pero ninguna policy → todo SELECT con anon key devolvía vacío. `useActiveContext` hacía join `org_members → organizations(...)` y el campo `organizations` siempre venía null → `orgList = []` → `WorkspaceSwitcher` mostraba "Sin PM Company".

**2. Tablas operativas con policies legacy `allow_all_*` (qual=true).** `units`, `contracts`, `payments`, `incidents`, `occupants` tenían políticas que no filtraban absolutamente nada — leak total cross-tenant. Por eso `/units` mostraba todo.

**3. `/api/onboarding` no era idempotente.** Cuando el wizard se reabría tras un onboarding exitoso (común porque por bug #1 el user creía que faltaba configurar), intentaba re-crear la org con el mismo slug → 23505 unique violation.

### Cambios

**Migration `20260429_03_rls_hotfix_s9.sql`** (ya aplicada al proyecto Supabase `zlcgxmllaeweypyodvzk`):
- `organizations`: nuevas policies `organizations_select` (members del org) y `organizations_update` (pm_owner/pm_admin). INSERT/DELETE quedan para service-role como hasta ahora.
- `units`, `contracts`, `payments`, `incidents`, `occupants`: drop `allow_all_*` y crear cuatro policies por tabla (SELECT/INSERT/UPDATE/DELETE) con filtro `org_id IN (SELECT om.org_id FROM org_members om WHERE om.user_id = auth.uid())` y los mismos role gates que `buildings`/`property_owners`.

**`src/app/api/onboarding/route.ts`**:
- Antes de insertar la org, chequea si el user ya tiene `org_member`. Si sí, retorna 200 con `already_onboarded: true` y los datos de la org existente. Evita duplicar slug y permite que el frontend redirija a Mission Control en vez de mostrar error.

**`src/lib/useActiveContext.ts`**:
- Lookup en dos pasos: primero `org_members` por `user_id`, luego `organizations` por `id IN (...)`. No depende del join. Si una de las dos queries falla por RLS, queda loggeado y el comportamiento es soft-fail.

**`src/app/page.tsx`** (Mission Control):
- Espera a que `useActiveContext` termine antes de hacer queries.
- Filtra todas las queries (`units`, `contracts`, `payments`, `incidents`) por `activeOrgId`.
- Empty state honesto: solo redirige a onboarding si `orgs.length === 0` (no si simplemente no hay datos cargados).
- Soluciona el "404" de iOS, que en realidad era el Promise.all colapsando por una query rota.

### Validación

- ✅ `npx tsc --noEmit` verde
- ✅ `npm run build` verde (Next.js 14, todas las rutas compilan)
- ✅ Migración aplicada en Supabase. Verificación post-aplicación:
  | Tabla | Policies post-fix |
  |---|---|
  | `organizations` | 2 (select, update) |
  | `units` | 4 (select, insert, update, delete) |
  | `contracts` | 4 |
  | `payments` | 4 |
  | `incidents` | 4 |
  | `occupants` | 4 |

### Pendientes (NO en este PR, para Sprint 4)

- Refactor real `getOrgId()` (S4-1) — sigue siendo best-effort.
- E2E test multi-tenant con 2 users distintos para validar aislamiento.
- Aplicar mismo patrón de filter `activeOrgId` a las páginas individuales (`/units`, `/contracts`, etc.) — en este PR solo Mission Control.

### Deploy

Vercel auto-desplegará al hacer merge a `main`. **No mergear sin revisión humana.**
