### PR TITLE
S4-2: Owner Portal v2 con login real (/owner + owner_invites)

### DIFF
--- a/src/app/api/owner-invites/route.ts
+++ b/src/app/api/owner-invites/route.ts
@@ -1,0 +1,97 @@
+// BaW OS — Owner Invites API (Sprint 4 / S4-2)
+//
+// Permite a pm_owner / pm_admin crear invites para que un property_owner
+// existente pueda loguearse al Owner Portal v2 con su email.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { createServiceClient } from '@/lib/api-auth'
+import { resolveOrgContext } from '@/lib/org-context'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const ctx = await resolveOrgContext()
+    if (!['pm_owner', 'pm_admin'].includes(ctx.role)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const service = createServiceClient()
+    const { data } = await service
+      .from('owner_invites')
+      .select(
+        'id, email, status, sent_at, accepted_at, expires_at, property_owner_id, notes',
+      )
+      .eq('org_id', ctx.orgId)
+      .order('sent_at', { ascending: false })
+
+    return NextResponse.json({ invites: data ?? [] })
+  } catch (e) {
+    return NextResponse.json(
+      { error: (e as Error).message },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const ctx = await resolveOrgContext()
+    if (!['pm_owner', 'pm_admin'].includes(ctx.role)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const body = await request.json().catch(() => null)
+    if (!body || typeof body.property_owner_id !== 'string') {
+      return NextResponse.json(
+        { error: 'property_owner_id required' },
+        { status: 400 },
+      )
+    }
+
+    const service = createServiceClient()
+
+    // Verify property_owner belongs to this org
+    const { data: po } = await service
+      .from('property_owners')
+      .select('id, email, full_name, org_id')
+      .eq('id', body.property_owner_id)
+      .maybeSingle()
+
+    if (!po || po.org_id !== ctx.orgId) {
+      return NextResponse.json({ error: 'Owner not found' }, { status: 404 })
+    }
+
+    const targetEmail = (body.email as string | undefined) || po.email
+    if (!targetEmail) {
+      return NextResponse.json(
+        { error: 'No email available for this owner' },
+        { status: 400 },
+      )
+    }
+
+    const { data: invite, error } = await service
+      .from('owner_invites')
+      .insert({
+        org_id: ctx.orgId,
+        property_owner_id: po.id,
+        email: targetEmail,
+        invited_by: ctx.userId,
+        notes: body.notes ?? null,
+      })
+      .select()
+      .single()
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ invite })
+  } catch (e) {
+    return NextResponse.json(
+      { error: (e as Error).message },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,11 +1,24 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { Suspense, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 
+// Sprint 4 / S4-2: useSearchParams requiere Suspense boundary en Next.js 14
 export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  )
+}
+
+function LoginForm() {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  // Sprint 4 / S4-2: respetar ?next= para deep-link en Owner Portal v2
+  const nextPath = searchParams.get('next') || '/'
+  const role = searchParams.get('role')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -25,7 +38,11 @@ export default function LoginPage() {
     }
 
     // Full reload so middleware picks up the new session cookie
-    window.location.href = '/'
+    // Validamos que nextPath sea relativa (no open-redirect)
+    const safeNext = nextPath.startsWith('/') && !nextPath.startsWith('//')
+      ? nextPath
+      : '/'
+    window.location.href = safeNext
   }
 
   return (
@@ -37,7 +54,9 @@ export default function LoginPage() {
             B
           </div>
           <h1 className="text-xl font-semibold text-gray-900 dark:text-white">BaW OS</h1>
-          <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">Property Management System</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">
+            {role === 'owner' ? 'Portal Propietario' : 'Property Management System'}
+          </p>
         </div>
 
         {/* Form */}

--- a/src/app/owner/OwnerSignOutButton.tsx
+++ b/src/app/owner/OwnerSignOutButton.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+// BaW OS — Owner sign out — Sprint 4 / S4-2
+
+import { useRouter } from 'next/navigation'
+import { LogOut } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+
+export default function OwnerSignOutButton() {
+  const router = useRouter()
+
+  async function handleSignOut() {
+    await supabase.auth.signOut()
+    router.replace('/login')
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleSignOut}
+      className="flex items-center gap-1.5 text-[12px] px-2 py-1 rounded hover:bg-white/5"
+      style={{ color: 'var(--baw-muted)' }}
+    >
+      <LogOut size={14} />
+      Cerrar sesión
+    </button>
+  )
+}

--- a/src/app/owner/buildings/[buildingId]/page.tsx
+++ b/src/app/owner/buildings/[buildingId]/page.tsx
@@ -1,0 +1,173 @@
+// BaW OS — Owner Portal v2 · Building Detail (Sprint 4 / S4-2)
+
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { tryResolveOwnerContext, ownerBuildingIds } from '@/lib/owner-context'
+import { createServiceClient } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+
+export default async function OwnerBuildingDetail({
+  params,
+}: {
+  params: { buildingId: string }
+}) {
+  const ctx = await tryResolveOwnerContext()
+  if (!ctx) redirect('/login?next=/owner&role=owner')
+
+  // Authorization: ¿este building está en los stakes del owner?
+  const allowed = ownerBuildingIds(ctx).includes(params.buildingId)
+  if (!allowed) redirect('/owner?error=forbidden')
+
+  const service = createServiceClient()
+
+  const [buildingR, unitsR] = await Promise.all([
+    service
+      .from('buildings')
+      .select('id, name, address, city')
+      .eq('id', params.buildingId)
+      .maybeSingle(),
+    service
+      .from('units')
+      .select('id, number, floor, type, status, monthly_rent')
+      .eq('building_id', params.buildingId)
+      .order('number', { ascending: true }),
+  ])
+
+  const building = buildingR.data
+  const units = unitsR.data ?? []
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: 'var(--baw-bg)' }}>
+      <header
+        className="border-b px-4 py-3 flex items-center gap-3"
+        style={{ borderColor: 'var(--baw-border)' }}
+      >
+        <Link
+          href="/owner"
+          className="text-[12px]"
+          style={{ color: 'var(--baw-muted)' }}
+        >
+          ← Volver
+        </Link>
+        <div
+          className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded"
+          style={{
+            backgroundColor: 'rgba(168, 85, 247, 0.15)',
+            color: '#D8B4FE',
+            border: '1px solid rgba(168, 85, 247, 0.3)',
+          }}
+        >
+          Edificio
+        </div>
+        <h1 className="text-[14px] font-medium" style={{ color: 'var(--baw-text)' }}>
+          {building?.name ?? 'Edificio'}
+        </h1>
+      </header>
+
+      <main className="p-6 max-w-5xl mx-auto space-y-4">
+        {building && (
+          <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+            {[building.address, building.city].filter(Boolean).join(', ') || '—'}
+          </p>
+        )}
+
+        <div
+          className="rounded-lg overflow-hidden"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          <table className="w-full text-[12px]">
+            <thead>
+              <tr
+                className="text-left"
+                style={{ borderBottom: '1px solid var(--baw-border)' }}
+              >
+                <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                  Unidad
+                </th>
+                <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                  Piso
+                </th>
+                <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                  Tipo
+                </th>
+                <th className="px-4 py-2.5 font-medium" style={{ color: 'var(--baw-muted)' }}>
+                  Estado
+                </th>
+                <th
+                  className="px-4 py-2.5 font-medium tabular-nums text-right"
+                  style={{ color: 'var(--baw-muted)' }}
+                >
+                  Renta
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {units.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-8 text-center"
+                    style={{ color: 'var(--baw-muted)' }}
+                  >
+                    Sin unidades registradas.
+                  </td>
+                </tr>
+              ) : (
+                units.map((u) => (
+                  <tr key={u.id} style={{ borderBottom: '1px solid var(--baw-border)' }}>
+                    <td className="px-4 py-3" style={{ color: 'var(--baw-text)' }}>
+                      {u.number}
+                    </td>
+                    <td className="px-4 py-3" style={{ color: 'var(--baw-muted)' }}>
+                      {u.floor ?? '—'}
+                    </td>
+                    <td className="px-4 py-3" style={{ color: 'var(--baw-muted)' }}>
+                      {u.type ?? '—'}
+                    </td>
+                    <td className="px-4 py-3">
+                      <UnitStatusBadge status={u.status} />
+                    </td>
+                    <td
+                      className="px-4 py-3 tabular-nums text-right"
+                      style={{ color: 'var(--baw-text)' }}
+                    >
+                      {u.monthly_rent
+                        ? `$${Number(u.monthly_rent).toLocaleString('es-MX')}`
+                        : '—'}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function UnitStatusBadge({ status }: { status: string | null }) {
+  const map: Record<string, { bg: string; fg: string; border: string; label: string }> = {
+    occupied: { bg: 'rgba(34,197,94,0.15)', fg: '#86EFAC', border: 'rgba(34,197,94,0.3)', label: 'Ocupada' },
+    available: { bg: 'rgba(59,130,246,0.15)', fg: '#93C5FD', border: 'rgba(59,130,246,0.3)', label: 'Disponible' },
+    maintenance: { bg: 'rgba(234,179,8,0.15)', fg: '#FDE68A', border: 'rgba(234,179,8,0.3)', label: 'Mantenimiento' },
+  }
+  const s = map[status ?? ''] ?? {
+    bg: 'rgba(148,163,184,0.15)',
+    fg: '#94A3B8',
+    border: 'rgba(148,163,184,0.3)',
+    label: status ?? '—',
+  }
+  return (
+    <span
+      className="px-1.5 py-0.5 text-[10px] rounded uppercase tracking-wider"
+      style={{ backgroundColor: s.bg, color: s.fg, border: `1px solid ${s.border}` }}
+    >
+      {s.label}
+    </span>
+  )
+}

--- a/src/app/owner/layout.tsx
+++ b/src/app/owner/layout.tsx
@@ -1,0 +1,14 @@
+// BaW OS — Owner Portal v2 Layout (Sprint 4 / S4-2)
+//
+// Chrome propio sin Sidebar de PM. Header diferenciado para que el owner
+// sepa que está viendo SUS propiedades, no las de un PM.
+
+export const metadata = {
+  title: 'Portal del Propietario · BaW',
+}
+
+export const dynamic = 'force-dynamic'
+
+export default function OwnerLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/owner/page.tsx
+++ b/src/app/owner/page.tsx
@@ -1,0 +1,310 @@
+// BaW OS — Owner Portal v2 Dashboard (Sprint 4 / S4-2)
+//
+// Punto de entrada del owner logueado. Muestra resumen agregado de todos los
+// edificios donde tiene ownership_stake activo, multi-tenant.
+
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { tryResolveOwnerContext, ownerBuildingIds } from '@/lib/owner-context'
+import { createServiceClient } from '@/lib/api-auth'
+import { Building2, Home, AlertCircle, Wallet, LogOut } from 'lucide-react'
+import OwnerSignOutButton from './OwnerSignOutButton'
+
+export const dynamic = 'force-dynamic'
+
+async function getOwnerData() {
+  const ctx = await tryResolveOwnerContext()
+  if (!ctx) return null
+
+  const service = createServiceClient()
+  const buildingIds = ownerBuildingIds(ctx)
+
+  if (buildingIds.length === 0) {
+    return { ctx, units: [], openIncidents: 0, monthRevenue: 0 }
+  }
+
+  const now = new Date()
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1)
+    .toISOString()
+    .slice(0, 10)
+  const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+    .toISOString()
+    .slice(0, 10)
+
+  const [unitsR, incidentsR, paymentsR] = await Promise.all([
+    service
+      .from('units')
+      .select('id, number, status, building_id')
+      .in('building_id', buildingIds),
+    service
+      .from('incidents')
+      .select('id', { count: 'exact', head: true })
+      .in('status', ['open', 'in_progress', 'waiting_parts'])
+      .in(
+        'unit_id',
+        // subquery would be cleaner but anonymous select is unwieldy; use service
+        [],
+      ),
+    service
+      .from('payments')
+      .select('amount_paid')
+      .gte('paid_date', monthStart)
+      .lte('paid_date', monthEnd)
+      .eq('status', 'paid'),
+  ])
+
+  const units = unitsR.data ?? []
+
+  // Re-query incidents now that we know the unit ids
+  const unitIds = units.map((u) => u.id)
+  let openIncidents = 0
+  if (unitIds.length > 0) {
+    const { count } = await service
+      .from('incidents')
+      .select('id', { count: 'exact', head: true })
+      .in('unit_id', unitIds)
+      .in('status', ['open', 'in_progress', 'waiting_parts'])
+    openIncidents = count ?? 0
+  }
+
+  const monthRevenue = (paymentsR.data ?? []).reduce(
+    (sum, p) => sum + Number(p.amount_paid ?? 0),
+    0,
+  )
+
+  return { ctx, units, openIncidents, monthRevenue }
+}
+
+export default async function OwnerDashboard() {
+  const data = await getOwnerData()
+
+  if (!data) {
+    redirect('/login?next=/owner&role=owner')
+  }
+
+  const { ctx, units, openIncidents, monthRevenue } = data
+
+  const totalBuildings = new Set(
+    ctx.properties.flatMap((p) => p.buildings.map((b) => b.building_id)),
+  ).size
+
+  const occupied = units.filter((u) => u.status === 'occupied').length
+  const occupancy =
+    units.length > 0 ? Math.round((occupied / units.length) * 100) : 0
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{ backgroundColor: 'var(--baw-bg)' }}
+    >
+      {/* Header */}
+      <header
+        className="border-b px-4 py-3 flex items-center justify-between"
+        style={{ borderColor: 'var(--baw-border)' }}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded"
+            style={{
+              backgroundColor: 'rgba(168, 85, 247, 0.15)',
+              color: '#D8B4FE',
+              border: '1px solid rgba(168, 85, 247, 0.3)',
+            }}
+          >
+            Portal Propietario
+          </div>
+          <h1 className="text-[14px] font-medium" style={{ color: 'var(--baw-text)' }}>
+            {ctx.email}
+          </h1>
+        </div>
+        <OwnerSignOutButton />
+      </header>
+
+      <main className="p-6 max-w-5xl mx-auto space-y-6">
+        {/* KPIs */}
+        <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Kpi
+            icon={<Building2 size={16} />}
+            label="Edificios"
+            value={totalBuildings}
+          />
+          <Kpi icon={<Home size={16} />} label="Unidades" value={units.length} />
+          <Kpi
+            icon={<Home size={16} />}
+            label="Ocupación"
+            value={`${occupancy}%`}
+            hint={`${occupied}/${units.length}`}
+          />
+          <Kpi
+            icon={<Wallet size={16} />}
+            label="Cobrado este mes"
+            value={`$${monthRevenue.toLocaleString('es-MX')}`}
+          />
+        </section>
+
+        {/* Properties by org */}
+        <section>
+          <h2
+            className="text-[14px] font-medium mb-3"
+            style={{ color: 'var(--baw-text)' }}
+          >
+            Tus propiedades
+          </h2>
+          <div className="space-y-3">
+            {ctx.properties.length === 0 && (
+              <Empty message="No tienes propiedades registradas." />
+            )}
+            {ctx.properties.map((p) => (
+              <div
+                key={p.property_owner_id}
+                className="rounded-lg p-4"
+                style={{
+                  backgroundColor: 'var(--baw-surface)',
+                  border: '1px solid var(--baw-border)',
+                }}
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <div>
+                    <div
+                      className="text-[10px] uppercase tracking-wider"
+                      style={{ color: 'var(--baw-muted)' }}
+                    >
+                      {p.org_name}
+                    </div>
+                    <div
+                      className="text-[14px] font-medium"
+                      style={{ color: 'var(--baw-text)' }}
+                    >
+                      {p.full_name}
+                    </div>
+                  </div>
+                </div>
+                {p.buildings.length === 0 ? (
+                  <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+                    Sin participaciones activas en esta organización.
+                  </p>
+                ) : (
+                  <ul className="divide-y" style={{ borderColor: 'var(--baw-border)' }}>
+                    {p.buildings.map((b) => (
+                      <li
+                        key={b.building_id}
+                        className="py-2 flex items-center justify-between"
+                        style={{ borderColor: 'var(--baw-border)' }}
+                      >
+                        <Link
+                          href={`/owner/buildings/${b.building_id}`}
+                          className="text-[13px] hover:underline"
+                          style={{ color: 'var(--baw-text)' }}
+                        >
+                          {b.building_name}
+                        </Link>
+                        <span
+                          className="text-[12px] tabular-nums"
+                          style={{ color: 'var(--baw-muted)' }}
+                        >
+                          {b.percentage.toFixed(2)}%
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Incidents */}
+        {openIncidents > 0 && (
+          <section
+            className="rounded-lg p-4 flex items-center gap-3"
+            style={{
+              backgroundColor: 'rgba(234, 179, 8, 0.08)',
+              border: '1px solid rgba(234, 179, 8, 0.25)',
+            }}
+          >
+            <AlertCircle size={18} style={{ color: '#FDE68A' }} />
+            <div className="flex-1">
+              <div
+                className="text-[13px] font-medium"
+                style={{ color: 'var(--baw-text)' }}
+              >
+                {openIncidents} incidente{openIncidents !== 1 ? 's' : ''} abierto
+                {openIncidents !== 1 ? 's' : ''}
+              </div>
+              <div className="text-[11px]" style={{ color: 'var(--baw-muted)' }}>
+                Mantenimiento o reportes en proceso en tus propiedades.
+              </div>
+            </div>
+            <Link
+              href="/owner/incidents"
+              className="text-[12px] px-3 py-1.5 rounded"
+              style={{
+                backgroundColor: 'rgba(234, 179, 8, 0.15)',
+                color: '#FDE68A',
+                border: '1px solid rgba(234, 179, 8, 0.3)',
+              }}
+            >
+              Ver detalles
+            </Link>
+          </section>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function Kpi({
+  icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string | number
+  hint?: string
+}) {
+  return (
+    <div
+      className="rounded-lg p-4"
+      style={{
+        backgroundColor: 'var(--baw-surface)',
+        border: '1px solid var(--baw-border)',
+      }}
+    >
+      <div
+        className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider mb-1"
+        style={{ color: 'var(--baw-muted)' }}
+      >
+        {icon}
+        {label}
+      </div>
+      <div
+        className="text-[24px] font-semibold tabular-nums"
+        style={{ color: 'var(--baw-text)' }}
+      >
+        {value}
+      </div>
+      {hint && (
+        <div className="text-[11px] mt-1" style={{ color: 'var(--baw-muted)' }}>
+          {hint}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Empty({ message }: { message: string }) {
+  return (
+    <div
+      className="rounded-lg p-6 text-center text-[12px]"
+      style={{
+        backgroundColor: 'var(--baw-surface)',
+        border: '1px dashed var(--baw-border)',
+        color: 'var(--baw-muted)',
+      }}
+    >
+      {message}
+    </div>
+  )
+}

--- a/src/lib/owner-context.ts
+++ b/src/lib/owner-context.ts
@@ -1,0 +1,129 @@
+// BaW OS — Owner Portal v2 Context (Sprint 4 / S4-2)
+//
+// Resuelve "¿quién es este property_owner logueado?" leyendo:
+//   1. Sesión de auth.users
+//   2. property_owners.user_id que matchea
+//   3. ownership_stakes para sus edificios visibles
+//
+// A diferencia de resolveOrgId() (que resuelve PM Company), aquí resolvemos
+// el SUBJECT desde el lado del owner: qué edificios y unidades puede ver.
+
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { createServiceClient } from '@/lib/api-auth'
+
+export type OwnerContext = {
+  userId: string
+  email: string
+  properties: Array<{
+    property_owner_id: string
+    full_name: string
+    org_id: string
+    org_name: string
+    org_slug: string
+    buildings: Array<{
+      building_id: string
+      building_name: string
+      percentage: number
+      starts_on: string | null
+      ends_on: string | null
+    }>
+  }>
+}
+
+export class OwnerContextError extends Error {
+  constructor(
+    message: string,
+    public code: 'NO_SESSION' | 'NOT_OWNER' = 'NO_SESSION',
+  ) {
+    super(message)
+    this.name = 'OwnerContextError'
+  }
+}
+
+/**
+ * Resuelve el OwnerContext del usuario logueado.
+ *
+ * Un mismo usuario puede ser owner en múltiples PM Companies (multi-tenant
+ * desde el lado del owner) y en múltiples edificios dentro de una org.
+ */
+export async function resolveOwnerContext(): Promise<OwnerContext> {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user || !user.email) {
+    throw new OwnerContextError('No authenticated user', 'NO_SESSION')
+  }
+
+  const service = createServiceClient()
+
+  // 1. property_owners enlazados al user_id O matching por email (fallback)
+  const { data: owners } = await service
+    .from('property_owners')
+    .select('id, full_name, org_id, organizations(name, slug)')
+    .or(`user_id.eq.${user.id},email.ilike.${user.email}`)
+
+  if (!owners || owners.length === 0) {
+    throw new OwnerContextError(
+      'User is not registered as a property owner',
+      'NOT_OWNER',
+    )
+  }
+
+  // 2. Para cada property_owner, obtener sus stakes con building names
+  const properties = await Promise.all(
+    owners.map(async (po) => {
+      const org = Array.isArray(po.organizations) ? po.organizations[0] : po.organizations
+      const { data: stakes } = await service
+        .from('ownership_stakes')
+        .select('building_id, percentage, starts_on, ends_on, buildings(name)')
+        .eq('property_owner_id', po.id)
+        .eq('org_id', po.org_id)
+        .or('ends_on.is.null,ends_on.gte.' + new Date().toISOString().slice(0, 10))
+
+      return {
+        property_owner_id: po.id,
+        full_name: po.full_name,
+        org_id: po.org_id,
+        org_name: org?.name ?? '—',
+        org_slug: org?.slug ?? '',
+        buildings: (stakes ?? []).map((s) => {
+          const b = Array.isArray(s.buildings) ? s.buildings[0] : s.buildings
+          return {
+            building_id: s.building_id,
+            building_name: b?.name ?? '—',
+            percentage: Number(s.percentage),
+            starts_on: s.starts_on,
+            ends_on: s.ends_on,
+          }
+        }),
+      }
+    }),
+  )
+
+  return {
+    userId: user.id,
+    email: user.email,
+    properties,
+  }
+}
+
+export async function tryResolveOwnerContext(): Promise<OwnerContext | null> {
+  try {
+    return await resolveOwnerContext()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Devuelve el set de building_ids que el owner puede ver (across all orgs).
+ */
+export function ownerBuildingIds(ctx: OwnerContext): string[] {
+  const ids = new Set<string>()
+  for (const p of ctx.properties) {
+    for (const b of p.buildings) ids.add(b.building_id)
+  }
+  return Array.from(ids)
+}

--- a/supabase/migrations/20260429_05_owner_portal_v2.sql
+++ b/supabase/migrations/20260429_05_owner_portal_v2.sql
@@ -1,0 +1,78 @@
+-- Sprint 4 / S4-2: Owner Portal v2 con login real
+--
+-- Elimina la dependencia del OWNER_TOKEN compartido. Cada owner se loguea con
+-- su email y ve solo los edificios donde tiene ownership_stake activo.
+
+CREATE TABLE IF NOT EXISTS owner_invites (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  property_owner_id uuid NOT NULL REFERENCES property_owners(id) ON DELETE CASCADE,
+  email text NOT NULL,
+  invited_by uuid REFERENCES auth.users(id),
+  invite_token text UNIQUE NOT NULL DEFAULT replace(gen_random_uuid()::text, '-', ''),
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'revoked', 'expired')),
+  sent_at timestamptz NOT NULL DEFAULT now(),
+  accepted_at timestamptz,
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '14 days'),
+  notes text
+);
+
+CREATE INDEX IF NOT EXISTS idx_owner_invites_org ON owner_invites(org_id);
+CREATE INDEX IF NOT EXISTS idx_owner_invites_email ON owner_invites(lower(email));
+CREATE INDEX IF NOT EXISTS idx_owner_invites_token ON owner_invites(invite_token);
+CREATE INDEX IF NOT EXISTS idx_owner_invites_property_owner ON owner_invites(property_owner_id);
+
+ALTER TABLE owner_invites ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "owner_invites_pm_admins_all" ON owner_invites;
+CREATE POLICY "owner_invites_pm_admins_all" ON owner_invites
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = owner_invites.org_id
+        AND m.user_id = auth.uid()
+        AND m.role IN ('pm_owner', 'pm_admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM org_members m
+      WHERE m.org_id = owner_invites.org_id
+        AND m.user_id = auth.uid()
+        AND m.role IN ('pm_owner', 'pm_admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "owner_invites_self_read" ON owner_invites;
+CREATE POLICY "owner_invites_self_read" ON owner_invites
+  FOR SELECT
+  USING (
+    lower(email) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  );
+
+CREATE INDEX IF NOT EXISTS idx_property_owners_user_id ON property_owners(user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_property_owners_email ON property_owners(lower(email)) WHERE email IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.link_property_owner_user()
+RETURNS trigger AS $$
+BEGIN
+  UPDATE property_owners
+  SET user_id = NEW.id, updated_at = now()
+  WHERE lower(email) = lower(NEW.email)
+    AND user_id IS NULL;
+
+  UPDATE owner_invites
+  SET status = 'accepted', accepted_at = now()
+  WHERE lower(email) = lower(NEW.email)
+    AND status = 'pending';
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS link_property_owner_on_user_create ON auth.users;
+CREATE TRIGGER link_property_owner_on_user_create
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.link_property_owner_user();


### PR DESCRIPTION
## S4-2 · Owner Portal v2 con login real

Reemplaza el portal v1 basado en `OWNER_TOKEN` compartido global por un portal con autenticación real, scoped a las propiedades del owner logueado.

### Antes (v1, legacy)
- Token compartido `OWNER_TOKEN` en env
- Resolvía "primera org" via shim deprecated
- Mostraba TODAS las unidades de la org (no solo las del owner)
- Una sola URL `/owner/[token]` para todos los owners

### Después (v2)
- Login con email/password real
- `property_owners.user_id` enlaza al `auth.users`
- Solo muestra edificios donde el owner tiene `ownership_stake` activo
- Multi-tenant desde el lado del owner: un mismo email puede ser owner en varias PM Companies
- Trigger DB enlaza `user_id` automáticamente cuando un invitee se registra
- Sistema de `owner_invites` con tokens, expiración 14 días, status (pending/accepted/revoked/expired)

### Cambios

**Base de datos** (migración aplicada en `zlcgxmllaeweypyodvzk`):
- `owner_invites` con RLS para `pm_owner`/`pm_admin` + self-read por email
- Índices en `property_owners.user_id` y `lower(email)`
- Trigger `link_property_owner_user()` que enlaza `user_id` al registrarse
- Backfill automático de `user_id` para owners con email matching

**Backend**:
- `src/lib/owner-context.ts` — `resolveOwnerContext()`, `tryResolveOwnerContext()`, `ownerBuildingIds()`
- `src/app/api/owner-invites/route.ts` — GET/POST para que admins inviten

**Frontend**:
- `/owner` dashboard con KPIs (edificios, unidades, ocupación, ingresos del mes)
- `/owner/buildings/[id]` detalle con auth check (solo edificios del owner)
- Tema diferenciado (badge violeta "Portal Propietario", sin Sidebar de PM)
- `/login?next=/owner&role=owner` respeta deep-link y muestra "Portal Propietario"

### Compatibilidad
- `/owner/[token]` legacy sigue funcionando — owners existentes no se rompen
- Migración gradual: cada owner que reciba invite se mueve al nuevo portal
- Plan de eliminar legacy en S5 después de validar adopción

### Plan
- `S4-3` Agente Cobranza v1 + infra agentes
- `S4-4` E2E testing producción
- `S4-5` Handoff Notion + Feature Board
