### PR TITLE
Fix #22: webhooks usan resolveOrgIdForWebhook (multi-tenant safe)

### DIFF
--- a/src/app/api/channex/sync/route.ts
+++ b/src/app/api/channex/sync/route.ts
@@ -1,12 +1,16 @@
 // BaW OS — Sync Channex bookings → Supabase reservations
-import { NextResponse } from 'next/server'
+//
+// Sprint 5 / fix #22: el cron debe llamarse con `?org=<slug>` o
+// `x-baw-org-id` para indicar a qué tenant sincronizar. Si el caller no
+// provee org y solo hay 1 tenant en el sistema, lo usa automáticamente;
+// si hay 2+ tenants devuelve 400 (cada tenant Channex tiene su propio
+// cron URL con su org).
+import { NextRequest, NextResponse } from 'next/server'
 import { channexFetch } from '@/lib/channex'
-import { createServiceClient, getOrgIdAsync } from '@/lib/api-auth'
+import { createServiceClient } from '@/lib/api-auth'
+import { resolveOrgIdForWebhook, listAllOrgIds } from '@/lib/org-context'
 
 export const dynamic = 'force-dynamic'
-
-// TODO S4-1.5: aceptar org_id en query string del cron job (cada tenant
-// con Channex tendrá su propio cron URL con su org_id)
 
 interface ChannexBooking {
   id: string
@@ -45,8 +49,24 @@ function mapStatus(status: string | undefined): string {
   }
 }
 
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    let orgId = await resolveOrgIdForWebhook(request, null)
+    if (!orgId) {
+      const allOrgs = await listAllOrgIds()
+      if (allOrgs.length === 1) {
+        orgId = allOrgs[0]
+      } else {
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              'Missing org context. Pass ?org=<slug> or x-baw-org-id header (multi-tenant safe).',
+          },
+          { status: 400 },
+        )
+      }
+    }
     const now = new Date()
     const from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
     const params = new URLSearchParams({
@@ -62,7 +82,7 @@ export async function POST() {
     const bookings = response.data || []
 
     const supabase = createServiceClient()
-    const ORG_ID = await getOrgIdAsync()
+    const ORG_ID = orgId
     let synced = 0
     let errors = 0
 

--- a/src/app/api/channex/webhook/route.ts
+++ b/src/app/api/channex/webhook/route.ts
@@ -1,14 +1,14 @@
 // BaW OS — Channex webhook receiver for real-time booking events
+//
+// Sprint 5 / fix #22: ahora resuelve el org desde header `x-baw-org-id`,
+// `x-baw-org-slug`, query `?org=<slug>` o body `{org_id, org_slug}` en lugar
+// de "primera org por created_at". Configurar Channex para incluir el org
+// del tenant en la URL del webhook (e.g. `/api/channex/webhook?org=baw-operations`).
 import { NextRequest, NextResponse } from 'next/server'
-import { createServiceClient, getOrgIdAsync } from '@/lib/api-auth'
+import { createServiceClient } from '@/lib/api-auth'
+import { resolveOrgIdForWebhook } from '@/lib/org-context'
 
 export const dynamic = 'force-dynamic'
-
-// TODO S4-1.5: aceptar org_id en query string o header del webhook (configurable
-// por tenant en Channex). Por ahora resuelve la primera org disponible.
-async function getOrgIdForWebhook() {
-  return getOrgIdAsync()
-}
 
 function mapChannel(source: string | undefined): string {
   if (!source) return 'direct'
@@ -34,7 +34,17 @@ export async function POST(request: NextRequest) {
 
     const supabase = createServiceClient()
     const a = payload.attributes || payload
-    const orgId = await getOrgIdForWebhook()
+    const orgId = await resolveOrgIdForWebhook(request, body)
+    if (!orgId) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            'Missing org context. Configure Channex webhook URL with ?org=<slug> or send x-baw-org-id header.',
+        },
+        { status: 400 },
+      )
+    }
 
     if (event === 'booking.cancelled' || event === 'booking_cancelled') {
       const { error } = await supabase

--- a/src/app/api/mora/notify/route.ts
+++ b/src/app/api/mora/notify/route.ts
@@ -1,13 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { getMoraLevel } from '@/lib/mora-engine'
-import { getOrgIdAsync } from '@/lib/api-auth'
+import { resolveOrgIdForWebhook, listAllOrgIds } from '@/lib/org-context'
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ||
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
-// TODO S4-1.5: aceptar org_id en payload del POST request
+// Sprint 5 / fix #22: cron multi-tenant.
+// - Si el body trae `org_id` o `org_slug`, opera solo sobre ese tenant.
+// - Si no, itera sobre TODOS los tenants (default cron sin filtro).
 
 function createMoraClient() {
   return createClient(SUPABASE_URL, SUPABASE_KEY, {
@@ -15,71 +17,96 @@ function createMoraClient() {
   })
 }
 
+interface MoraEntry {
+  contractId: string
+  unitNumber: string
+  tenantName: string
+  daysPastDue: number
+  totalOverdue: number
+  level: string
+}
+
+async function notifyForOrg(
+  baseUrl: string,
+  orgId: string,
+  contractIds: string[] | undefined,
+): Promise<{ orgId: string; notified: string[] }> {
+  const moraRes = await fetch(`${baseUrl}/api/mora?org_id=${orgId}`)
+  const moraData = await moraRes.json()
+  if (!moraData.success || !moraData.data) {
+    return { orgId, notified: [] }
+  }
+
+  let toNotify = moraData.data as MoraEntry[]
+  if (contractIds && contractIds.length > 0) {
+    toNotify = toNotify.filter((m) => contractIds.includes(m.contractId))
+  }
+  if (toNotify.length === 0) {
+    return { orgId, notified: [] }
+  }
+
+  const supabase = createMoraClient()
+  const notified: string[] = []
+
+  for (const mora of toNotify) {
+    const { error } = await supabase.from('audit_log').insert({
+      org_id: orgId,
+      actor_type: 'agent',
+      actor_id: 'mora-engine',
+      action: 'mora.notificacion_enviada',
+      entity_type: 'contract',
+      entity_id: mora.contractId,
+      metadata: {
+        unit_number: mora.unitNumber,
+        tenant_name: mora.tenantName,
+        days_past_due: mora.daysPastDue,
+        total_overdue: mora.totalOverdue,
+        level: mora.level,
+        notified_at: new Date().toISOString(),
+      },
+    })
+    if (!error) notified.push(mora.contractId)
+  }
+
+  return { orgId, notified }
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json()
+    const body = await request.json().catch(() => ({}))
     const { contractIds } = body as { contractIds?: string[] }
 
-    // Fetch mora data from our own API
     const baseUrl = request.nextUrl.origin
-    const moraRes = await fetch(`${baseUrl}/api/mora`)
-    const moraData = await moraRes.json()
 
-    if (!moraData.success || !moraData.data) {
-      return NextResponse.json({ success: false, error: 'Failed to fetch mora data' }, { status: 500 })
+    // Resolver target orgs: explicit > all
+    const explicitOrg = await resolveOrgIdForWebhook(request, body)
+    const targetOrgs = explicitOrg ? [explicitOrg] : await listAllOrgIds()
+
+    if (targetOrgs.length === 0) {
+      return NextResponse.json(
+        { success: false, error: 'No organizations found' },
+        { status: 404 },
+      )
     }
 
-    // Filter by contractIds if provided, otherwise notify all non-grace
-    let toNotify = moraData.data as Array<{
-      contractId: string
-      unitNumber: string
-      tenantName: string
-      daysPastDue: number
-      totalOverdue: number
-      level: string
-    }>
+    const results = await Promise.all(
+      targetOrgs.map((orgId) => notifyForOrg(baseUrl, orgId, contractIds)),
+    )
 
-    if (contractIds && contractIds.length > 0) {
-      toNotify = toNotify.filter((m) => contractIds.includes(m.contractId))
-    }
-
-    if (toNotify.length === 0) {
-      return NextResponse.json({ success: true, data: { notified: 0, contracts: [] } })
-    }
-
-    const supabase = createMoraClient()
-    const ORG_ID = await getOrgIdAsync()
-    const notifiedContracts: string[] = []
-
-    for (const mora of toNotify) {
-      const { error } = await supabase.from('audit_log').insert({
-        org_id: ORG_ID,
-        actor_type: 'agent',
-        actor_id: 'mora-engine',
-        action: 'mora.notificacion_enviada',
-        entity_type: 'contract',
-        entity_id: mora.contractId,
-        metadata: {
-          unit_number: mora.unitNumber,
-          tenant_name: mora.tenantName,
-          days_past_due: mora.daysPastDue,
-          total_overdue: mora.totalOverdue,
-          level: mora.level,
-          notified_at: new Date().toISOString(),
-        },
-      })
-
-      if (!error) {
-        notifiedContracts.push(mora.contractId)
-      }
-    }
+    const totalNotified = results.reduce((sum, r) => sum + r.notified.length, 0)
 
     return NextResponse.json({
       success: true,
-      data: { notified: notifiedContracts.length, contracts: notifiedContracts },
+      data: {
+        notified: totalNotified,
+        per_org: results,
+      },
     })
   } catch (err) {
     console.error('Mora notify error:', err)
-    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 })
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 },
+    )
   }
 }

--- a/src/app/api/mora/route.ts
+++ b/src/app/api/mora/route.ts
@@ -24,12 +24,20 @@ export async function GET(request: NextRequest) {
     const now = new Date()
     const todayStr = now.toISOString().split('T')[0]
 
+    // Sprint 5 / fix #22: filtro multi-tenant opcional. Si el caller pasa
+    // ?org_id=<uuid> solo se devuelven datos de ese tenant. Si no se pasa,
+    // se devuelven datos cross-tenant (legacy behavior, solo seguro mientras
+    // hay 1 tenant en el sistema).
+    const orgIdParam = request.nextUrl.searchParams.get('org_id')
+
     // 1. Fetch overdue unconfirmed payments
-    const { data: payments, error: paymentsErr } = await supabase
+    let paymentsQuery = supabase
       .from('payments')
       .select('id, contract_id, due_date, amount, status, confirmed_by')
       .in('status', ['pending', 'late'])
       .lt('due_date', todayStr)
+    if (orgIdParam) paymentsQuery = paymentsQuery.eq('org_id', orgIdParam)
+    const { data: payments, error: paymentsErr } = await paymentsQuery
 
     if (paymentsErr) {
       return NextResponse.json({ success: false, error: paymentsErr.message }, { status: 500 })
@@ -54,11 +62,13 @@ export async function GET(request: NextRequest) {
 
     // 3. Fetch contract + unit + occupant data
     const contractIds = Array.from(byContract.keys())
-    const { data: contracts, error: contractsErr } = await supabase
+    let contractsQuery = supabase
       .from('contracts')
       .select('id, unit_id, occupant_id, status')
       .in('id', contractIds)
       .in('status', ['active', 'en_renovacion'])
+    if (orgIdParam) contractsQuery = contractsQuery.eq('org_id', orgIdParam)
+    const { data: contracts, error: contractsErr } = await contractsQuery
 
     if (contractsErr) {
       return NextResponse.json({ success: false, error: contractsErr.message }, { status: 500 })

--- a/src/lib/org-context.ts
+++ b/src/lib/org-context.ts
@@ -142,4 +142,99 @@ export async function resolveOrgIdFromRequest(
   return resolveOrgId()
 }
 
+/**
+ * Resuelve el org_id para webhooks externos / cron jobs sin sesión.
+ *
+ * Sprint 5 / fix #22: reemplaza el shim deprecated `getOrgIdAsync()` que
+ * silenciosamente devolvía la primera org por created_at — comportamiento
+ * que rompe en cuanto hay 2+ tenants.
+ *
+ * Orden de resolución:
+ *   1. Header `x-baw-org-id` (UUID) — uso recomendado en integraciones
+ *   2. Header `x-baw-org-slug` (slug) — alternativa human-friendly
+ *   3. Query string `?org=<slug>` — útil para webhooks configurables por URL
+ *   4. Body JSON `org_id` o `org_slug` (si `body` se pasa)
+ *   5. `null` — el caller decide si fallback a iterar todos los tenants
+ *      o devolver 400.
+ *
+ * Siempre valida que el org existe y devuelve su UUID canónico.
+ */
+export async function resolveOrgIdForWebhook(
+  request: NextRequest,
+  body?: Record<string, unknown> | null,
+): Promise<string | null> {
+  const service = createServiceClient()
+
+  // 1. UUID en header
+  const headerUuid = request.headers.get('x-baw-org-id')
+  if (headerUuid && /^[0-9a-f-]{36}$/i.test(headerUuid)) {
+    const { data } = await service
+      .from('organizations')
+      .select('id')
+      .eq('id', headerUuid)
+      .maybeSingle()
+    if (data?.id) return data.id
+  }
+
+  // 2. Slug en header
+  const headerSlug = request.headers.get('x-baw-org-slug')
+  if (headerSlug) {
+    const { data } = await service
+      .from('organizations')
+      .select('id')
+      .eq('slug', headerSlug)
+      .maybeSingle()
+    if (data?.id) return data.id
+  }
+
+  // 3. Query string
+  const querySlug = request.nextUrl.searchParams.get('org')
+  if (querySlug) {
+    const { data } = await service
+      .from('organizations')
+      .select('id')
+      .eq('slug', querySlug)
+      .maybeSingle()
+    if (data?.id) return data.id
+  }
+
+  // 4. Body
+  if (body) {
+    const bodyUuid = typeof body.org_id === 'string' ? body.org_id : null
+    const bodySlug = typeof body.org_slug === 'string' ? body.org_slug : null
+    if (bodyUuid && /^[0-9a-f-]{36}$/i.test(bodyUuid)) {
+      const { data } = await service
+        .from('organizations')
+        .select('id')
+        .eq('id', bodyUuid)
+        .maybeSingle()
+      if (data?.id) return data.id
+    }
+    if (bodySlug) {
+      const { data } = await service
+        .from('organizations')
+        .select('id')
+        .eq('slug', bodySlug)
+        .maybeSingle()
+      if (data?.id) return data.id
+    }
+  }
+
+  return null
+}
+
+/**
+ * Lista todos los org_ids del sistema. Útil para cron jobs que iteran
+ * sobre cada tenant cuando no se especifica `org_id` explícito.
+ */
+export async function listAllOrgIds(): Promise<string[]> {
+  const service = createServiceClient()
+  const { data, error } = await service
+    .from('organizations')
+    .select('id')
+    .order('created_at', { ascending: true })
+  if (error || !data) return []
+  return data.map((row) => row.id)
+}
+
 export const ACTIVE_ORG_COOKIE_NAME = ACTIVE_ORG_COOKIE


### PR DESCRIPTION
## Summary

Closes #22.

Reemplaza el shim deprecated `getOrgIdAsync()` (que devolvía "primera org por created_at" — bug latente en multi-tenant) con un resolver explícito multi-fuente para webhooks externos y cron jobs.

## Cambios

### Nuevo helper `src/lib/org-context.ts`
- `resolveOrgIdForWebhook(request, body?)` — orden:
  1. header `x-baw-org-id` (UUID)
  2. header `x-baw-org-slug` (slug)
  3. query string `?org=<slug>`
  4. body JSON `{org_id, org_slug}`
  5. `null` si nada matchea (caller decide)
- `listAllOrgIds()` — para cron jobs que iteran sobre todos los tenants

### `/api/channex/webhook` (Channex booking events)
- Usa `resolveOrgIdForWebhook(request, body)`
- Devuelve **400** si no hay org context con mensaje accionable: configurar Channex con `?org=<slug>` o header `x-baw-org-id`

### `/api/channex/sync` (cron sync 30 días)
- Acepta header/query para org explícito
- Si no se especifica y solo hay 1 tenant, usa ese (graceful default)
- Si hay 2+ tenants y no se especifica, devuelve 400

### `/api/mora/notify` (cron de notificación de mora)
- Si el body trae `org_id` o `org_slug` → notifica solo ese tenant
- Si no → itera sobre **todos** los tenants en paralelo (`Promise.all`)
- Respuesta incluye `per_org` breakdown

### `/api/mora` (engine de cálculo de mora)
- Acepta `?org_id=<uuid>` opcional para filtrar `payments` y `contracts` (necesario para que el cron multi-tenant separe datos correctamente)
- Sin parámetro: comportamiento legacy (cross-tenant) — solo seguro mientras hay 1 org

## Out of scope

- `/api/owner/[token]` sigue usando `getOrgIdAsync()`. Se aborda en #25 (junto con la migración de owners legacy del `OWNER_TOKEN` compartido), no aquí — son cambios entrelazados.
- Eliminar el shim `getOrgIdAsync` de `api-auth.ts`: lo dejo deprecated por ahora porque otras 30+ rutas API con sesión normal también lo usan; no es bloqueante para go-live multi-tenant si los webhooks ya están limpios.

## Verificación

- `npx tsc --noEmit` → ✅
- `npm run build` → ✅
- Schema verificado vía Supabase MCP: `payments.org_id` y `contracts.org_id` existen.

## Smoke test post-merge

1. **Channex webhook:** `POST /api/channex/webhook?org=baw-operations` con payload booking → upsert con `organization_id` correcto.
2. **Channex webhook sin org:** `POST /api/channex/webhook` sin parámetros → **400** con mensaje claro.
3. **Channex sync:** `POST /api/channex/sync?org=baw-operations` → sync con `organization_id` correcto.
4. **Mora notify cross-tenant:** `POST /api/mora/notify` body `{}` → itera todas las orgs, response trae `per_org` breakdown.
5. **Mora notify por tenant:** `POST /api/mora/notify` body `{"org_slug":"baw-operations"}` → solo ese tenant.

## Reglas

- Single-line commit ✅
- Sin "scrape" en código ni copy ✅
- **NO auto-merge.** Requiere review humano.
