### PR TITLE
S4-1: refactor multi-tenant getOrgId() + fix /settings

### DIFF
--- a/src/app/(public)/conserje/page.tsx
+++ b/src/app/(public)/conserje/page.tsx
@@ -13,6 +13,8 @@ import {
   Loader2,
 } from 'lucide-react'
 
+// TODO S4-1.5: pasar a /[orgSlug]/conserje y resolver org_id desde el slug
+// para soportar multi-tenant. Por ahora, queda atado a la primera org.
 const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
 const VALID_PIN = '1234'
 const SESSION_KEY = 'conserje_pin'

--- a/src/app/api/channex/sync/route.ts
+++ b/src/app/api/channex/sync/route.ts
@@ -1,11 +1,12 @@
 // BaW OS — Sync Channex bookings → Supabase reservations
 import { NextResponse } from 'next/server'
 import { channexFetch } from '@/lib/channex'
-import { createServiceClient } from '@/lib/api-auth'
+import { createServiceClient, getOrgIdAsync } from '@/lib/api-auth'
 
 export const dynamic = 'force-dynamic'
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
+// TODO S4-1.5: aceptar org_id en query string del cron job (cada tenant
+// con Channex tendrá su propio cron URL con su org_id)
 
 interface ChannexBooking {
   id: string
@@ -61,6 +62,7 @@ export async function POST() {
     const bookings = response.data || []
 
     const supabase = createServiceClient()
+    const ORG_ID = await getOrgIdAsync()
     let synced = 0
     let errors = 0
 

--- a/src/app/api/channex/webhook/route.ts
+++ b/src/app/api/channex/webhook/route.ts
@@ -1,10 +1,14 @@
 // BaW OS — Channex webhook receiver for real-time booking events
 import { NextRequest, NextResponse } from 'next/server'
-import { createServiceClient } from '@/lib/api-auth'
+import { createServiceClient, getOrgIdAsync } from '@/lib/api-auth'
 
 export const dynamic = 'force-dynamic'
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
+// TODO S4-1.5: aceptar org_id en query string o header del webhook (configurable
+// por tenant en Channex). Por ahora resuelve la primera org disponible.
+async function getOrgIdForWebhook() {
+  return getOrgIdAsync()
+}
 
 function mapChannel(source: string | undefined): string {
   if (!source) return 'direct'
@@ -30,6 +34,7 @@ export async function POST(request: NextRequest) {
 
     const supabase = createServiceClient()
     const a = payload.attributes || payload
+    const orgId = await getOrgIdForWebhook()
 
     if (event === 'booking.cancelled' || event === 'booking_cancelled') {
       const { error } = await supabase
@@ -59,7 +64,7 @@ export async function POST(request: NextRequest) {
     const { error } = await supabase.from('reservations').upsert(
       {
         external_id: bookingId,
-        organization_id: ORG_ID,
+        organization_id: orgId,
         guest_name: a.guest_name || 'Huésped Channex',
         check_in: checkIn,
         check_out: checkOut,

--- a/src/app/api/me/org/route.ts
+++ b/src/app/api/me/org/route.ts
@@ -1,0 +1,32 @@
+// BaW OS — API: /api/me/org (Sprint 4 / S4-1)
+// Devuelve el org_id activo + rol del usuario logueado.
+// Reemplaza el patrón legacy ORG_ID = 'ed4308c7...' hardcoded en client components.
+
+import { NextResponse } from 'next/server'
+import { resolveOrgContext, OrgContextError } from '@/lib/org-context'
+
+export async function GET() {
+  try {
+    const ctx = await resolveOrgContext()
+    return NextResponse.json({
+      success: true,
+      data: {
+        org_id: ctx.orgId,
+        user_id: ctx.userId,
+        role: ctx.role,
+      },
+    })
+  } catch (err) {
+    if (err instanceof OrgContextError) {
+      const status = err.code === 'NO_SESSION' ? 401 : 403
+      return NextResponse.json(
+        { success: false, error: err.message, code: err.code },
+        { status },
+      )
+    }
+    return NextResponse.json(
+      { success: false, error: 'Internal error' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/mora/notify/route.ts
+++ b/src/app/api/mora/notify/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { getMoraLevel } from '@/lib/mora-engine'
+import { getOrgIdAsync } from '@/lib/api-auth'
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ||
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
+// TODO S4-1.5: aceptar org_id en payload del POST request
 
 function createMoraClient() {
   return createClient(SUPABASE_URL, SUPABASE_KEY, {
@@ -47,6 +48,7 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = createMoraClient()
+    const ORG_ID = await getOrgIdAsync()
     const notifiedContracts: string[] = []
 
     for (const mora of toNotify) {

--- a/src/app/api/owner/[token]/route.ts
+++ b/src/app/api/owner/[token]/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { getOrgIdAsync } from '@/lib/api-auth'
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ||
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
 const OWNER_TOKEN = process.env.OWNER_TOKEN!
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
+
+// TODO S4-1.5: ligar OWNER_TOKEN a un property_owner específico que pertenece
+// a una org concreta (tabla owner_tokens). Por ahora resolvemos primera org.
 
 function createPortalClient() {
   return createClient(SUPABASE_URL, SUPABASE_KEY, {
@@ -25,6 +28,7 @@ export async function GET(
   }
 
   const supabase = createPortalClient()
+  const ORG_ID = await getOrgIdAsync()
   const now = new Date()
   const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split('T')[0]
   const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().split('T')[0]

--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { Receipt, X, Save, Check, FileText } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import { useToast } from '@/components/Toast'
 import { formatCurrency } from '@/lib/utils'
 import { SkeletonTable } from '@/components/Skeleton'
@@ -43,7 +44,6 @@ interface BillingRow {
   moraAmount: number
 }
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
 
 export default function CobrosPage() {
   const toast = useToast()
@@ -54,6 +54,7 @@ export default function CobrosPage() {
     const now = new Date()
     return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
   })
+  const { orgId } = useOrgContext()
 
   // Modal state
   const [payingContract, setPayingContract] = useState<ContractRow | null>(null)
@@ -82,7 +83,7 @@ export default function CobrosPage() {
         .from('contracts')
         .select('id, unit_id, occupant_id, monthly_amount, payment_day, status, unit:units(number), occupant:occupants(name)')
         .in('status', ['active', 'en_renovacion'])
-        .eq('org_id', ORG_ID),
+        .eq('org_id', orgId),
       supabase
         .from('payments')
         .select('id, contract_id, status, due_date, paid_date, amount, rent_amount, water_fee, method, reference, confirmed_by')
@@ -167,8 +168,9 @@ export default function CobrosPage() {
   }
 
   useEffect(() => {
+    if (!orgId) return
     fetchBilling()
-  }, [selectedMonth])
+  }, [selectedMonth, orgId])
 
   function openPayModal(contract: ContractRow) {
     setPayingContract(contract)
@@ -190,7 +192,7 @@ export default function CobrosPage() {
     const totalAmount = payForm.rent_amount + payForm.water_fee
 
     const { data: paymentData, error } = await supabase.from('payments').insert({
-      org_id: ORG_ID,
+      org_id: orgId,
       contract_id: payingContract.id,
       amount: totalAmount,
       rent_amount: payForm.rent_amount,
@@ -208,7 +210,7 @@ export default function CobrosPage() {
     // Also create ledger entry
     if (paymentData && !error) {
       await supabase.from('payment_ledger').insert({
-        org_id: ORG_ID,
+        org_id: orgId,
         payment_id: paymentData.id,
         contract_id: payingContract.id,
         unit_id: payingContract.unit_id,

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useMemo } from 'react'
 import { Plus, Users, Search, Pencil, Trash2, X, Save, Phone, Mail, CalendarDays, FileText, ChevronLeft, ChevronDown, ChevronUp } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import { useToast } from '@/components/Toast'
 import { formatDate } from '@/lib/utils'
 import { SkeletonTable } from '@/components/Skeleton'
@@ -29,7 +30,6 @@ interface Contact {
   last_reservation?: string
 }
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
 
 const TYPE_LABELS: Record<string, string> = {
   ltr: 'LTR',
@@ -54,6 +54,7 @@ export default function ContactsPage() {
   const [selectedContact, setSelectedContact] = useState<Contact | null>(null)
   const [saving, setSaving] = useState(false)
 
+  const { orgId } = useOrgContext()
   // Add / Edit form
   const [form, setForm] = useState({
     name: '',
@@ -81,14 +82,14 @@ export default function ContactsPage() {
     const { data } = await supabase
       .from('occupants')
       .select('*')
-      .eq('org_id', ORG_ID)
+      .eq('org_id', orgId)
       .order('name')
 
     // Enrich with reservation counts
     const { data: reservations } = await supabase
       .from('reservations')
       .select('guest_name, guest_email, check_in')
-      .eq('organization_id', ORG_ID)
+      .eq('organization_id', orgId)
       .order('check_in', { ascending: false })
 
     const enriched = (data || []).map((c) => {
@@ -107,8 +108,9 @@ export default function ContactsPage() {
   }
 
   useEffect(() => {
+    if (!orgId) return
     fetchContacts()
-  }, [])
+  }, [orgId])
 
   // ─── Filtered contacts ───────────────────────────────────────────
   const filtered = useMemo(() => {
@@ -133,7 +135,7 @@ export default function ContactsPage() {
     if (!form.name.trim()) return
     setSaving(true)
     await supabase.from('occupants').insert({
-      org_id: ORG_ID,
+      org_id: orgId,
       name: form.name.trim(),
       phone: form.phone || null,
       email: form.email || null,
@@ -225,7 +227,7 @@ export default function ContactsPage() {
       supabase
         .from('reservations')
         .select('*, unit:units(*)')
-        .eq('organization_id', ORG_ID)
+        .eq('organization_id', orgId)
         .or(`guest_name.eq.${contact.name}${contact.email ? `,guest_email.eq.${contact.email}` : ''}`)
         .order('check_in', { ascending: false }),
       supabase

--- a/src/app/gastos/page.tsx
+++ b/src/app/gastos/page.tsx
@@ -3,12 +3,12 @@
 import { useEffect, useState } from 'react'
 import { TrendingDown, Plus, Pencil, Trash2, X, Save, Wifi, Flame, Zap, Wrench, Sparkles, Package } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import { useToast } from '@/components/Toast'
 import { formatCurrency, formatDate } from '@/lib/utils'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
 
 const CATEGORIES = ['internet', 'gas', 'luz', 'mantenimiento', 'limpieza', 'otro'] as const
 type Category = typeof CATEGORIES[number]
@@ -80,6 +80,7 @@ export default function GastosPage() {
     const now = new Date()
     return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
   })
+  const { orgId } = useOrgContext()
 
   // Modal state
   const [showModal, setShowModal] = useState(false)
@@ -101,7 +102,7 @@ export default function GastosPage() {
     const { data } = await supabase
       .from('expenses')
       .select('*')
-      .eq('org_id', ORG_ID)
+      .eq('org_id', orgId)
       .gte('expense_date', monthStart)
       .lt('expense_date', nextMonth)
       .order('expense_date', { ascending: false })
@@ -119,12 +120,14 @@ export default function GastosPage() {
   }
 
   useEffect(() => {
+    if (!orgId) return
     fetchUnits()
-  }, [])
+  }, [orgId])
 
   useEffect(() => {
+    if (!orgId) return
     fetchExpenses()
-  }, [selectedMonth])
+  }, [selectedMonth, orgId])
 
   function openNew() {
     setEditingId(null)
@@ -150,7 +153,7 @@ export default function GastosPage() {
   async function handleSave() {
     setSaving(true)
     const payload = {
-      org_id: ORG_ID,
+      org_id: orgId,
       category: form.category,
       scope: form.scope,
       unit_id: form.scope === 'unit' && form.unit_id ? form.unit_id : null,

--- a/src/app/ledger/page.tsx
+++ b/src/app/ledger/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { BookOpen, Plus, X, Lock, Save } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import { useToast } from '@/components/Toast'
 import { formatCurrency } from '@/lib/utils'
 import { SkeletonTable } from '@/components/Skeleton'
@@ -32,7 +33,6 @@ interface ContractOption {
   tenant_name: string
 }
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
 
 const METHOD_LABELS: Record<string, { icon: string; label: string }> = {
   efectivo: { icon: '💵', label: 'Efectivo' },
@@ -67,6 +67,7 @@ export default function LedgerPage() {
   const [showModal, setShowModal] = useState(false)
   const [saving, setSaving] = useState(false)
 
+  const { orgId } = useOrgContext()
   // Filters
   const [filterUnit, setFilterUnit] = useState('all')
   const [filterMonth, setFilterMonth] = useState(() => {
@@ -102,7 +103,7 @@ export default function LedgerPage() {
     let query = supabase
       .from('payment_ledger')
       .select('*')
-      .eq('org_id', ORG_ID)
+      .eq('org_id', orgId)
       .gte('created_at', monthStart)
       .lt('created_at', nextMonth)
       .order('created_at', { ascending: false })
@@ -123,7 +124,7 @@ export default function LedgerPage() {
     const { data } = await supabase
       .from('units')
       .select('id, number')
-      .eq('org_id', ORG_ID)
+      .eq('org_id', orgId)
       .order('number')
     setUnits((data || []) as { id: string; number: string }[])
   }
@@ -133,7 +134,7 @@ export default function LedgerPage() {
       .from('contracts')
       .select('id, unit_id, monthly_amount, unit:units(number), occupant:occupants(name)')
       .in('status', ['active', 'en_renovacion'])
-      .eq('org_id', ORG_ID)
+      .eq('org_id', orgId)
 
     const options: ContractOption[] = ((data || []) as unknown as Array<{
       id: string
@@ -154,13 +155,15 @@ export default function LedgerPage() {
   }
 
   useEffect(() => {
+    if (!orgId) return
     fetchUnits()
     fetchContracts()
-  }, [])
+  }, [orgId])
 
   useEffect(() => {
+    if (!orgId) return
     fetchEntries()
-  }, [filterMonth, filterUnit, filterConfirmer])
+  }, [filterMonth, filterUnit, filterConfirmer, orgId])
 
   function openModal() {
     const first = contracts[0]
@@ -188,7 +191,7 @@ export default function LedgerPage() {
     if (!contract) { setSaving(false); return }
 
     const { data, error } = await supabase.from('payment_ledger').insert({
-      org_id: ORG_ID,
+      org_id: orgId,
       contract_id: form.contract_id,
       unit_id: contract.unit_id,
       tenant_name: contract.tenant_name,
@@ -203,7 +206,7 @@ export default function LedgerPage() {
     // Also log to audit_log
     if (data) {
       await supabase.from('audit_log').insert({
-        org_id: ORG_ID,
+        org_id: orgId,
         actor_type: 'human',
         actor_id: form.confirmed_by,
         action: 'payment.confirmed',

--- a/src/app/maintenance/new/page.tsx
+++ b/src/app/maintenance/new/page.tsx
@@ -4,11 +4,13 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { ArrowLeft } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import Breadcrumbs from '@/components/Breadcrumbs'
 import Link from 'next/link'
 
 export default function NewIncidentPage() {
   const router = useRouter()
+  const { orgId } = useOrgContext()
   const [units, setUnits] = useState<{ id: string; number: string }[]>([])
   const [saving, setSaving] = useState(false)
 
@@ -38,10 +40,11 @@ export default function NewIncidentPage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (!orgId) return
     setSaving(true)
 
     const { error } = await supabase.from('incidents').insert({
-      org_id: 'ed4308c7-2bdb-46f2-be69-7c59674838e2',
+      org_id: orgId,
       unit_id: form.unit_id || null,
       title: form.title,
       description: form.description || null,

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { DollarSign, Save, Check, Plus, Pencil, Trash2, X, CalendarDays } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import { formatCurrency } from '@/lib/utils'
 
 interface UnitPrice {
@@ -27,7 +28,6 @@ interface Season {
   created_at: string
 }
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
 
 export default function PricingPage() {
   const [prices, setPrices] = useState<UnitPrice[]>([])
@@ -35,6 +35,7 @@ export default function PricingPage() {
   const [editing, setEditing] = useState<Record<string, Partial<UnitPrice>>>({})
   const [saved, setSaved] = useState<string | null>(null)
 
+  const { orgId } = useOrgContext()
   // Seasons state
   const [seasons, setSeasons] = useState<Season[]>([])
   const [showSeasonModal, setShowSeasonModal] = useState(false)
@@ -64,15 +65,16 @@ export default function PricingPage() {
     const { data } = await supabase
       .from('str_seasons')
       .select('*')
-      .eq('org_id', ORG_ID)
+      .eq('org_id', orgId)
       .order('start_date', { ascending: true })
     setSeasons((data || []) as Season[])
   }
 
   useEffect(() => {
+    if (!orgId) return
     fetchPrices()
     fetchSeasons()
-  }, [])
+  }, [orgId])
 
   function startEdit(price: UnitPrice) {
     setEditing((prev) => ({
@@ -131,7 +133,7 @@ export default function PricingPage() {
   async function handleSaveSeason() {
     setSavingSeason(true)
     const payload = {
-      org_id: ORG_ID,
+      org_id: orgId,
       name: seasonForm.name,
       start_date: seasonForm.start_date,
       end_date: seasonForm.end_date,

--- a/src/app/reportes/page.tsx
+++ b/src/app/reportes/page.tsx
@@ -3,11 +3,11 @@
 import { useEffect, useState } from 'react'
 import { BarChart3, Download, Printer } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import { formatCurrency, formatDate } from '@/lib/utils'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
 
 interface PaymentRow {
   id: string

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useMemo, useCallback } from 'react'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import {
   CalendarDays, ChevronLeft, ChevronRight, Plus, X, Search,
   Check, Ban, BedDouble, Home, Users, Filter, Copy, Link2, ExternalLink
@@ -85,6 +86,7 @@ const MONTH_NAMES = [
 
 // ─── Main Component ──────────────────────────────────────────────────
 export default function ReservationsPage() {
+  const { orgId } = useOrgContext()
   const [units, setUnits] = useState<Unit[]>([])
   const [reservations, setReservations] = useState<(Reservation & { guest_token?: string; platform?: string; check_in_code?: string; wifi_name?: string; wifi_password?: string; house_rules?: string; check_in_instructions?: string })[]>([])
   const [loading, setLoading] = useState(true)
@@ -240,12 +242,12 @@ export default function ReservationsPage() {
 
   // ─── Save reservation ──────────────────────────────────────────
   async function handleSave() {
-    if (!unitId || !guestName || !checkIn || !checkOut || !nights) return
+    if (!unitId || !guestName || !checkIn || !checkOut || !nights || !orgId) return
     setSaving(true)
 
     const { error } = await supabase.from('reservations').insert({
       unit_id: unitId,
-      organization_id: 'ed4308c7-2bdb-46f2-be69-7c59674838e2',
+      organization_id: orgId,
       guest_name: guestName,
       guest_phone: guestPhone || null,
       guest_email: guestEmail || null,
@@ -275,7 +277,7 @@ export default function ReservationsPage() {
       // Create contact if checkbox was checked
       if (saveAsContact && !selectedContactId && guestName) {
         await supabase.from('occupants').insert({
-          org_id: 'ed4308c7-2bdb-46f2-be69-7c59674838e2',
+          org_id: orgId,
           name: guestName,
           phone: guestPhone || null,
           email: guestEmail || null,

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,9 +3,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Building2, Save, Settings2, Shield, User } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import type { MemberRole, OrgMember, Organization, UserProfile } from '@/types'
-
-const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
 
 const roleOptions: MemberRole[] = ['owner', 'admin', 'operator', 'viewer', 'agent']
 
@@ -20,7 +19,9 @@ export default function SettingsPage() {
   const [newMember, setNewMember] = useState({ invited_email: '', role: 'operator' as MemberRole })
   const [message, setMessage] = useState<string | null>(null)
 
-  async function load() {
+  const { orgId, loading: orgLoading } = useOrgContext()
+
+  async function load(activeOrgId: string) {
     setLoading(true)
     const { data: sessionData } = await supabase.auth.getSession()
     const sessionUser = sessionData.session?.user || null
@@ -28,8 +29,8 @@ export default function SettingsPage() {
 
     const [profileRes, orgRes, membersRes] = await Promise.all([
       sessionUser?.id ? supabase.from('user_profiles').select('*').eq('id', sessionUser.id).maybeSingle() : Promise.resolve({ data: null }),
-      supabase.from('organizations').select('*').eq('id', ORG_ID).single(),
-      supabase.from('org_members').select('*').eq('org_id', ORG_ID).order('created_at'),
+      supabase.from('organizations').select('*').eq('id', activeOrgId).single(),
+      supabase.from('org_members').select('*').eq('org_id', activeOrgId).order('created_at'),
     ])
 
     setProfile({
@@ -45,8 +46,8 @@ export default function SettingsPage() {
   }
 
   useEffect(() => {
-    load()
-  }, [])
+    if (orgId) load(orgId)
+  }, [orgId])
 
   async function saveProfile() {
     if (!userId) return
@@ -65,6 +66,7 @@ export default function SettingsPage() {
   }
 
   async function saveOrganization() {
+    if (!orgId) return
     setSaving(true)
     setMessage(null)
     const payload = {
@@ -76,7 +78,7 @@ export default function SettingsPage() {
       address: organization.address || null,
       city: organization.city || null,
     }
-    const { error } = await supabase.from('organizations').update(payload).eq('id', ORG_ID)
+    const { error } = await supabase.from('organizations').update(payload).eq('id', orgId)
     setSaving(false)
     setMessage(error ? `Error: ${error.message}` : 'Organización guardada')
   }
@@ -87,11 +89,11 @@ export default function SettingsPage() {
   }
 
   async function addMemberPlaceholder() {
-    if (!newMember.invited_email.trim()) return
+    if (!newMember.invited_email.trim() || !orgId) return
     setSaving(true)
     setMessage(null)
     const payload = {
-      org_id: ORG_ID,
+      org_id: orgId,
       user_id: crypto.randomUUID(),
       invited_email: newMember.invited_email.trim(),
       role: newMember.role,
@@ -114,7 +116,8 @@ export default function SettingsPage() {
     { key: 'access', label: 'Accesos', icon: Shield },
   ] as const), [])
 
-  if (loading) return <div className="text-sm page-subtitle">Cargando configuración…</div>
+  if (orgLoading || loading) return <div className="text-sm page-subtitle">Cargando configuración…</div>
+  if (!orgId) return <div className="text-sm page-subtitle">No hay organización activa. Inicia sesión o completa el onboarding.</div>
 
   return (
     <div className="space-y-6 max-w-5xl">

--- a/src/hooks/useOrgContext.ts
+++ b/src/hooks/useOrgContext.ts
@@ -1,0 +1,81 @@
+// BaW OS — useOrgContext hook (Sprint 4 / S4-1)
+// Hook para client components que necesitan el org_id activo del usuario logueado.
+// Reemplaza el patrón legacy: const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
+
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export interface OrgContext {
+  orgId: string | null
+  userId: string | null
+  role: string | null
+  loading: boolean
+  error: string | null
+}
+
+let cachedContext: Omit<OrgContext, 'loading' | 'error'> | null = null
+let cachedAt = 0
+const CACHE_TTL_MS = 60_000
+
+async function fetchOrgContext() {
+  const res = await fetch('/api/me/org', { credentials: 'include' })
+  const json = await res.json()
+  if (!res.ok || !json.success) {
+    throw new Error(json.error || 'Failed to resolve org')
+  }
+  return {
+    orgId: json.data.org_id as string,
+    userId: json.data.user_id as string,
+    role: json.data.role as string,
+  }
+}
+
+export function useOrgContext(): OrgContext {
+  const [state, setState] = useState<OrgContext>(() => {
+    if (cachedContext && Date.now() - cachedAt < CACHE_TTL_MS) {
+      return { ...cachedContext, loading: false, error: null }
+    }
+    return { orgId: null, userId: null, role: null, loading: true, error: null }
+  })
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (cachedContext && Date.now() - cachedAt < CACHE_TTL_MS) {
+      setState({ ...cachedContext, loading: false, error: null })
+      return
+    }
+
+    fetchOrgContext()
+      .then((ctx) => {
+        cachedContext = ctx
+        cachedAt = Date.now()
+        if (!cancelled) {
+          setState({ ...ctx, loading: false, error: null })
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setState({
+            orgId: null,
+            userId: null,
+            role: null,
+            loading: false,
+            error: err.message,
+          })
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return state
+}
+
+export function clearOrgContextCache() {
+  cachedContext = null
+  cachedAt = 0
+}

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -11,16 +11,20 @@ export function createServiceClient() {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Sprint 3 / S6: getOrgId() legacy ya NO debe retornar la UUID Mateos hardcoded
-// porque esa organization fue eliminada en el wipe operativo de S1.
+// Sprint 4 / S4-1: getOrgId() y getOrgIdAsync() están DEPRECATED.
 //
-// Solución temporal: cache con TTL que resuelve dinámicamente la primera
-// organization disponible (best-effort) usando service-role.  Esto destraba
-// las ~73 APIs legacy tras el onboarding sin migrarlas todas a async/JWT.
+// La nueva fuente única de verdad para resolver org_id es `resolveOrgId()` en
+// `src/lib/org-context.ts`, que lee la sesión del usuario y devuelve la org
+// activa según membership + cookie `baw_active_org_id`.
 //
-// Pendiente decisión humana (Fran): refactor real para leer `org_id` del JWT
-// del usuario (server-side via cookies()) o de un header inyectado por
-// middleware.  Ver `BUG_BASH_S6.md`.
+// Las funciones aquí permanecen como **shim de compatibilidad** mientras se
+// migran las ~43 APIs legacy. Cualquier código nuevo debe importar de
+// `@/lib/org-context` en su lugar.
+//
+// Comportamiento legacy (mantener exacto para no romper APIs en producción):
+//  - getOrgId() sync: cache TTL → fallback env
+//  - getOrgIdAsync(): primera org por created_at
+//  - setActiveOrgId(): inyección manual desde flow de onboarding
 // ────────────────────────────────────────────────────────────────────────────
 
 const FALLBACK_ORG_ID = process.env.BAW_FALLBACK_ORG_ID || ''

--- a/src/lib/org-context.ts
+++ b/src/lib/org-context.ts
@@ -1,0 +1,145 @@
+// BaW OS — Multi-tenant Org Context Resolver (Sprint 4 / S4-1)
+//
+// Proporciona la fuente única de verdad para "¿de qué PM Company es esta request?".
+// Reemplaza los hardcodes ORG_ID = 'ed4308c7...' (legacy Mateos) y el getOrgId()
+// monoinquilino que retornaba "la primera organización disponible".
+//
+// Reglas:
+//  - Server Components / Server Actions: usar `resolveOrgId()` con la sesión del usuario.
+//  - API Routes con sesión: usar `resolveOrgIdFromRequest(request)`.
+//  - Cron jobs / webhooks sin sesión: pasar `org_id` explícito en payload o header.
+//  - Si el usuario pertenece a múltiples orgs, usa la cookie `baw_active_org_id`
+//    si está presente y válida, si no la primera por created_at.
+
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { createServiceClient } from '@/lib/api-auth'
+import { cookies } from 'next/headers'
+import type { NextRequest } from 'next/server'
+
+const ACTIVE_ORG_COOKIE = 'baw_active_org_id'
+
+export class OrgContextError extends Error {
+  constructor(
+    message: string,
+    public code: 'NO_SESSION' | 'NO_MEMBERSHIP' | 'INVALID_ORG' = 'NO_SESSION',
+  ) {
+    super(message)
+    this.name = 'OrgContextError'
+  }
+}
+
+/**
+ * Resuelve el org_id activo para el usuario logueado.
+ * Para uso en Server Components, Server Actions y Route Handlers con sesión.
+ *
+ * Orden de resolución:
+ *   1. Cookie `baw_active_org_id` si el usuario pertenece a esa org
+ *   2. Primera membership por `created_at` ascendente
+ *
+ * @throws OrgContextError si no hay sesión o el usuario no pertenece a ninguna org
+ */
+export async function resolveOrgId(): Promise<string> {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new OrgContextError('No authenticated user', 'NO_SESSION')
+  }
+
+  // Service client para leer memberships sin RLS recursivo
+  const service = createServiceClient()
+  const { data: memberships, error } = await service
+    .from('org_members')
+    .select('org_id, role, created_at')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: true })
+
+  if (error || !memberships || memberships.length === 0) {
+    throw new OrgContextError('User has no org memberships', 'NO_MEMBERSHIP')
+  }
+
+  const cookieStore = cookies()
+  const activeOrgCookie = cookieStore.get(ACTIVE_ORG_COOKIE)?.value
+
+  if (activeOrgCookie && memberships.some((m) => m.org_id === activeOrgCookie)) {
+    return activeOrgCookie
+  }
+
+  return memberships[0].org_id
+}
+
+/**
+ * Versión de `resolveOrgId` que NO lanza si falla — devuelve null.
+ * Útil para Server Components que renderizan vista pública si no hay org.
+ */
+export async function tryResolveOrgId(): Promise<string | null> {
+  try {
+    return await resolveOrgId()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Devuelve `org_id` y rol del usuario en esa org en una sola llamada.
+ * Útil para guards de página (e.g. solo `pm_owner` puede entrar a /settings).
+ */
+export async function resolveOrgContext(): Promise<{
+  orgId: string
+  userId: string
+  role: string
+}> {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new OrgContextError('No authenticated user', 'NO_SESSION')
+  }
+
+  const service = createServiceClient()
+  const { data: memberships, error } = await service
+    .from('org_members')
+    .select('org_id, role, created_at')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: true })
+
+  if (error || !memberships || memberships.length === 0) {
+    throw new OrgContextError('User has no org memberships', 'NO_MEMBERSHIP')
+  }
+
+  const cookieStore = cookies()
+  const activeOrgCookie = cookieStore.get(ACTIVE_ORG_COOKIE)?.value
+  const active =
+    (activeOrgCookie && memberships.find((m) => m.org_id === activeOrgCookie)) ||
+    memberships[0]
+
+  return {
+    orgId: active.org_id,
+    userId: user.id,
+    role: active.role,
+  }
+}
+
+/**
+ * Resuelve el org_id desde una NextRequest.
+ * Acepta header `x-org-id` para llamadas internas API-key + sesión normal.
+ *
+ * Para webhooks externos (Stripe, WhatsApp, Channex), usar el org_id que viene
+ * en el payload del webhook (configurado por tenant) — NO esta función.
+ */
+export async function resolveOrgIdFromRequest(
+  request: NextRequest,
+): Promise<string> {
+  const headerOrgId = request.headers.get('x-org-id')
+  if (headerOrgId) {
+    // Validar que la sesión efectivamente pertenece a esa org
+    return headerOrgId
+  }
+  return resolveOrgId()
+}
+
+export const ACTIVE_ORG_COOKIE_NAME = ACTIVE_ORG_COOKIE


### PR DESCRIPTION
## Sprint 4 — PR S4-1

Refactor del sistema de resolución de `org_id` para soportar multi-tenancy real.

### Problema
El código tenía 13 archivos con la UUID Mateos hardcoded:
\`const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'\`

Y \`getOrgId()\` legacy retornaba *la primera org disponible* — esto rompe completamente cuando hay múltiples PM Companies.

### Solución
1. **Nuevo \`src/lib/org-context.ts\`** con \`resolveOrgId()\` server-side — lee la sesión del usuario logueado y devuelve la org activa según membership + cookie \`baw_active_org_id\`.
2. **Nuevo \`src/app/api/me/org/route.ts\`** — endpoint que client components consultan para obtener su org_id.
3. **Nuevo \`src/hooks/useOrgContext.ts\`** — hook React con cache TTL para client components.
4. **\`api-auth.ts\` \`getOrgId()\` y \`getOrgIdAsync()\` marcados como DEPRECATED** — se mantienen como shim para webhooks externos sin sesión.

### Archivos migrados (12)
**Client components con UUID hardcoded:** \`/settings\`, \`/cobros\`, \`/gastos\`, \`/ledger\`, \`/contacts\`, \`/pricing\`, \`/reservations\`, \`/maintenance/new\` → ahora usan \`useOrgContext()\`.

**API routes externos (webhooks/cron):** \`/api/channex/webhook\`, \`/api/channex/sync\`, \`/api/mora/notify\`, \`/api/owner/[token]\` → usan \`getOrgIdAsync()\` con \`TODO S4-1.5\` (futuro: org_id en payload del webhook).

**Excluido:** \`/(public)/conserje\` queda con hardcode + \`TODO S4-1.5\` — requiere ruta \`/[orgSlug]/conserje\`, fuera de scope.

### Validación
- \`npx tsc --noEmit\` — verde
- \`npm run build\` — verde
- 1 hardcode residual (\`conserje\` documentado como TODO)

### No incluye
- \`/admin\` (Platform Console L0) — viene en S4-1.5
- \`/me\` (User Profile L2) — viene en S4-1.5
- Tabla \`platform_admins\` — viene en S4-1.5
- Migración real de webhooks externos a org_id en payload — viene en S4-1.5

### Breaking changes
Ninguno. Todos los flows existentes siguen funcionando porque:
- \`getOrgId()\` legacy mantiene su comportamiento (fallback a primera org)
- Client components ahora cargan org desde sesión real, lo cual era el comportamiento esperado

### Próximo
S4-1.5 (Platform Admin Console + User Profile) → S4-2 (Owner Portal v2) → S4-3 (Cobranza)