### PR TITLE
S4-1.5: Platform Admin Console (/admin) + User Profile (/me)

### DIFF
--- a/src/app/admin/admins/page.tsx
+++ b/src/app/admin/admins/page.tsx
@@ -1,0 +1,126 @@
+// BaW OS — Platform Admin · Admins — Sprint 4 / S4-1.5
+
+import { createServiceClient } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+
+type AdminRow = {
+  id: string
+  email: string
+  granted_by: string
+  granted_at: string
+  notes: string | null
+  user_id: string | null
+}
+
+async function getAdmins(): Promise<AdminRow[]> {
+  const service = createServiceClient()
+  const { data } = await service
+    .from('platform_admins')
+    .select('id, email, granted_by, granted_at, notes, user_id')
+    .order('granted_at', { ascending: true })
+  return data ?? []
+}
+
+export default async function PlatformAdminsPage() {
+  const admins = await getAdmins()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2
+          className="text-[18px] font-semibold mb-1"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Platform Admins (L0)
+        </h2>
+        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          Cuentas con acceso a /admin. Sólo ZXY humanos. Para añadir un nuevo
+          admin, ejecuta el INSERT en Supabase (audit trail vía granted_by).
+        </p>
+      </div>
+
+      <div
+        className="rounded-lg overflow-hidden"
+        style={{
+          backgroundColor: 'var(--baw-surface)',
+          border: '1px solid var(--baw-border)',
+        }}
+      >
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr
+              className="text-left"
+              style={{ borderBottom: '1px solid var(--baw-border)' }}
+            >
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Email
+              </th>
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Concedido por
+              </th>
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Fecha
+              </th>
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Estado
+              </th>
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Notas
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {admins.map((a) => (
+              <tr key={a.id} style={{ borderBottom: '1px solid var(--baw-border)' }}>
+                <td className="px-4 py-3" style={{ color: 'var(--baw-text)' }}>
+                  {a.email}
+                </td>
+                <td className="px-4 py-3" style={{ color: 'var(--baw-muted)' }}>
+                  {a.granted_by}
+                </td>
+                <td className="px-4 py-3" style={{ color: 'var(--baw-muted)' }}>
+                  {new Date(a.granted_at).toLocaleDateString('es-MX')}
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className="px-1.5 py-0.5 text-[10px] rounded uppercase tracking-wider"
+                    style={{
+                      backgroundColor: a.user_id
+                        ? 'rgba(34,197,94,0.15)'
+                        : 'rgba(234,179,8,0.15)',
+                      color: a.user_id ? '#86EFAC' : '#FDE68A',
+                      border: `1px solid ${
+                        a.user_id ? 'rgba(34,197,94,0.3)' : 'rgba(234,179,8,0.3)'
+                      }`,
+                    }}
+                  >
+                    {a.user_id ? 'Activo' : 'Pendiente login'}
+                  </span>
+                </td>
+                <td className="px-4 py-3" style={{ color: 'var(--baw-muted)' }}>
+                  {a.notes ?? '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div
+        className="rounded-lg p-4 text-[12px]"
+        style={{
+          backgroundColor: 'rgba(59,130,246,0.08)',
+          border: '1px solid rgba(59,130,246,0.2)',
+          color: 'var(--baw-muted)',
+        }}
+      >
+        <strong style={{ color: 'var(--baw-text)' }}>Nota arquitectónica:</strong>{' '}
+        Los agentes ZXY (Hugo-COS, Alicia-Ops, Conta-Beto, Maribel-Law,
+        Luis-Growth, Andres-Tech) NO tienen acceso L0 propio. Operan dentro del
+        tenant que los contrata vía rol <code>agent</code> en{' '}
+        <code>org_members</code>.
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/health/page.tsx
+++ b/src/app/admin/health/page.tsx
@@ -1,0 +1,155 @@
+// BaW OS — Platform Admin · Health — Sprint 4 / S4-1.5
+
+import { createServiceClient } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+
+type Check = {
+  name: string
+  status: 'ok' | 'warn' | 'error'
+  detail: string
+}
+
+async function runChecks(): Promise<Check[]> {
+  const checks: Check[] = []
+  const service = createServiceClient()
+
+  // 1. Tenants without owner
+  const { data: orgs } = await service.from('organizations').select('id, name, slug')
+  if (orgs) {
+    for (const o of orgs) {
+      const { data: owners } = await service
+        .from('org_members')
+        .select('user_id')
+        .eq('org_id', o.id)
+        .eq('role', 'pm_owner')
+      if (!owners || owners.length === 0) {
+        checks.push({
+          name: `Tenant sin owner: ${o.name}`,
+          status: 'error',
+          detail: `Org ${o.slug} no tiene ningún pm_owner asignado.`,
+        })
+      }
+    }
+    if (orgs.length > 0 && checks.length === 0) {
+      checks.push({
+        name: 'Tenants con owner',
+        status: 'ok',
+        detail: `Todos los ${orgs.length} tenants tienen pm_owner.`,
+      })
+    }
+  }
+
+  // 2. Buildings without org_id
+  const { count: orphanBuildings } = await service
+    .from('buildings')
+    .select('id', { count: 'exact', head: true })
+    .is('org_id', null)
+  checks.push({
+    name: 'Edificios huérfanos',
+    status: (orphanBuildings ?? 0) === 0 ? 'ok' : 'error',
+    detail: `${orphanBuildings ?? 0} edificios sin org_id`,
+  })
+
+  // 3. Units without org_id
+  const { count: orphanUnits } = await service
+    .from('units')
+    .select('id', { count: 'exact', head: true })
+    .is('org_id', null)
+  checks.push({
+    name: 'Unidades huérfanas',
+    status: (orphanUnits ?? 0) === 0 ? 'ok' : 'error',
+    detail: `${orphanUnits ?? 0} unidades sin org_id`,
+  })
+
+  // 4. Platform admins
+  const { count: adminCount } = await service
+    .from('platform_admins')
+    .select('id', { count: 'exact', head: true })
+  checks.push({
+    name: 'Platform admins',
+    status: (adminCount ?? 0) >= 1 ? 'ok' : 'error',
+    detail: `${adminCount ?? 0} L0 admins configurados`,
+  })
+
+  return checks
+}
+
+const statusStyles: Record<Check['status'], { bg: string; fg: string; border: string; label: string }> = {
+  ok: {
+    bg: 'rgba(34,197,94,0.12)',
+    fg: '#86EFAC',
+    border: 'rgba(34,197,94,0.3)',
+    label: 'OK',
+  },
+  warn: {
+    bg: 'rgba(234,179,8,0.12)',
+    fg: '#FDE68A',
+    border: 'rgba(234,179,8,0.3)',
+    label: 'WARN',
+  },
+  error: {
+    bg: 'rgba(239,68,68,0.12)',
+    fg: '#FCA5A5',
+    border: 'rgba(239,68,68,0.3)',
+    label: 'ERROR',
+  },
+}
+
+export default async function HealthPage() {
+  const checks = await runChecks()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2
+          className="text-[18px] font-semibold mb-1"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Salud de la plataforma
+        </h2>
+        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          Verificaciones automáticas de integridad multi-tenant.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {checks.map((c, i) => {
+          const s = statusStyles[c.status]
+          return (
+            <div
+              key={i}
+              className="rounded-lg p-3 flex items-center gap-3"
+              style={{
+                backgroundColor: 'var(--baw-surface)',
+                border: '1px solid var(--baw-border)',
+              }}
+            >
+              <span
+                className="px-1.5 py-0.5 text-[10px] rounded uppercase tracking-wider"
+                style={{
+                  backgroundColor: s.bg,
+                  color: s.fg,
+                  border: `1px solid ${s.border}`,
+                }}
+              >
+                {s.label}
+              </span>
+              <div className="flex-1">
+                <div
+                  className="text-[12px] font-medium"
+                  style={{ color: 'var(--baw-text)' }}
+                >
+                  {c.name}
+                </div>
+                <div className="text-[11px]" style={{ color: 'var(--baw-muted)' }}>
+                  {c.detail}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,95 @@
+// BaW OS — Platform Admin Console (L0) — Sprint 4 / S4-1.5
+//
+// Solo accesible para Platform Admins (fran@zxy.vc).
+// L1 admins de tenant deben usar /settings/account, no /admin.
+
+import { redirect } from 'next/navigation'
+import { isPlatformAdmin } from '@/lib/platform-admin'
+import Link from 'next/link'
+import { LayoutDashboard, Building2, Users, Server, Activity } from 'lucide-react'
+
+export const metadata = {
+  title: 'Platform Admin · BaW OS',
+}
+
+export const dynamic = 'force-dynamic'
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const ok = await isPlatformAdmin()
+  if (!ok) {
+    redirect('/?error=forbidden')
+  }
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: 'var(--baw-bg)' }}>
+      <div
+        className="border-b px-4 py-3 flex items-center justify-between"
+        style={{ borderColor: 'var(--baw-border)' }}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded"
+            style={{
+              backgroundColor: 'rgba(239, 68, 68, 0.15)',
+              color: '#FCA5A5',
+              border: '1px solid rgba(239, 68, 68, 0.3)',
+            }}
+          >
+            L0 · Platform
+          </div>
+          <h1
+            className="text-[14px] font-medium"
+            style={{ color: 'var(--baw-text)' }}
+          >
+            Platform Admin
+          </h1>
+        </div>
+        <Link
+          href="/"
+          className="text-[12px]"
+          style={{ color: 'var(--baw-muted)' }}
+        >
+          ← Volver al tenant
+        </Link>
+      </div>
+
+      <nav
+        className="border-b px-4 flex gap-1 overflow-x-auto"
+        style={{ borderColor: 'var(--baw-border)' }}
+      >
+        <AdminTab href="/admin" icon={<LayoutDashboard size={14} />} label="Dashboard" />
+        <AdminTab href="/admin/tenants" icon={<Building2 size={14} />} label="Tenants" />
+        <AdminTab href="/admin/users" icon={<Users size={14} />} label="Usuarios" />
+        <AdminTab href="/admin/admins" icon={<Server size={14} />} label="Platform Admins" />
+        <AdminTab href="/admin/health" icon={<Activity size={14} />} label="Salud" />
+      </nav>
+
+      <main className="p-6">{children}</main>
+    </div>
+  )
+}
+
+function AdminTab({
+  href,
+  icon,
+  label,
+}: {
+  href: string
+  icon: React.ReactNode
+  label: string
+}) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-1.5 px-3 py-2 text-[12px] border-b-2 border-transparent hover:border-[var(--baw-primary)]"
+      style={{ color: 'var(--baw-muted)' }}
+    >
+      {icon}
+      {label}
+    </Link>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,111 @@
+// BaW OS — Platform Admin Dashboard — Sprint 4 / S4-1.5
+
+import { createServiceClient } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+
+async function getStats() {
+  const service = createServiceClient()
+
+  const [orgsR, membersR, buildingsR, unitsR, adminsR] = await Promise.all([
+    service.from('organizations').select('id', { count: 'exact', head: true }),
+    service.from('org_members').select('user_id', { count: 'exact', head: true }),
+    service.from('buildings').select('id', { count: 'exact', head: true }),
+    service.from('units').select('id', { count: 'exact', head: true }),
+    service.from('platform_admins').select('id', { count: 'exact', head: true }),
+  ])
+
+  return {
+    orgs: orgsR.count ?? 0,
+    members: membersR.count ?? 0,
+    buildings: buildingsR.count ?? 0,
+    units: unitsR.count ?? 0,
+    admins: adminsR.count ?? 0,
+  }
+}
+
+export default async function AdminDashboard() {
+  const stats = await getStats()
+
+  const cards = [
+    { label: 'Tenants (orgs)', value: stats.orgs, hint: 'PM Companies activas' },
+    { label: 'Miembros', value: stats.members, hint: 'Usuarios con rol PM' },
+    { label: 'Edificios', value: stats.buildings, hint: 'Activos bajo gestión' },
+    { label: 'Unidades', value: stats.units, hint: 'En el sistema' },
+    { label: 'Platform Admins', value: stats.admins, hint: 'L0 con acceso /admin' },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2
+          className="text-[18px] font-semibold mb-1"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Estado de la plataforma
+        </h2>
+        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          Vista global de todos los tenants. Solo visible para L0.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+        {cards.map((c) => (
+          <div
+            key={c.label}
+            className="rounded-lg p-4"
+            style={{
+              backgroundColor: 'var(--baw-surface)',
+              border: '1px solid var(--baw-border)',
+            }}
+          >
+            <div
+              className="text-[10px] uppercase tracking-wider mb-1"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              {c.label}
+            </div>
+            <div
+              className="text-[28px] font-semibold tabular-nums"
+              style={{ color: 'var(--baw-text)' }}
+            >
+              {c.value}
+            </div>
+            <div
+              className="text-[11px] mt-1"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              {c.hint}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        className="rounded-lg p-4"
+        style={{
+          backgroundColor: 'var(--baw-surface)',
+          border: '1px solid var(--baw-border)',
+        }}
+      >
+        <h3 className="text-[14px] font-medium mb-2" style={{ color: 'var(--baw-text)' }}>
+          Capas de administración
+        </h3>
+        <ul className="space-y-2 text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          <li>
+            <strong style={{ color: 'var(--baw-text)' }}>L0 Platform</strong> · /admin
+            · solo ZXY (fran@zxy.vc)
+          </li>
+          <li>
+            <strong style={{ color: 'var(--baw-text)' }}>L1 Tenant</strong> ·
+            /settings/account · pm_owner | pm_admin por org
+          </li>
+          <li>
+            <strong style={{ color: 'var(--baw-text)' }}>L2 User</strong> · /me ·
+            preferencias del usuario actual
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/tenants/page.tsx
+++ b/src/app/admin/tenants/page.tsx
@@ -1,0 +1,170 @@
+// BaW OS — Platform Admin · Tenants — Sprint 4 / S4-1.5
+
+import { createServiceClient } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+
+type TenantRow = {
+  id: string
+  name: string
+  slug: string
+  created_at: string
+  member_count: number
+  building_count: number
+  unit_count: number
+}
+
+async function getTenants(): Promise<TenantRow[]> {
+  const service = createServiceClient()
+
+  const { data: orgs } = await service
+    .from('organizations')
+    .select('id, name, slug, created_at')
+    .order('created_at', { ascending: false })
+
+  if (!orgs) return []
+
+  // N+1 acceptable here — we expect <50 tenants for a long while
+  const rows: TenantRow[] = await Promise.all(
+    orgs.map(async (o) => {
+      const [m, b, u] = await Promise.all([
+        service
+          .from('org_members')
+          .select('user_id', { count: 'exact', head: true })
+          .eq('org_id', o.id),
+        service
+          .from('buildings')
+          .select('id', { count: 'exact', head: true })
+          .eq('org_id', o.id),
+        service
+          .from('units')
+          .select('id', { count: 'exact', head: true })
+          .eq('org_id', o.id),
+      ])
+      return {
+        id: o.id,
+        name: o.name,
+        slug: o.slug,
+        created_at: o.created_at,
+        member_count: m.count ?? 0,
+        building_count: b.count ?? 0,
+        unit_count: u.count ?? 0,
+      }
+    }),
+  )
+
+  return rows
+}
+
+export default async function TenantsPage() {
+  const tenants = await getTenants()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2
+          className="text-[18px] font-semibold mb-1"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Tenants ({tenants.length})
+        </h2>
+        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          Todas las PM Companies registradas en la plataforma.
+        </p>
+      </div>
+
+      <div
+        className="rounded-lg overflow-hidden"
+        style={{
+          backgroundColor: 'var(--baw-surface)',
+          border: '1px solid var(--baw-border)',
+        }}
+      >
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr
+              className="text-left"
+              style={{ borderBottom: '1px solid var(--baw-border)' }}
+            >
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Tenant
+              </th>
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Slug
+              </th>
+              <th
+                className="px-4 py-2.5 font-medium tabular-nums text-right"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                Miembros
+              </th>
+              <th
+                className="px-4 py-2.5 font-medium tabular-nums text-right"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                Edificios
+              </th>
+              <th
+                className="px-4 py-2.5 font-medium tabular-nums text-right"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                Unidades
+              </th>
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Creada
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {tenants.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 py-8 text-center"
+                  style={{ color: 'var(--baw-muted)' }}
+                >
+                  Sin tenants aún.
+                </td>
+              </tr>
+            ) : (
+              tenants.map((t) => (
+                <tr
+                  key={t.id}
+                  style={{ borderBottom: '1px solid var(--baw-border)' }}
+                >
+                  <td className="px-4 py-3" style={{ color: 'var(--baw-text)' }}>
+                    {t.name}
+                  </td>
+                  <td className="px-4 py-3" style={{ color: 'var(--baw-muted)' }}>
+                    {t.slug}
+                  </td>
+                  <td
+                    className="px-4 py-3 tabular-nums text-right"
+                    style={{ color: 'var(--baw-text)' }}
+                  >
+                    {t.member_count}
+                  </td>
+                  <td
+                    className="px-4 py-3 tabular-nums text-right"
+                    style={{ color: 'var(--baw-text)' }}
+                  >
+                    {t.building_count}
+                  </td>
+                  <td
+                    className="px-4 py-3 tabular-nums text-right"
+                    style={{ color: 'var(--baw-text)' }}
+                  >
+                    {t.unit_count}
+                  </td>
+                  <td className="px-4 py-3" style={{ color: 'var(--baw-muted)' }}>
+                    {new Date(t.created_at).toLocaleDateString('es-MX')}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,138 @@
+// BaW OS — Platform Admin · Users — Sprint 4 / S4-1.5
+
+import { createServiceClient } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+
+type UserRow = {
+  user_id: string
+  email: string | null
+  org_count: number
+  roles: string[]
+  is_platform_admin: boolean
+}
+
+async function getUsers(): Promise<UserRow[]> {
+  const service = createServiceClient()
+
+  // Auth users via admin API
+  const { data: authData } = await service.auth.admin.listUsers({ perPage: 200 })
+  const users = authData?.users ?? []
+
+  const { data: members } = await service
+    .from('org_members')
+    .select('user_id, role')
+
+  const { data: pAdmins } = await service.from('platform_admins').select('email')
+  const adminEmails = new Set(
+    (pAdmins ?? []).map((a: { email: string }) => a.email.toLowerCase()),
+  )
+
+  const memberMap = new Map<string, { count: number; roles: Set<string> }>()
+  for (const m of members ?? []) {
+    const cur = memberMap.get(m.user_id) ?? { count: 0, roles: new Set<string>() }
+    cur.count += 1
+    cur.roles.add(m.role)
+    memberMap.set(m.user_id, cur)
+  }
+
+  return users.map((u) => {
+    const info = memberMap.get(u.id)
+    return {
+      user_id: u.id,
+      email: u.email ?? null,
+      org_count: info?.count ?? 0,
+      roles: Array.from(info?.roles ?? []),
+      is_platform_admin:
+        !!u.email && adminEmails.has(u.email.toLowerCase()),
+    }
+  })
+}
+
+export default async function UsersPage() {
+  const users = await getUsers()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2
+          className="text-[18px] font-semibold mb-1"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Usuarios ({users.length})
+        </h2>
+        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          Todos los usuarios registrados en la plataforma. Los Platform Admins
+          se marcan con badge L0.
+        </p>
+      </div>
+
+      <div
+        className="rounded-lg overflow-hidden"
+        style={{
+          backgroundColor: 'var(--baw-surface)',
+          border: '1px solid var(--baw-border)',
+        }}
+      >
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr
+              className="text-left"
+              style={{ borderBottom: '1px solid var(--baw-border)' }}
+            >
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Email
+              </th>
+              <th
+                className="px-4 py-2.5 font-medium tabular-nums text-right"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                Orgs
+              </th>
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Roles
+              </th>
+              <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                Plataforma
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.user_id} style={{ borderBottom: '1px solid var(--baw-border)' }}>
+                <td className="px-4 py-3" style={{ color: 'var(--baw-text)' }}>
+                  {u.email ?? <span style={{ color: 'var(--baw-muted)' }}>(sin email)</span>}
+                </td>
+                <td
+                  className="px-4 py-3 tabular-nums text-right"
+                  style={{ color: 'var(--baw-text)' }}
+                >
+                  {u.org_count}
+                </td>
+                <td className="px-4 py-3" style={{ color: 'var(--baw-muted)' }}>
+                  {u.roles.length === 0 ? '—' : u.roles.join(', ')}
+                </td>
+                <td className="px-4 py-3">
+                  {u.is_platform_admin ? (
+                    <span
+                      className="px-1.5 py-0.5 text-[10px] rounded uppercase tracking-wider"
+                      style={{
+                        backgroundColor: 'rgba(239, 68, 68, 0.15)',
+                        color: '#FCA5A5',
+                        border: '1px solid rgba(239, 68, 68, 0.3)',
+                      }}
+                    >
+                      L0
+                    </span>
+                  ) : (
+                    <span style={{ color: 'var(--baw-muted)' }}>—</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/admin/whoami/route.ts
+++ b/src/app/api/admin/whoami/route.ts
@@ -1,0 +1,14 @@
+// BaW OS — Platform Admin: am I L0? — Sprint 4 / S4-1.5
+//
+// Endpoint que client components pueden consumir para mostrar/ocultar entradas
+// de menú L0 sin recargar la página.
+
+import { NextResponse } from 'next/server'
+import { getPlatformAdminContext } from '@/lib/platform-admin'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const { email, isAdmin } = await getPlatformAdminContext()
+  return NextResponse.json({ email, isPlatformAdmin: isAdmin })
+}

--- a/src/app/api/me/preferences/route.ts
+++ b/src/app/api/me/preferences/route.ts
@@ -1,0 +1,76 @@
+// BaW OS — User Preferences API — Sprint 4 / S4-1.5
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { createServiceClient } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'No session' }, { status: 401 })
+  }
+
+  const service = createServiceClient()
+  const { data, error } = await service
+    .from('user_preferences')
+    .select('locale, timezone, notification_prefs, theme, updated_at')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json(
+    data ?? {
+      locale: 'es',
+      timezone: 'America/Mexico_City',
+      notification_prefs: { email: true, whatsapp: true, in_app: true },
+      theme: 'dark',
+    },
+  )
+}
+
+export async function PUT(request: NextRequest) {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'No session' }, { status: 401 })
+  }
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 })
+  }
+
+  // Whitelist allowed fields
+  const allowed: Record<string, unknown> = {}
+  if (typeof body.locale === 'string') allowed.locale = body.locale
+  if (typeof body.timezone === 'string') allowed.timezone = body.timezone
+  if (typeof body.theme === 'string') allowed.theme = body.theme
+  if (body.notification_prefs && typeof body.notification_prefs === 'object') {
+    allowed.notification_prefs = body.notification_prefs
+  }
+
+  if (Object.keys(allowed).length === 0) {
+    return NextResponse.json({ error: 'No valid fields' }, { status: 400 })
+  }
+
+  const service = createServiceClient()
+  const { data, error } = await service
+    .from('user_preferences')
+    .upsert({ user_id: user.id, ...allowed })
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}

--- a/src/app/me/MePreferencesForm.tsx
+++ b/src/app/me/MePreferencesForm.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+// BaW OS — User Preferences form (L2) — Sprint 4 / S4-1.5
+
+import { useState } from 'react'
+
+type Prefs = {
+  locale: string
+  timezone: string
+  notification_prefs: { email?: boolean; whatsapp?: boolean; in_app?: boolean }
+  theme: string
+}
+
+const LOCALE_OPTIONS = [
+  { value: 'es', label: 'Español (México)' },
+  { value: 'en', label: 'English (US)' },
+]
+
+const TIMEZONE_OPTIONS = [
+  'America/Mexico_City',
+  'America/Tijuana',
+  'America/Cancun',
+  'America/Chicago',
+  'America/Los_Angeles',
+  'America/New_York',
+  'UTC',
+]
+
+export default function MePreferencesForm({ initial }: { initial: Prefs }) {
+  const [prefs, setPrefs] = useState<Prefs>(initial)
+  const [saving, setSaving] = useState(false)
+  const [savedAt, setSavedAt] = useState<Date | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function save() {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/me/preferences', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(prefs),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j.error || `HTTP ${res.status}`)
+      }
+      setSavedAt(new Date())
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section
+      className="rounded-lg p-5 space-y-4"
+      style={{
+        backgroundColor: 'var(--baw-surface)',
+        border: '1px solid var(--baw-border)',
+      }}
+    >
+      <h2
+        className="text-[14px] font-medium"
+        style={{ color: 'var(--baw-text)' }}
+      >
+        Preferencias
+      </h2>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label
+            className="block text-[10px] uppercase tracking-wider mb-1"
+            style={{ color: 'var(--baw-muted)' }}
+          >
+            Idioma
+          </label>
+          <select
+            value={prefs.locale}
+            onChange={(e) => setPrefs({ ...prefs, locale: e.target.value })}
+            className="w-full px-2 py-1.5 text-[12px] rounded"
+            style={{
+              backgroundColor: 'var(--baw-bg)',
+              color: 'var(--baw-text)',
+              border: '1px solid var(--baw-border)',
+            }}
+          >
+            {LOCALE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            className="block text-[10px] uppercase tracking-wider mb-1"
+            style={{ color: 'var(--baw-muted)' }}
+          >
+            Zona horaria
+          </label>
+          <select
+            value={prefs.timezone}
+            onChange={(e) => setPrefs({ ...prefs, timezone: e.target.value })}
+            className="w-full px-2 py-1.5 text-[12px] rounded"
+            style={{
+              backgroundColor: 'var(--baw-bg)',
+              color: 'var(--baw-text)',
+              border: '1px solid var(--baw-border)',
+            }}
+          >
+            {TIMEZONE_OPTIONS.map((tz) => (
+              <option key={tz} value={tz}>
+                {tz}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <div
+          className="text-[10px] uppercase tracking-wider mb-2"
+          style={{ color: 'var(--baw-muted)' }}
+        >
+          Notificaciones
+        </div>
+        <div className="space-y-1.5">
+          <Toggle
+            label="Email"
+            checked={!!prefs.notification_prefs.email}
+            onChange={(v) =>
+              setPrefs({
+                ...prefs,
+                notification_prefs: { ...prefs.notification_prefs, email: v },
+              })
+            }
+          />
+          <Toggle
+            label="WhatsApp"
+            checked={!!prefs.notification_prefs.whatsapp}
+            onChange={(v) =>
+              setPrefs({
+                ...prefs,
+                notification_prefs: { ...prefs.notification_prefs, whatsapp: v },
+              })
+            }
+          />
+          <Toggle
+            label="In-app"
+            checked={!!prefs.notification_prefs.in_app}
+            onChange={(v) =>
+              setPrefs({
+                ...prefs,
+                notification_prefs: { ...prefs.notification_prefs, in_app: v },
+              })
+            }
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 pt-2">
+        <button
+          type="button"
+          onClick={save}
+          disabled={saving}
+          className="px-3 py-1.5 text-[12px] rounded font-medium disabled:opacity-50"
+          style={{
+            backgroundColor: 'var(--baw-primary)',
+            color: 'white',
+          }}
+        >
+          {saving ? 'Guardando…' : 'Guardar preferencias'}
+        </button>
+        {savedAt && !error && (
+          <span className="text-[11px]" style={{ color: 'var(--baw-muted)' }}>
+            Guardado a las {savedAt.toLocaleTimeString('es-MX')}
+          </span>
+        )}
+        {error && (
+          <span className="text-[11px]" style={{ color: '#FCA5A5' }}>
+            Error: {error}
+          </span>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  onChange: (v: boolean) => void
+}) {
+  return (
+    <label className="flex items-center gap-2 text-[12px] cursor-pointer">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <span style={{ color: 'var(--baw-text)' }}>{label}</span>
+    </label>
+  )
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,0 +1,236 @@
+// BaW OS — User Profile (L2) — Sprint 4 / S4-1.5
+//
+// Página personal del usuario. NO depende de org. Cada usuario tiene una sola
+// página /me sin importar a cuántos tenants pertenezca.
+
+import { redirect } from 'next/navigation'
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { createServiceClient } from '@/lib/api-auth'
+import { getPlatformAdminContext } from '@/lib/platform-admin'
+import Link from 'next/link'
+import MePreferencesForm from './MePreferencesForm'
+
+export const metadata = { title: 'Mi perfil · BaW OS' }
+export const dynamic = 'force-dynamic'
+
+type Membership = {
+  org_id: string
+  role: string
+  org_name: string
+  org_slug: string
+}
+
+async function getData() {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return null
+
+  const service = createServiceClient()
+
+  const [profileR, prefsR, membershipsR] = await Promise.all([
+    service
+      .from('user_profiles')
+      .select('full_name, avatar_url')
+      .eq('user_id', user.id)
+      .maybeSingle(),
+    service
+      .from('user_preferences')
+      .select('locale, timezone, notification_prefs, theme')
+      .eq('user_id', user.id)
+      .maybeSingle(),
+    service
+      .from('org_members')
+      .select('org_id, role, organizations(name, slug)')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: true }),
+  ])
+
+  const memberships: Membership[] = (membershipsR.data ?? []).map(
+    (m: {
+      org_id: string
+      role: string
+      organizations: { name: string; slug: string } | { name: string; slug: string }[] | null
+    }) => {
+      const org = Array.isArray(m.organizations) ? m.organizations[0] : m.organizations
+      return {
+        org_id: m.org_id,
+        role: m.role,
+        org_name: org?.name ?? '—',
+        org_slug: org?.slug ?? '',
+      }
+    },
+  )
+
+  const adminCtx = await getPlatformAdminContext()
+
+  return {
+    user: {
+      id: user.id,
+      email: user.email ?? null,
+      full_name: profileR.data?.full_name ?? null,
+      avatar_url: profileR.data?.avatar_url ?? null,
+    },
+    prefs: prefsR.data ?? {
+      locale: 'es',
+      timezone: 'America/Mexico_City',
+      notification_prefs: { email: true, whatsapp: true, in_app: true },
+      theme: 'dark',
+    },
+    memberships,
+    isPlatformAdmin: adminCtx.isAdmin,
+  }
+}
+
+export default async function MePage() {
+  const data = await getData()
+  if (!data) redirect('/login?next=/me')
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <div>
+        <div
+          className="text-[10px] uppercase tracking-wider mb-1"
+          style={{ color: 'var(--baw-muted)' }}
+        >
+          L2 · Usuario
+        </div>
+        <h1
+          className="text-[20px] font-semibold"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Mi perfil
+        </h1>
+        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          Preferencias personales que viajan contigo entre tenants.
+        </p>
+      </div>
+
+      {/* Identity */}
+      <section
+        className="rounded-lg p-5"
+        style={{
+          backgroundColor: 'var(--baw-surface)',
+          border: '1px solid var(--baw-border)',
+        }}
+      >
+        <h2
+          className="text-[14px] font-medium mb-3"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Identidad
+        </h2>
+        <div className="grid grid-cols-2 gap-4 text-[12px]">
+          <Field label="Email" value={data.user.email ?? '—'} />
+          <Field label="Nombre" value={data.user.full_name ?? '—'} />
+          <Field label="User ID" value={data.user.id} mono />
+          <Field
+            label="Plataforma"
+            value={data.isPlatformAdmin ? 'L0 — Platform Admin' : 'Usuario regular'}
+          />
+        </div>
+      </section>
+
+      {/* Memberships */}
+      <section
+        className="rounded-lg p-5"
+        style={{
+          backgroundColor: 'var(--baw-surface)',
+          border: '1px solid var(--baw-border)',
+        }}
+      >
+        <h2
+          className="text-[14px] font-medium mb-3"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Tus organizaciones ({data.memberships.length})
+        </h2>
+        {data.memberships.length === 0 ? (
+          <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+            No perteneces a ninguna organización aún.
+          </p>
+        ) : (
+          <ul className="divide-y" style={{ borderColor: 'var(--baw-border)' }}>
+            {data.memberships.map((m) => (
+              <li
+                key={m.org_id}
+                className="py-2 flex items-center justify-between"
+                style={{ borderColor: 'var(--baw-border)' }}
+              >
+                <div>
+                  <div className="text-[13px]" style={{ color: 'var(--baw-text)' }}>
+                    {m.org_name}
+                  </div>
+                  <div className="text-[11px]" style={{ color: 'var(--baw-muted)' }}>
+                    {m.org_slug}
+                  </div>
+                </div>
+                <span
+                  className="px-1.5 py-0.5 text-[10px] rounded uppercase tracking-wider"
+                  style={{
+                    backgroundColor: 'rgba(59,130,246,0.12)',
+                    color: '#93C5FD',
+                    border: '1px solid rgba(59,130,246,0.25)',
+                  }}
+                >
+                  {m.role}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Preferences (client form) */}
+      <MePreferencesForm initial={data.prefs} />
+
+      {/* Quick links */}
+      <section className="text-[12px] flex flex-wrap gap-3">
+        <Link
+          href="/settings"
+          className="underline"
+          style={{ color: 'var(--baw-primary)' }}
+        >
+          Configuración del tenant (L1)
+        </Link>
+        {data.isPlatformAdmin && (
+          <Link
+            href="/admin"
+            className="underline"
+            style={{ color: 'var(--baw-primary)' }}
+          >
+            Platform Admin (L0)
+          </Link>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div>
+      <div
+        className="text-[10px] uppercase tracking-wider mb-0.5"
+        style={{ color: 'var(--baw-muted)' }}
+      >
+        {label}
+      </div>
+      <div
+        className={mono ? 'font-mono text-[11px] break-all' : ''}
+        style={{ color: 'var(--baw-text)' }}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -13,13 +13,13 @@ import { ToastProvider } from '@/components/Toast'
 import ContractAlertsBanner from '@/components/ContractAlertsBanner'
 import { findSection } from '@/lib/navigation'
 
-// Sprint 4 / S4-0 fix: estos prefijos son rutas públicas con su propio layout
-// (sin sidebar, sin header). El match debe ser estricto — `pathname === prefix`
-// o `pathname.startsWith(prefix + '/')` — para que `/owners` (plural, interno)
-// NO matchee con `/owner` (singular, público). Mismo caso para `/onboarding`
-// que tiene tanto layout público (e.g. `/onboarding/[token]`) como vista
-// interna en el sub-nav de Inquilinos.
-const PUBLIC_PREFIXES = ['/portal', '/tenant', '/owner', '/conserje', '/apply']
+// Sprint 4 / S4-0 + S4-1.5: estos prefijos son rutas públicas con su propio
+// layout (sin sidebar, sin header). El match debe ser estricto —
+// `pathname === prefix` o `pathname.startsWith(prefix + '/')` — para que
+// `/owners` (plural, interno) NO matchee con `/owner` (singular, público).
+// `/admin` (S4-1.5) tiene su propio chrome en `admin/layout.tsx` y debe
+// renderizarse fuera del AppShell de tenant.
+const PUBLIC_PREFIXES = ['/portal', '/tenant', '/owner', '/conserje', '/apply', '/admin']
 
 const PAGE_TITLES: Record<string, string> = {
   '/': 'Mission Control',

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useState, useRef } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { User, LogOut, Settings, Sun, Moon, Monitor } from 'lucide-react'
+import { User, LogOut, Settings, Sun, Moon, Monitor, Shield } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 
 type ThemePref = 'light' | 'dark' | 'system'
@@ -17,6 +17,7 @@ interface UserBasics {
   email: string | null
   full_name: string | null
   avatar_url: string | null
+  isPlatformAdmin: boolean
 }
 
 function getInitials(nameOrEmail: string | null): string {
@@ -54,11 +55,25 @@ export default function ProfileMenu() {
         .select('full_name, avatar_url')
         .eq('user_id', session.user.id)
         .maybeSingle()
+
+      // Sprint 4 / S4-1.5: detectar si es Platform Admin (L0)
+      let isPlatformAdmin = false
+      try {
+        const r = await fetch('/api/admin/whoami', { cache: 'no-store' })
+        if (r.ok) {
+          const j = await r.json()
+          isPlatformAdmin = !!j.isPlatformAdmin
+        }
+      } catch {
+        // ignore — default false
+      }
+
       setUser({
         id: session.user.id,
         email: session.user.email ?? null,
         full_name: profile?.full_name ?? null,
         avatar_url: profile?.avatar_url ?? null,
+        isPlatformAdmin,
       })
     }
     load()
@@ -178,13 +193,19 @@ export default function ProfileMenu() {
           <ul>
             <li>
               <Link
-                href="/settings"
+                href="/me"
                 onClick={() => setOpen(false)}
                 className="flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
                 style={{ color: 'var(--baw-text)' }}
               >
                 <User size={14} />
                 Mi perfil
+                <span
+                  className="ml-auto text-[9px] uppercase tracking-wider"
+                  style={{ color: 'var(--baw-muted)' }}
+                >
+                  L2
+                </span>
               </Link>
             </li>
             <li>
@@ -196,8 +217,33 @@ export default function ProfileMenu() {
               >
                 <Settings size={14} />
                 Configuración
+                <span
+                  className="ml-auto text-[9px] uppercase tracking-wider"
+                  style={{ color: 'var(--baw-muted)' }}
+                >
+                  L1
+                </span>
               </Link>
             </li>
+            {user?.isPlatformAdmin && (
+              <li>
+                <Link
+                  href="/admin"
+                  onClick={() => setOpen(false)}
+                  className="flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-white/5"
+                  style={{ color: 'var(--baw-text)' }}
+                >
+                  <Shield size={14} />
+                  Platform Admin
+                  <span
+                    className="ml-auto text-[9px] uppercase tracking-wider"
+                    style={{ color: '#FCA5A5' }}
+                  >
+                    L0
+                  </span>
+                </Link>
+              </li>
+            )}
           </ul>
 
           <div

--- a/src/lib/platform-admin.ts
+++ b/src/lib/platform-admin.ts
@@ -1,0 +1,80 @@
+// BaW OS — Platform Admin (L0) Guard (Sprint 4 / S4-1.5)
+//
+// Las 3 capas de admin:
+//   L0 Platform   → /admin, solo ZXY humanos (fran@zxy.vc)
+//   L1 Tenant     → /settings/account, pm_owner | pm_admin por org
+//   L2 User       → /me, preferencias del usuario actual
+//
+// La fuente de verdad es la tabla `platform_admins`. El env var
+// `PLATFORM_ADMIN_EMAILS` actúa como bootstrap fallback antes de que la
+// migración corra.
+
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { createServiceClient } from '@/lib/api-auth'
+
+function bootstrapEmails(): string[] {
+  return (process.env.PLATFORM_ADMIN_EMAILS || 'fran@zxy.vc')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+/**
+ * ¿Es el usuario logueado un Platform Admin (L0)?
+ *
+ * Resolución:
+ *  1. Sesión válida con email
+ *  2. El email aparece en la tabla `platform_admins`, O
+ *  3. Bootstrap: el email aparece en `PLATFORM_ADMIN_EMAILS`
+ */
+export async function isPlatformAdmin(): Promise<boolean> {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user?.email) return false
+
+  const email = user.email.toLowerCase()
+
+  // Bootstrap fallback (antes de que la migración haya corrido en algún env)
+  if (bootstrapEmails().includes(email)) return true
+
+  const service = createServiceClient()
+  const { data, error } = await service
+    .from('platform_admins')
+    .select('id')
+    .eq('email', email)
+    .maybeSingle()
+
+  if (error) return false
+  return !!data
+}
+
+/**
+ * Devuelve el email + flag de Platform Admin del usuario actual.
+ * Útil para Server Components que renderizan el menú de cuenta.
+ */
+export async function getPlatformAdminContext(): Promise<{
+  email: string | null
+  isAdmin: boolean
+}> {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user?.email) return { email: null, isAdmin: false }
+  return { email: user.email, isAdmin: await isPlatformAdmin() }
+}
+
+/**
+ * Lanza si el usuario no es L0. Usar al inicio de Server Components o
+ * Route Handlers que requieren acceso de plataforma.
+ */
+export async function requirePlatformAdmin(): Promise<void> {
+  const ok = await isPlatformAdmin()
+  if (!ok) {
+    throw new Error('FORBIDDEN: Platform admin required')
+  }
+}

--- a/supabase/migrations/20260429_04_platform_admin.sql
+++ b/supabase/migrations/20260429_04_platform_admin.sql
@@ -1,0 +1,95 @@
+-- Sprint 4 / S4-1.5: Platform Admin Console + User Preferences
+--
+-- Arquitectura de 3 capas de admin:
+--   L0 Platform   → tabla platform_admins (acceso a /admin, ZXY only)
+--   L1 Tenant     → org_members.role = 'pm_owner' | 'pm_admin' (existente)
+--   L2 User       → tabla user_preferences (preferencias personales)
+--
+-- L0 admins son SOLO ZXY humanos (fran@zxy.vc). Los agentes ZXY
+-- (Hugo-COS, Alicia-Ops, Conta-Beto, Maribel-Law, Luis-Growth, Andres-Tech)
+-- NO tienen acceso L0 propio — actúan dentro del tenant que los contrata.
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Platform Admins (L0)
+-- ──────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS platform_admins (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email text UNIQUE NOT NULL,
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  granted_by text NOT NULL,
+  granted_at timestamptz NOT NULL DEFAULT now(),
+  notes text
+);
+
+CREATE INDEX IF NOT EXISTS idx_platform_admins_user_id ON platform_admins(user_id);
+CREATE INDEX IF NOT EXISTS idx_platform_admins_email ON platform_admins(lower(email));
+
+ALTER TABLE platform_admins ENABLE ROW LEVEL SECURITY;
+
+-- Solo platform admins pueden leer la tabla. Service role bypass aplica.
+DROP POLICY IF EXISTS "platform_admins_self_read" ON platform_admins;
+CREATE POLICY "platform_admins_self_read" ON platform_admins
+  FOR SELECT
+  USING (
+    user_id = auth.uid()
+    OR lower(email) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  );
+
+-- Seed inicial: solo fran@zxy.vc (no mezclar con personal franduranv@gmail.com)
+INSERT INTO platform_admins (email, granted_by, notes)
+VALUES ('fran@zxy.vc', 'system:seed-s4-1.5', 'L0 ZXY founder')
+ON CONFLICT (email) DO NOTHING;
+
+-- Trigger para enlazar user_id cuando el usuario se registre
+CREATE OR REPLACE FUNCTION public.link_platform_admin_user()
+RETURNS trigger AS $$
+BEGIN
+  UPDATE platform_admins
+  SET user_id = NEW.id
+  WHERE lower(email) = lower(NEW.email)
+    AND user_id IS NULL;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS link_platform_admin_on_user_create ON auth.users;
+CREATE TRIGGER link_platform_admin_on_user_create
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.link_platform_admin_user();
+
+-- ──────────────────────────────────────────────────────────────────────
+-- User Preferences (L2)
+-- ──────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS user_preferences (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  locale text NOT NULL DEFAULT 'es',
+  timezone text NOT NULL DEFAULT 'America/Mexico_City',
+  notification_prefs jsonb NOT NULL DEFAULT '{"email": true, "whatsapp": true, "in_app": true}'::jsonb,
+  theme text NOT NULL DEFAULT 'dark',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE user_preferences ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "user_preferences_self_all" ON user_preferences;
+CREATE POLICY "user_preferences_self_all" ON user_preferences
+  FOR ALL
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- Trigger para actualizar updated_at
+CREATE OR REPLACE FUNCTION public.touch_user_preferences()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS touch_user_preferences_trg ON user_preferences;
+CREATE TRIGGER touch_user_preferences_trg
+  BEFORE UPDATE ON user_preferences
+  FOR EACH ROW
+  EXECUTE FUNCTION public.touch_user_preferences();


### PR DESCRIPTION
## S4-1.5 · Platform Admin Console + User Profile

Implementa la arquitectura de **3 capas de admin** acordada esta sesión.

### Capas
| Capa | Ruta | Acceso | Propósito |
|---|---|---|---|
| **L0 Platform** | `/admin` | `platform_admins` (sólo `fran@zxy.vc`) | Vista global multi-tenant |
| **L1 Tenant** | `/settings` | `pm_owner` / `pm_admin` por org | Config del tenant actual |
| **L2 User** | `/me` | usuario logueado | Preferencias personales |

### Cambios

**Base de datos** (migración aplicada en producción `zlcgxmllaeweypyodvzk`):
- `platform_admins` con RLS self-read + trigger que enlaza `user_id` al registrarse el usuario
- `user_preferences` con RLS por `user_id` + trigger `updated_at`
- Seed: `fran@zxy.vc` como L0 founder

**Backend**:
- `src/lib/platform-admin.ts` — `isPlatformAdmin()`, `requirePlatformAdmin()`, `getPlatformAdminContext()`
- `src/app/api/admin/whoami/route.ts` — GET endpoint para client components
- `src/app/api/me/preferences/route.ts` — GET/PUT preferencias

**Frontend**:
- `/admin` con layout propio (sin Sidebar de tenant, redirect si no L0)
  - Dashboard, Tenants, Usuarios, Platform Admins, Salud
- `/me` con identidad, memberships, preferencias (idioma, timezone, notificaciones)
- `ProfileMenu` actualizado: "Mi perfil" → `/me` (L2), "Configuración" → `/settings` (L1), "Platform Admin" → `/admin` (L0, condicional)
- `AppShell` añade `/admin` a `PUBLIC_PREFIXES` para que renderice su propio chrome

### Decisiones arquitectónicas
- L0 SOLO `fran@zxy.vc` (`@zxy.vc`, no mezclar con `@baw.mx` ni con personal `@gmail.com`)
- Los **agentes ZXY** (Hugo-COS, Alicia-Ops, Conta-Beto, Maribel-Law, Luis-Growth, Andres-Tech) **NO tienen L0** — operan dentro del tenant que los contrata vía `org_members.role = 'agent'`
- Beto es agente, no humano — confirmado en seed notes
- Misma app, no plataforma separada — cuando crezca a 50+ tenants migrar a `admin.baw.mx`

### Env requerido
```
PLATFORM_ADMIN_EMAILS=fran@zxy.vc
```
Bootstrap fallback que aplica si la migración aún no corrió en algún env.

### Plan
- `S4-2` Owner Portal v2 con login real
- `S4-3` Agente Cobranza v1 + infra agentes
- `S4-4` E2E testing
- `S4-5` Handoff Notion + Feature Board
