### PR TITLE
Fix admin login loop with SSR cookies

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,49 @@
+import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
-// Simplified middleware — auth protection handled client-side
-// TODO: implement server-side auth once SSR cookie flow is resolved
+// Auth protection stays in route/layout guards and AuthGuard.
+// Middleware only keeps Supabase SSR cookies fresh so Server Components
+// (notably /admin L0 guard) can see the browser session after login.
 export async function middleware(request: NextRequest) {
-  return NextResponse.next()
+  let response = NextResponse.next({ request })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(
+          cookiesToSet: {
+            name: string
+            value: string
+            options?: Record<string, unknown>
+          }[],
+        ) {
+          cookiesToSet.forEach(({ name, value }) => {
+            request.cookies.set(name, value)
+          })
+
+          response = NextResponse.next({ request })
+
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(
+              name,
+              value,
+              options as Parameters<typeof response.cookies.set>[2],
+            )
+          })
+        },
+      },
+    },
+  )
+
+  // Required by @supabase/ssr to refresh auth cookies for Server Components.
+  await supabase.auth.getUser()
+
+  return response
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

Hotfix for the login loop reported after #30.

`/admin` validates L0 in a Server Component, but middleware was no-op, so Supabase SSR cookies were not refreshed for Server Components after client login. This keeps auth protection where it already lives, and makes middleware only refresh Supabase SSR cookies.

## Pre-flight checklist

- [x] `git fetch origin && git log origin/main --oneline -10` — revisé estado real de main
- [x] `gh pr list --state all --limit 10` — verifiqué que mi trabajo no duplica un PR ya mergeado
- [x] `git log --oneline -5 -- <archivos modificados>` — revisé historia reciente de `src/middleware.ts`
- [x] Esta rama está basada en `origin/main` actualizado (último commit visible: `7c57cac`)
- [x] Scope discipline: este PR tiene **un solo objetivo**, no mezcla mejoras de scope distinto
- [x] `npx tsc --noEmit` pasa
- [x] `npm run build` pasa

## Invariantes (sección 2 de AGENTS.md)

- [x] No toqué la tipografía Inter en `src/app/layout.tsx`
- [x] No creé sets paralelos de tokens (`--d-*`, `--brand-*`, etc.) — uso `var(--baw-*)` desde `design/baw-design/tokens/`
- [x] No agregué/quité/renombré secciones de `SIDEBAR_SECTIONS` en `src/lib/navigation.ts`
- [x] No bypass-eé `isPlatformAdmin()` ni `resolveOrgId()`
- [x] No agregué referencias al enum legacy `member_role`
- [x] No introduje agentes fuera del catálogo 10+1 (BaW + 4 PM-Ops + 6 ZXY shared)
- [x] No eliminé features mergeadas funcionales (badge notificaciones, sub-navs, etc.)

Si **alguna** invariante se viola intencionalmente, explica por qué aquí:

N/A

## Acuerdos canónicos afectados

- [x] Ninguno — este PR es estrictamente implementación dentro de los acuerdos vigentes
- [ ] Schema DB / migración SQL aplicada (link al log Notion):
- [ ] Diseño / tokens / tipografía:
- [ ] Navegación canónica:
- [ ] Roles / permisos / RLS:
- [ ] Catálogo de agentes:
- [ ] API pública:

## Verification

- [x] Build local verde
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Migraciones SQL aplicadas en producción ANTES de pushear código que las consume (si aplica) — N/A
- [ ] Preview Vercel inspeccionado visualmente (si afecta UI)

## Issues relacionados

Follow-up hotfix for #19 / #30.
References #29

## Follow-ups detectados (NO incluidos en este PR)

Ninguno.

## Merge

- [x] Confirmo que **NO** se mergeará automáticamente. Espero aprobación humana de @franduranv.
