### PR TITLE
S4-3: Agente Cobranza v1 + infra común agentes (10+1)

### DIFF
--- a/src/app/agents/AgentRunButton.tsx
+++ b/src/app/agents/AgentRunButton.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  agentId: string
+  agentName: string
+}
+
+export default function AgentRunButton({ agentId, agentName }: Props) {
+  const router = useRouter()
+  const [running, setRunning] = useState(false)
+  const [result, setResult] = useState<string | null>(null)
+
+  async function invoke(dryRun: boolean) {
+    setRunning(true)
+    setResult(null)
+    try {
+      const res = await fetch(`/api/agents/${agentId}/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dry_run: dryRun }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        const m = data.data?.result?.metrics || {}
+        setResult(`${data.data.status} · ${m.actions_ok || 0}✓ ${m.actions_failed || 0}✗`)
+        router.refresh()
+      } else {
+        setResult(`error: ${data.error || 'unknown'}`)
+      }
+    } catch (e) {
+      setResult(`error: ${e instanceof Error ? e.message : 'network'}`)
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-2">
+        <button
+          onClick={() => invoke(true)}
+          disabled={running}
+          className="flex-1 text-[11px] px-3 py-1.5 rounded-md font-medium transition-opacity disabled:opacity-50"
+          style={{
+            backgroundColor: 'var(--baw-surface-alt, var(--baw-surface))',
+            color: 'var(--baw-text)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          {running ? '…' : `Dry-run ${agentName}`}
+        </button>
+        <button
+          onClick={() => invoke(false)}
+          disabled={running}
+          className="flex-1 text-[11px] px-3 py-1.5 rounded-md font-medium transition-opacity disabled:opacity-50"
+          style={{
+            backgroundColor: 'var(--baw-accent, #7c3aed)',
+            color: '#fff',
+          }}
+        >
+          {running ? '…' : 'Ejecutar'}
+        </button>
+      </div>
+      {result && (
+        <div className="text-[11px] tabular-nums" style={{ color: 'var(--baw-muted)' }}>
+          {result}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,0 +1,261 @@
+// BaW OS — /agents · Catálogo + invocación + runs (S4-3)
+
+import Link from 'next/link'
+import { createServiceClient } from '@/lib/api-auth'
+import { resolveOrgId } from '@/lib/org-context'
+import { listImplementedAgents } from '@/lib/agents/registry'
+import AgentRunButton from './AgentRunButton'
+
+export const dynamic = 'force-dynamic'
+
+interface AgentRow {
+  id: string
+  display_name: string
+  full_name: string
+  family: string
+  domain: string
+  description: string | null
+  capability_level: number
+  feedback_level: number
+  status: string
+  is_shared_zxy: boolean
+}
+
+interface AgentRunRow {
+  id: string
+  agent_id: string
+  triggered_by: string
+  status: string
+  started_at: string
+  finished_at: string | null
+  duration_ms: number | null
+  metrics: { actions_total?: number; actions_ok?: number; actions_failed?: number; actions_skipped?: number } | null
+  error: string | null
+}
+
+async function loadData() {
+  const supabase = createServiceClient()
+  let orgId: string | null = null
+  try {
+    orgId = await resolveOrgId()
+  } catch {
+    orgId = null
+  }
+
+  const { data: agentsData } = await supabase
+    .from('agents')
+    .select('*')
+    .order('family')
+    .order('display_name')
+
+  let runs: AgentRunRow[] = []
+  if (orgId) {
+    const { data: runsData } = await supabase
+      .from('agent_runs')
+      .select('id, agent_id, triggered_by, status, started_at, finished_at, duration_ms, metrics, error')
+      .eq('org_id', orgId)
+      .order('started_at', { ascending: false })
+      .limit(20)
+    runs = (runsData || []) as AgentRunRow[]
+  }
+
+  return { agents: (agentsData || []) as AgentRow[], runs, orgId }
+}
+
+const FAMILY_LABEL: Record<string, string> = {
+  'baw-coord': 'BaW · Coordinador',
+  'pm-ops': 'PM Operations',
+  'zxy-shared': 'ZXY Shared',
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, { bg: string; fg: string }> = {
+    live: { bg: 'rgba(34,197,94,0.12)', fg: '#22c55e' },
+    beta: { bg: 'rgba(168,85,247,0.12)', fg: '#a855f7' },
+    planned: { bg: 'rgba(148,163,184,0.12)', fg: '#94a3b8' },
+    paused: { bg: 'rgba(234,179,8,0.12)', fg: '#eab308' },
+    deprecated: { bg: 'rgba(239,68,68,0.12)', fg: '#ef4444' },
+  }
+  const s = styles[status] || styles.planned
+  return (
+    <span
+      className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full"
+      style={{ backgroundColor: s.bg, color: s.fg }}
+    >
+      {status}
+    </span>
+  )
+}
+
+function RunStatusBadge({ status }: { status: string }) {
+  const styles: Record<string, { bg: string; fg: string }> = {
+    running: { bg: 'rgba(59,130,246,0.12)', fg: '#3b82f6' },
+    succeeded: { bg: 'rgba(34,197,94,0.12)', fg: '#22c55e' },
+    failed: { bg: 'rgba(239,68,68,0.12)', fg: '#ef4444' },
+    partial: { bg: 'rgba(234,179,8,0.12)', fg: '#eab308' },
+    canceled: { bg: 'rgba(148,163,184,0.12)', fg: '#94a3b8' },
+  }
+  const s = styles[status] || styles.canceled
+  return (
+    <span
+      className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full"
+      style={{ backgroundColor: s.bg, color: s.fg }}
+    >
+      {status}
+    </span>
+  )
+}
+
+export default async function AgentsPage() {
+  const { agents, runs, orgId } = await loadData()
+  const implemented = new Set<string>(listImplementedAgents())
+
+  const grouped = agents.reduce<Record<string, AgentRow[]>>((acc, a) => {
+    acc[a.family] = acc[a.family] || []
+    acc[a.family].push(a)
+    return acc
+  }, {})
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1
+          className="text-[24px] font-semibold mb-1"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Agentes
+        </h1>
+        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          10+1 agentes BaW OS · BaW coordinador + 4 PM-Ops + 6 ZXY shared. v1: Cobranza dunning.
+        </p>
+      </div>
+
+      {Object.entries(grouped).map(([family, list]) => (
+        <section key={family}>
+          <h2
+            className="text-[14px] font-semibold mb-3 uppercase tracking-wider"
+            style={{ color: 'var(--baw-muted)' }}
+          >
+            {FAMILY_LABEL[family] || family}
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {list.map((a) => {
+              const isImpl = implemented.has(a.id)
+              return (
+                <div
+                  key={a.id}
+                  className="rounded-lg p-4 flex flex-col gap-3"
+                  style={{
+                    backgroundColor: 'var(--baw-surface)',
+                    border: '1px solid var(--baw-border)',
+                  }}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <div
+                        className="text-[15px] font-semibold"
+                        style={{ color: 'var(--baw-text)' }}
+                      >
+                        {a.full_name}
+                      </div>
+                      <div
+                        className="text-[11px] mt-0.5"
+                        style={{ color: 'var(--baw-muted)' }}
+                      >
+                        {a.domain} · L{a.capability_level} · F{a.feedback_level}
+                      </div>
+                    </div>
+                    <StatusBadge status={a.status} />
+                  </div>
+                  {a.description && (
+                    <p
+                      className="text-[12px] leading-relaxed"
+                      style={{ color: 'var(--baw-muted)' }}
+                    >
+                      {a.description}
+                    </p>
+                  )}
+                  {isImpl && orgId ? (
+                    <AgentRunButton agentId={a.id} agentName={a.display_name} />
+                  ) : (
+                    <div
+                      className="text-[11px] italic"
+                      style={{ color: 'var(--baw-muted)' }}
+                    >
+                      {!orgId ? 'requiere sesión activa' : 'pendiente de implementación'}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      ))}
+
+      <section>
+        <h2
+          className="text-[14px] font-semibold mb-3 uppercase tracking-wider"
+          style={{ color: 'var(--baw-muted)' }}
+        >
+          Runs recientes
+        </h2>
+        {runs.length === 0 ? (
+          <div
+            className="rounded-lg p-4 text-[12px]"
+            style={{
+              backgroundColor: 'var(--baw-surface)',
+              border: '1px solid var(--baw-border)',
+              color: 'var(--baw-muted)',
+            }}
+          >
+            Aún no hay runs en este tenant. Invoca a un agente para ver el historial.
+          </div>
+        ) : (
+          <div
+            className="rounded-lg overflow-hidden"
+            style={{ border: '1px solid var(--baw-border)' }}
+          >
+            <table className="w-full text-[12px]">
+              <thead style={{ backgroundColor: 'var(--baw-surface)' }}>
+                <tr>
+                  <th className="text-left p-2" style={{ color: 'var(--baw-muted)' }}>Agente</th>
+                  <th className="text-left p-2" style={{ color: 'var(--baw-muted)' }}>Trigger</th>
+                  <th className="text-left p-2" style={{ color: 'var(--baw-muted)' }}>Estado</th>
+                  <th className="text-left p-2" style={{ color: 'var(--baw-muted)' }}>Acciones</th>
+                  <th className="text-left p-2" style={{ color: 'var(--baw-muted)' }}>Duración</th>
+                  <th className="text-left p-2" style={{ color: 'var(--baw-muted)' }}>Inicio</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((r) => {
+                  const m = r.metrics || {}
+                  return (
+                    <tr key={r.id} style={{ borderTop: '1px solid var(--baw-border)' }}>
+                      <td className="p-2" style={{ color: 'var(--baw-text)' }}>{r.agent_id}</td>
+                      <td className="p-2" style={{ color: 'var(--baw-muted)' }}>{r.triggered_by}</td>
+                      <td className="p-2"><RunStatusBadge status={r.status} /></td>
+                      <td className="p-2 tabular-nums" style={{ color: 'var(--baw-muted)' }}>
+                        {(m.actions_ok || 0)}✓ · {(m.actions_failed || 0)}✗
+                        {m.actions_skipped ? ` · ${m.actions_skipped}↷` : ''}
+                      </td>
+                      <td className="p-2 tabular-nums" style={{ color: 'var(--baw-muted)' }}>
+                        {r.duration_ms != null ? `${r.duration_ms}ms` : '—'}
+                      </td>
+                      <td className="p-2 tabular-nums" style={{ color: 'var(--baw-muted)' }}>
+                        {new Date(r.started_at).toLocaleString('es-MX')}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <div className="text-[11px]" style={{ color: 'var(--baw-muted)' }}>
+        <Link href="/admin" className="underline">L0 Platform admin</Link> · Catálogo de agentes solo editable por platform admins.
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/agents/[id]/run/route.ts
+++ b/src/app/api/agents/[id]/run/route.ts
@@ -1,0 +1,58 @@
+// BaW OS — POST /api/agents/[id]/run · invoca un agente
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveOrgId, OrgContextError } from '@/lib/org-context'
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { getAgentRunner } from '@/lib/agents/registry'
+import { executeAgentRun } from '@/lib/agents/runner'
+import type { AgentId } from '@/lib/agents/types'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  const agentId = params.id as AgentId
+  const runner = getAgentRunner(agentId)
+
+  if (!runner) {
+    return NextResponse.json(
+      { success: false, error: `Agente '${agentId}' no implementado o aún 'planned'` },
+      { status: 404 },
+    )
+  }
+
+  let orgId: string
+  try {
+    orgId = await resolveOrgId()
+  } catch (e) {
+    if (e instanceof OrgContextError) {
+      return NextResponse.json({ success: false, error: e.message }, { status: 401 })
+    }
+    return NextResponse.json({ success: false, error: 'org_resolve_failed' }, { status: 500 })
+  }
+
+  const supabase = createSupabaseServer()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  let body: Record<string, unknown> = {}
+  try {
+    body = await request.json()
+  } catch {
+    body = {}
+  }
+
+  try {
+    const result = await executeAgentRun(runner, {
+      orgId,
+      agentId,
+      triggeredBy: 'manual',
+      triggeredByUser: user?.id || null,
+      input: body,
+    })
+
+    return NextResponse.json({ success: true, data: result })
+  } catch (e) {
+    return NextResponse.json(
+      { success: false, error: e instanceof Error ? e.message : 'run_failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,0 +1,19 @@
+// BaW OS — GET /api/agents · listado catálogo
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const supabase = createServiceClient()
+  const { data, error } = await supabase
+    .from('agents')
+    .select('id, display_name, full_name, family, domain, description, capability_level, feedback_level, status, is_shared_zxy')
+    .order('family', { ascending: true })
+    .order('display_name', { ascending: true })
+
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ success: true, data: data || [] })
+}

--- a/src/app/api/agents/runs/route.ts
+++ b/src/app/api/agents/runs/route.ts
@@ -1,0 +1,38 @@
+// BaW OS — GET /api/agents/runs · runs recientes del tenant activo
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveOrgId, OrgContextError } from '@/lib/org-context'
+import { createServiceClient } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  let orgId: string
+  try {
+    orgId = await resolveOrgId()
+  } catch (e) {
+    if (e instanceof OrgContextError) {
+      return NextResponse.json({ success: false, error: e.message }, { status: 401 })
+    }
+    return NextResponse.json({ success: false, error: 'org_resolve_failed' }, { status: 500 })
+  }
+
+  const url = new URL(request.url)
+  const limit = Math.min(Number(url.searchParams.get('limit') || '20'), 100)
+  const agentFilter = url.searchParams.get('agent_id')
+
+  const supabase = createServiceClient()
+  let query = supabase
+    .from('agent_runs')
+    .select('id, agent_id, triggered_by, status, started_at, finished_at, duration_ms, metrics, error')
+    .eq('org_id', orgId)
+    .order('started_at', { ascending: false })
+    .limit(limit)
+
+  if (agentFilter) query = query.eq('agent_id', agentFilter)
+
+  const { data, error } = await query
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ success: true, data: data || [] })
+}

--- a/src/lib/agents/cobranza.ts
+++ b/src/lib/agents/cobranza.ts
@@ -1,0 +1,199 @@
+// BaW OS — Agente Cobranza v1 (S4-3)
+// Ejecuta dunning sobre payments overdue: detecta mora, escala niveles, registra notificaciones.
+// Reutiliza la lógica de mora-engine. v1 = dry-run + audit; v2 enviará emails/whatsapp reales.
+
+import { createServiceClient } from '@/lib/api-auth'
+import { getMoraLevel } from '@/lib/mora-engine'
+import type { AgentRunContext, AgentRunResult, AgentRunner } from './types'
+
+interface PaymentRow {
+  id: string
+  contract_id: string | null
+  due_date: string
+  amount: number | null
+  rent_amount: number | null
+  water_fee: number | null
+  status: string | null
+  confirmed_at: string | null
+  org_id: string
+}
+
+interface ContractRow {
+  id: string
+  unit_id: string | null
+  tenant_name: string | null
+  org_id: string
+}
+
+interface UnitRow {
+  id: string
+  unit_number: string | null
+  building_id: string | null
+}
+
+export const cobranzaRunner: AgentRunner = {
+  agentId: 'cobranza',
+
+  async run(ctx: AgentRunContext): Promise<AgentRunResult> {
+    const supabase = createServiceClient()
+    const dryRun = ctx.input.dry_run !== false // por defecto dry-run en v1
+    const today = new Date()
+
+    // 1. Cargar payments overdue (no confirmados, due_date pasado) del org actual
+    const { data: payments, error: pErr } = await supabase
+      .from('payments')
+      .select('id, contract_id, due_date, amount, rent_amount, water_fee, status, confirmed_at, org_id')
+      .eq('org_id', ctx.orgId)
+      .is('confirmed_at', null)
+      .lte('due_date', today.toISOString().slice(0, 10))
+      .limit(500)
+
+    if (pErr) {
+      await ctx.recordAction({
+        action_type: 'cobranza.fetch_payments',
+        status: 'failed',
+        error: pErr.message,
+      })
+      return {
+        output: { error: 'fetch_payments_failed' },
+        metrics: { actions_total: 1, actions_ok: 0, actions_failed: 1 },
+      }
+    }
+
+    const overdue = (payments || []) as PaymentRow[]
+
+    if (overdue.length === 0) {
+      await ctx.recordAction({
+        action_type: 'cobranza.scan_complete',
+        status: 'ok',
+        result: { overdue_count: 0 },
+      })
+      return {
+        output: { message: 'no overdue payments', overdue_count: 0 },
+        metrics: { actions_total: 1, actions_ok: 1, actions_failed: 0 },
+      }
+    }
+
+    // 2. Agrupar por contract_id, calcular días de mora
+    const byContract = new Map<string, PaymentRow[]>()
+    for (const p of overdue) {
+      if (!p.contract_id) continue
+      const arr = byContract.get(p.contract_id) || []
+      arr.push(p)
+      byContract.set(p.contract_id, arr)
+    }
+
+    const contractIds = Array.from(byContract.keys())
+    let contracts: ContractRow[] = []
+    if (contractIds.length > 0) {
+      const { data: cRows } = await supabase
+        .from('contracts')
+        .select('id, unit_id, tenant_name, org_id')
+        .in('id', contractIds)
+      contracts = (cRows || []) as ContractRow[]
+    }
+
+    const unitIds = contracts.map((c) => c.unit_id).filter(Boolean) as string[]
+    let units: UnitRow[] = []
+    if (unitIds.length > 0) {
+      const { data: uRows } = await supabase
+        .from('units')
+        .select('id, unit_number, building_id')
+        .in('id', unitIds)
+      units = (uRows || []) as UnitRow[]
+    }
+
+    let actionsOk = 0
+    let actionsFailed = 0
+    let actionsSkipped = 0
+    const escalations: Record<string, number> = { grace: 0, warning: 0, critical: 0, legal: 0, abogado: 0 }
+
+    for (const contract of contracts) {
+      const contractPayments = byContract.get(contract.id) || []
+      const oldest = contractPayments.reduce((acc, p) =>
+        new Date(p.due_date) < new Date(acc.due_date) ? p : acc,
+      contractPayments[0])
+
+      const daysPastDue = Math.floor((today.getTime() - new Date(oldest.due_date).getTime()) / 86400000)
+      const level = getMoraLevel(daysPastDue)
+      escalations[level] = (escalations[level] || 0) + 1
+
+      const totalOverdue = contractPayments.reduce((sum, p) => {
+        const amount = Number(p.amount || (Number(p.rent_amount || 0) + Number(p.water_fee || 0)))
+        return sum + amount
+      }, 0)
+
+      const unit = units.find((u) => u.id === contract.unit_id)
+
+      if (level === 'grace') {
+        await ctx.recordAction({
+          action_type: 'cobranza.skip_grace',
+          entity_type: 'contract',
+          entity_id: contract.id,
+          status: 'skipped',
+          payload: { days_past_due: daysPastDue, level },
+        })
+        actionsSkipped++
+        continue
+      }
+
+      // v1: registrar acción de notificación (dry-run por defecto)
+      const notifyStatus = dryRun ? 'pending_approval' : 'ok'
+      await ctx.recordAction({
+        action_type: 'cobranza.notify',
+        entity_type: 'contract',
+        entity_id: contract.id,
+        status: notifyStatus,
+        payload: {
+          dry_run: dryRun,
+          tenant_name: contract.tenant_name,
+          unit_number: unit?.unit_number,
+          days_past_due: daysPastDue,
+          level,
+          total_overdue: totalOverdue,
+          payments_count: contractPayments.length,
+        },
+        result: dryRun
+          ? { message: 'dry-run: notificación NO enviada, requiere aprobación humana' }
+          : { message: 'notificación registrada en audit' },
+      })
+
+      // En no-dry-run, además escribimos a audit_log para backward-compat con /api/mora/notify
+      if (!dryRun) {
+        await supabase.from('audit_log').insert({
+          org_id: ctx.orgId,
+          actor_type: 'agent',
+          actor_id: 'cobranza',
+          action: 'mora.notificacion_enviada',
+          entity_type: 'contract',
+          entity_id: contract.id,
+          metadata: {
+            unit_number: unit?.unit_number,
+            tenant_name: contract.tenant_name,
+            days_past_due: daysPastDue,
+            total_overdue: totalOverdue,
+            level,
+            run_id: ctx.runId,
+          },
+        })
+      }
+
+      actionsOk++
+    }
+
+    return {
+      output: {
+        overdue_count: overdue.length,
+        contracts_processed: contracts.length,
+        escalations,
+        dry_run: dryRun,
+      },
+      metrics: {
+        actions_total: actionsOk + actionsFailed + actionsSkipped,
+        actions_ok: actionsOk,
+        actions_failed: actionsFailed,
+        actions_skipped: actionsSkipped,
+      },
+    }
+  },
+}

--- a/src/lib/agents/registry.ts
+++ b/src/lib/agents/registry.ts
@@ -1,0 +1,17 @@
+// BaW OS — Registry de runners disponibles (S4-3)
+// Solo Cobranza v1 implementado. El resto se suma cuando salgan de 'planned'.
+
+import { cobranzaRunner } from './cobranza'
+import type { AgentId, AgentRunner } from './types'
+
+const REGISTRY: Partial<Record<AgentId, AgentRunner>> = {
+  cobranza: cobranzaRunner,
+}
+
+export function getAgentRunner(agentId: AgentId): AgentRunner | null {
+  return REGISTRY[agentId] || null
+}
+
+export function listImplementedAgents(): AgentId[] {
+  return Object.keys(REGISTRY) as AgentId[]
+}

--- a/src/lib/agents/runner.ts
+++ b/src/lib/agents/runner.ts
@@ -1,0 +1,105 @@
+// BaW OS — Orquestador genérico de runs de agentes (S4-3)
+// Crea un agent_run, invoca el runner específico, registra acciones, finaliza.
+
+import { createServiceClient } from '@/lib/api-auth'
+import type {
+  AgentActionInput,
+  AgentId,
+  AgentRunContext,
+  AgentRunResult,
+  AgentRunner,
+  AgentTrigger,
+} from './types'
+
+interface RunOptions {
+  orgId: string
+  agentId: AgentId
+  triggeredBy: AgentTrigger
+  triggeredByUser?: string | null
+  input?: Record<string, unknown>
+}
+
+export async function executeAgentRun(
+  runner: AgentRunner,
+  opts: RunOptions,
+): Promise<{ runId: string; status: 'succeeded' | 'failed' | 'partial'; result: AgentRunResult; error?: string }> {
+  const supabase = createServiceClient()
+  const startedAt = Date.now()
+
+  const { data: runRow, error: runErr } = await supabase
+    .from('agent_runs')
+    .insert({
+      org_id: opts.orgId,
+      agent_id: opts.agentId,
+      triggered_by: opts.triggeredBy,
+      triggered_by_user: opts.triggeredByUser || null,
+      status: 'running',
+      input: opts.input || {},
+    })
+    .select('id')
+    .single()
+
+  if (runErr || !runRow) {
+    throw new Error(`No se pudo crear agent_run: ${runErr?.message || 'unknown'}`)
+  }
+
+  const runId = runRow.id as string
+  const collectedActions: AgentActionInput[] = []
+
+  const recordAction = async (action: AgentActionInput) => {
+    collectedActions.push(action)
+    await supabase.from('agent_actions').insert({
+      run_id: runId,
+      org_id: opts.orgId,
+      agent_id: opts.agentId,
+      action_type: action.action_type,
+      entity_type: action.entity_type || null,
+      entity_id: action.entity_id || null,
+      status: action.status || 'ok',
+      payload: action.payload || {},
+      result: action.result || {},
+      error: action.error || null,
+    })
+  }
+
+  const ctx: AgentRunContext = {
+    runId,
+    orgId: opts.orgId,
+    agentId: opts.agentId,
+    triggeredBy: opts.triggeredBy,
+    triggeredByUser: opts.triggeredByUser || undefined,
+    input: opts.input || {},
+    recordAction,
+  }
+
+  let status: 'succeeded' | 'failed' | 'partial' = 'succeeded'
+  let result: AgentRunResult = { output: {}, metrics: { actions_total: 0, actions_ok: 0, actions_failed: 0 } }
+  let errMessage: string | undefined
+
+  try {
+    result = await runner.run(ctx)
+    if (result.metrics.actions_failed > 0 && result.metrics.actions_ok > 0) {
+      status = 'partial'
+    } else if (result.metrics.actions_failed > 0 && result.metrics.actions_ok === 0) {
+      status = 'failed'
+    }
+  } catch (e) {
+    status = 'failed'
+    errMessage = e instanceof Error ? e.message : String(e)
+  }
+
+  const finishedAt = Date.now()
+  await supabase
+    .from('agent_runs')
+    .update({
+      status,
+      finished_at: new Date(finishedAt).toISOString(),
+      duration_ms: finishedAt - startedAt,
+      output: result.output,
+      metrics: result.metrics,
+      error: errMessage || null,
+    })
+    .eq('id', runId)
+
+  return { runId, status, result, error: errMessage }
+}

--- a/src/lib/agents/types.ts
+++ b/src/lib/agents/types.ts
@@ -1,0 +1,53 @@
+// BaW OS — Tipos compartidos infra agentes (S4-3)
+
+export type AgentId =
+  | 'baw'
+  | 'cobranza'
+  | 'reservas'
+  | 'mantenimiento'
+  | 'huesped'
+  | 'hugo-cos'
+  | 'alicia-ops'
+  | 'conta-beto'
+  | 'maribel-law'
+  | 'luis-growth'
+  | 'andres-tech'
+
+export type AgentRunStatus = 'running' | 'succeeded' | 'failed' | 'partial' | 'canceled'
+export type AgentTrigger = 'manual' | 'cron' | 'webhook' | 'agent'
+export type AgentActionStatus = 'ok' | 'failed' | 'skipped' | 'pending_approval'
+
+export interface AgentActionInput {
+  action_type: string
+  entity_type?: string
+  entity_id?: string
+  status?: AgentActionStatus
+  payload?: Record<string, unknown>
+  result?: Record<string, unknown>
+  error?: string
+}
+
+export interface AgentRunContext {
+  runId: string
+  orgId: string
+  agentId: AgentId
+  triggeredBy: AgentTrigger
+  triggeredByUser?: string
+  input: Record<string, unknown>
+  recordAction: (action: AgentActionInput) => Promise<void>
+}
+
+export interface AgentRunResult {
+  output: Record<string, unknown>
+  metrics: {
+    actions_total: number
+    actions_ok: number
+    actions_failed: number
+    actions_skipped?: number
+  }
+}
+
+export interface AgentRunner {
+  agentId: AgentId
+  run: (ctx: AgentRunContext) => Promise<AgentRunResult>
+}

--- a/supabase/migrations/20260429_06_agents_infra.sql
+++ b/supabase/migrations/20260429_06_agents_infra.sql
@@ -1,0 +1,137 @@
+-- S4-3: Infra común agentes BaW OS — 10+1 agentes ZXY
+-- Tablas: agents (catálogo), agent_runs (ejecuciones), agent_actions (efectos auditables)
+-- BaW = Building Always Working (coordinador, no es uno de los 10)
+
+-- Catálogo de agentes ZXY
+CREATE TABLE IF NOT EXISTS public.agents (
+  id TEXT PRIMARY KEY,                -- slug estable: 'cobranza', 'hugo-cos', etc.
+  display_name TEXT NOT NULL,         -- 'Cobranza' (sin "Agente" prefix)
+  full_name TEXT NOT NULL,            -- 'Agente Cobranza' for UI labels
+  family TEXT NOT NULL,               -- 'pm-ops' | 'zxy-shared' | 'baw-coord'
+  domain TEXT NOT NULL,               -- 'finanzas' | 'ops' | 'legal' | etc.
+  description TEXT,
+  capability_level INT NOT NULL DEFAULT 0,  -- L0-L4 (autonomy framework)
+  feedback_level INT NOT NULL DEFAULT 0,    -- F0-F5 (feedback maturity)
+  status TEXT NOT NULL DEFAULT 'planned' CHECK (status IN ('planned','beta','live','paused','deprecated')),
+  is_shared_zxy BOOLEAN NOT NULL DEFAULT false,  -- agentes ZXY no tienen L0
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Ejecuciones de agentes (1 run = 1 invocación, manual o cron)
+CREATE TABLE IF NOT EXISTS public.agent_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL REFERENCES public.agents(id) ON DELETE RESTRICT,
+  triggered_by TEXT NOT NULL CHECK (triggered_by IN ('manual','cron','webhook','agent')),
+  triggered_by_user UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'running' CHECK (status IN ('running','succeeded','failed','partial','canceled')),
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  finished_at TIMESTAMPTZ,
+  duration_ms INT,
+  input JSONB NOT NULL DEFAULT '{}'::jsonb,
+  output JSONB NOT NULL DEFAULT '{}'::jsonb,
+  error TEXT,
+  metrics JSONB NOT NULL DEFAULT '{}'::jsonb  -- {actions_total, actions_ok, actions_failed, ...}
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_runs_org_started ON public.agent_runs(org_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_runs_agent_started ON public.agent_runs(agent_id, started_at DESC);
+
+-- Acciones individuales que un run produjo (auditables granular)
+CREATE TABLE IF NOT EXISTS public.agent_actions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL REFERENCES public.agent_runs(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL REFERENCES public.agents(id),
+  action_type TEXT NOT NULL,          -- 'mora.notify' | 'email.send' | 'task.create' | etc.
+  entity_type TEXT,
+  entity_id TEXT,
+  status TEXT NOT NULL DEFAULT 'ok' CHECK (status IN ('ok','failed','skipped','pending_approval')),
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  result JSONB NOT NULL DEFAULT '{}'::jsonb,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_actions_run ON public.agent_actions(run_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_agent_actions_org_agent ON public.agent_actions(org_id, agent_id, created_at DESC);
+
+-- RLS
+ALTER TABLE public.agents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.agent_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.agent_actions ENABLE ROW LEVEL SECURITY;
+
+-- Catálogo agents: legible por todo usuario autenticado, escritura solo platform admin
+DROP POLICY IF EXISTS agents_select_all ON public.agents;
+CREATE POLICY agents_select_all ON public.agents FOR SELECT USING (auth.role() = 'authenticated');
+
+DROP POLICY IF EXISTS agents_write_platform ON public.agents;
+CREATE POLICY agents_write_platform ON public.agents FOR ALL
+  USING (EXISTS (SELECT 1 FROM public.platform_admins WHERE user_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.platform_admins WHERE user_id = auth.uid()));
+
+-- agent_runs: visible para miembros del tenant
+DROP POLICY IF EXISTS agent_runs_select ON public.agent_runs;
+CREATE POLICY agent_runs_select ON public.agent_runs FOR SELECT USING (
+  EXISTS (SELECT 1 FROM public.org_members om WHERE om.org_id = agent_runs.org_id AND om.user_id = auth.uid())
+  OR EXISTS (SELECT 1 FROM public.platform_admins pa WHERE pa.user_id = auth.uid())
+);
+
+DROP POLICY IF EXISTS agent_runs_write_member ON public.agent_runs;
+CREATE POLICY agent_runs_write_member ON public.agent_runs FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM public.org_members om WHERE om.org_id = agent_runs.org_id AND om.user_id = auth.uid())
+);
+
+DROP POLICY IF EXISTS agent_runs_update_member ON public.agent_runs;
+CREATE POLICY agent_runs_update_member ON public.agent_runs FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM public.org_members om WHERE om.org_id = agent_runs.org_id AND om.user_id = auth.uid())
+);
+
+-- agent_actions: idem
+DROP POLICY IF EXISTS agent_actions_select ON public.agent_actions;
+CREATE POLICY agent_actions_select ON public.agent_actions FOR SELECT USING (
+  EXISTS (SELECT 1 FROM public.org_members om WHERE om.org_id = agent_actions.org_id AND om.user_id = auth.uid())
+  OR EXISTS (SELECT 1 FROM public.platform_admins pa WHERE pa.user_id = auth.uid())
+);
+
+DROP POLICY IF EXISTS agent_actions_write ON public.agent_actions;
+CREATE POLICY agent_actions_write ON public.agent_actions FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM public.org_members om WHERE om.org_id = agent_actions.org_id AND om.user_id = auth.uid())
+);
+
+-- Seed catálogo 10 + 1 agentes (BaW coordinador + 10 especializados)
+-- Familia pm-ops: 4 agentes específicos del PM
+-- Familia zxy-shared: 6 agentes ZXY (sin L0, compartidos entre tenants ZXY)
+INSERT INTO public.agents (id, display_name, full_name, family, domain, description, capability_level, feedback_level, status, is_shared_zxy)
+VALUES
+  ('baw',         'BaW',        'BaW',                  'baw-coord',  'coord',     'Coordinador Building Always Working — orquestador raíz',                  1, 1, 'beta',    false),
+  ('cobranza',    'Cobranza',   'Agente Cobranza',      'pm-ops',     'finanzas',  'Dunning automatizado: detecta mora, escala niveles, notifica',           1, 1, 'beta',    false),
+  ('reservas',    'Reservas',   'Agente Reservas',      'pm-ops',     'ops',       'Channex sync, disponibilidad, pricing dinámico',                          0, 0, 'planned', false),
+  ('mantenimiento','Mantenimiento','Agente Mantenimiento','pm-ops',   'ops',       'Tareas, vendors, SLA en unidades',                                        0, 0, 'planned', false),
+  ('huesped',     'Huésped',    'Agente Huésped',       'pm-ops',     'cx',        'Onboarding, check-in, soporte huésped',                                   0, 0, 'planned', false),
+  ('hugo-cos',    'Hugo-COS',   'Agente Hugo-COS',      'zxy-shared', 'ops',       'Chief of Staff ZXY — coordinación cross-vc',                              0, 0, 'planned', true),
+  ('alicia-ops',  'Alicia-Ops', 'Agente Alicia-Ops',    'zxy-shared', 'ops',       'Operaciones internas ZXY',                                                0, 0, 'planned', true),
+  ('conta-beto',  'Conta-Beto', 'Agente Conta-Beto',    'zxy-shared', 'finanzas',  'Contabilidad, conciliación, facturación CFDI',                            0, 0, 'planned', true),
+  ('maribel-law', 'Maribel-Law','Agente Maribel-Law',   'zxy-shared', 'legal',     'Legal: contratos, NDA, cumplimiento',                                     0, 0, 'planned', true),
+  ('luis-growth', 'Luis-Growth','Agente Luis-Growth',   'zxy-shared', 'growth',    'Growth, marketing, captación',                                            0, 0, 'planned', true),
+  ('andres-tech', 'Andres-Tech','Agente Andres-Tech',   'zxy-shared', 'tech',      'Plataforma, infra, build siempre verde',                                  0, 0, 'planned', true)
+ON CONFLICT (id) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  full_name = EXCLUDED.full_name,
+  family = EXCLUDED.family,
+  domain = EXCLUDED.domain,
+  description = EXCLUDED.description,
+  is_shared_zxy = EXCLUDED.is_shared_zxy,
+  updated_at = now();
+
+-- Trigger updated_at
+CREATE OR REPLACE FUNCTION public.touch_agents_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_agents_updated_at ON public.agents;
+CREATE TRIGGER trg_agents_updated_at BEFORE UPDATE ON public.agents
+  FOR EACH ROW EXECUTE FUNCTION public.touch_agents_updated_at();


### PR DESCRIPTION
## Sprint 4 — S4-3 · Agente Cobranza v1 + infra común agentes

Primera entrega de la capa de agentes BaW OS. Establece infraestructura común y entrega Cobranza v1 funcional.

### Migración SQL aplicada en producción
\`supabase/migrations/20260429_06_agents_infra.sql\`

- **\`agents\`** — catálogo 10+1: BaW (coordinador) + 4 PM-Ops (Cobranza, Reservas, Mantenimiento, Huésped) + 6 ZXY shared (Hugo-COS, Alicia-Ops, Conta-Beto, Maribel-Law, Luis-Growth, Andres-Tech). Campos: family, domain, capability_level (L0-L4), feedback_level (F0-F5), status, is_shared_zxy.
- **\`agent_runs\`** — una fila por invocación (manual/cron/webhook), con input/output/metrics/duration_ms.
- **\`agent_actions\`** — efectos auditables granular por run (notify, skip_grace, etc.) con status ok/failed/skipped/pending_approval.
- **RLS** — agents legible por todo authenticated, escritura solo platform_admin. agent_runs / agent_actions visibles para org_members del tenant.

### Código nuevo
- \`src/lib/agents/types.ts\` — tipos compartidos (\`AgentRunner\`, \`AgentRunContext\`, \`AgentRunResult\`).
- \`src/lib/agents/runner.ts\` — \`executeAgentRun()\`: crea run row, invoca runner, registra acciones, finaliza con metrics.
- \`src/lib/agents/cobranza.ts\` — Cobranza v1: detecta payments overdue, agrupa por contrato, calcula días de mora, escala niveles vía mora-engine, registra notificaciones (dry-run por defecto).
- \`src/lib/agents/registry.ts\` — registry de runners implementados (solo \`cobranza\` por ahora).
- \`src/app/api/agents/route.ts\` — GET catálogo.
- \`src/app/api/agents/[id]/run/route.ts\` — POST invocación manual con sesión.
- \`src/app/api/agents/runs/route.ts\` — GET runs recientes del tenant.
- \`src/app/agents/page.tsx\` + \`AgentRunButton.tsx\` — UI: catálogo agrupado por familia, botones dry-run/ejecutar para implementados, tabla runs recientes.

### Comportamiento Cobranza v1
- **dry-run por defecto** (\`dry_run: true\` en POST body) — registra acciones con status \`pending_approval\`, NO escribe a audit_log.
- **dry-run: false** — escribe a \`audit_log\` con \`actor_type='agent'\`, \`actor_id='cobranza'\` (compat con \`/api/mora/notify\` legacy).
- Niveles: grace (≤5 días → skip), warning (≤15), critical (≤30), legal (≤60), abogado (>60).

### Build verde
\`/agents\` (1.01 kB) · \`/api/agents\` · \`/api/agents/[id]/run\` · \`/api/agents/runs\` · sin errores TS.

### Acuerdos canónicos respetados
- 10+1 agentes (no 12)
- BaW sin "Agente" prefijo (es el coordinador)
- Conta-Beto como agente ZXY (no persona física)
- Agentes ZXY no tienen L0 (\`is_shared_zxy=true\`)
- Sidebar \`/agents\` ya en navigation desde S4-0

### Próximo
- S4-4: E2E testing producción + bugs como issues
- S4-5: Sanear Feature Board + handoff Notion