### PR TITLE
Fix #25: deprecar /owner/[token] legacy detras de feature flag

### DIFF
--- a/src/app/(public)/owner/[token]/page.tsx
+++ b/src/app/(public)/owner/[token]/page.tsx
@@ -94,16 +94,22 @@ export default function OwnerPortalPage() {
   const token = Array.isArray(params.token) ? params.token[0] : params.token
   const [data, setData] = useState<OwnerData | null>(null)
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
+  const [error, setError] = useState<'denied' | 'deprecated' | null>(null)
 
   useEffect(() => {
     fetch(`/api/owner/${token}`)
-      .then((res) => {
-        if (!res.ok) throw new Error()
+      .then(async (res) => {
+        if (res.status === 410) {
+          // Sprint 5 / fix #25: ruta legacy desactivada via OWNER_LEGACY_TOKEN_ENABLED.
+          throw new Error('deprecated')
+        }
+        if (!res.ok) throw new Error('denied')
         return res.json()
       })
       .then(setData)
-      .catch(() => setError(true))
+      .catch((err: Error) =>
+        setError(err.message === 'deprecated' ? 'deprecated' : 'denied'),
+      )
       .finally(() => setLoading(false))
   }, [token])
 
@@ -120,6 +126,31 @@ export default function OwnerPortalPage() {
     )
   }
 
+  if (error === 'deprecated') {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
+        <div className="text-center max-w-sm">
+          <div className="w-16 h-16 bg-amber-50 rounded-2xl flex items-center justify-center mx-auto mb-4">
+            <span className="text-3xl">&#128737;</span>
+          </div>
+          <h1 className="text-xl font-bold text-slate-900 mb-2">
+            Esta URL ya no funciona
+          </h1>
+          <p className="text-slate-500 text-sm mb-4">
+            BaW migró el portal de Property Owners a un sistema con login real
+            por seguridad. Inicia sesión con tu correo para ver tu estado de cuenta.
+          </p>
+          <a
+            href="/owner"
+            className="inline-flex items-center justify-center px-4 py-2 rounded-xl bg-slate-900 text-white text-sm font-semibold"
+          >
+            Ir al portal Owner
+          </a>
+        </div>
+      </div>
+    )
+  }
+
   if (error || !data) {
     return (
       <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
@@ -128,7 +159,9 @@ export default function OwnerPortalPage() {
             <span className="text-3xl">&#128274;</span>
           </div>
           <h1 className="text-xl font-bold text-slate-900 mb-2">Acceso denegado</h1>
-          <p className="text-slate-500 text-sm">Este enlace no es valido o no tienes autorizacion.</p>
+          <p className="text-slate-500 text-sm">
+            Este enlace no es válido o no tienes autorización.
+          </p>
         </div>
       </div>
     )

--- a/src/app/api/owner/[token]/route.ts
+++ b/src/app/api/owner/[token]/route.ts
@@ -8,8 +8,15 @@ const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ||
 
 const OWNER_TOKEN = process.env.OWNER_TOKEN!
 
-// TODO S4-1.5: ligar OWNER_TOKEN a un property_owner específico que pertenece
-// a una org concreta (tabla owner_tokens). Por ahora resolvemos primera org.
+// Sprint 5 / fix #25: este endpoint legacy queda detrás de un feature flag.
+// Solo responde si `OWNER_LEGACY_TOKEN_ENABLED=true` está explicitamente seteado.
+// Default: desactivado — los owners deben usar /owner con login real (S4-2 Owner Portal v2).
+//
+// Para reactivar temporalmente (e.g. para que un owner termine de migrar):
+//   1. Set OWNER_LEGACY_TOKEN_ENABLED=true en Vercel
+//   2. Avisar al owner que la URL está viva por X días
+//   3. Quitar el flag al término
+const LEGACY_ENABLED = process.env.OWNER_LEGACY_TOKEN_ENABLED === 'true'
 
 function createPortalClient() {
   return createClient(SUPABASE_URL, SUPABASE_KEY, {
@@ -21,6 +28,17 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: { token: string } }
 ) {
+  if (!LEGACY_ENABLED) {
+    return NextResponse.json(
+      {
+        error: 'Endpoint deprecated',
+        message:
+          'Este endpoint legacy fue desactivado. Inicia sesión en /owner con tu cuenta real.',
+      },
+      { status: 410 },
+    )
+  }
+
   const { token } = params
 
   if (token !== OWNER_TOKEN) {


### PR DESCRIPTION
## Summary

Closes #25.

Deprecación segura del `OWNER_TOKEN` compartido legacy. Estado real verificado vía Supabase MCP:

- **0** owner invites pendientes en `owner_invites`
- **1** property owner activo (Liz Vargas) — ya tiene `user_id` ligado y puede entrar por `/owner` con login real (Owner Portal v2 / S4-2)

→ El token compartido es vulnerabilidad sin uso activo. Lo apago detrás de feature flag.

## Cambios

### `/api/owner/[token]/route.ts`
- Nuevo flag `OWNER_LEGACY_TOKEN_ENABLED` (env var, default `false`)
- Si está apagado: devuelve **410 Gone** con mensaje accionable, sin tocar DB
- Si está prendido: comportamiento legacy intacto (escape hatch para casos extremos)

### `/(public)/owner/[token]/page.tsx`
- Detecta el 410 y muestra estado dedicado: "Esta URL ya no funciona — ir al portal Owner"
- Botón directo a `/owner` (login real)
- Estado "Acceso denegado" se mantiene para 401 (token incorrecto cuando flag está prendido)

## Por qué este approach (no eliminación dura)

- **Reversible:** si Liz o algún owner futuro tiene un link guardado, basta con setear `OWNER_LEGACY_TOKEN_ENABLED=true` por unos días para darle tiempo a migrar.
- **No rompe enlaces existentes** silenciosamente: el 410 + UI redirigen al portal nuevo, no devuelven 404.
- **No requiere migración de DB:** owner_invites + property_owners ya soportan el flujo nuevo, no hay que tocar schema.
- Eliminar definitivamente `/owner/[token]` y `OWNER_TOKEN` env var queda como follow-up cuando confirmemos que nadie usa la URL legacy (sugerido: 60 días).

## Verificación

- `npx tsc --noEmit` → ✅
- `npm run build` → ✅

## Smoke test post-merge

1. **Sin flag (default):**
   - `GET /api/owner/<token>` → 410 Gone con `{error: 'Endpoint deprecated'}`
   - `/owner/<token>` UI → muestra "Esta URL ya no funciona" + botón a `/owner`
2. **Con flag prendido (`OWNER_LEGACY_TOKEN_ENABLED=true` en Vercel):**
   - `GET /api/owner/<token-correcto>` → 200 con datos legacy
   - `GET /api/owner/<token-mal>` → 401
3. `/owner` (login real) → sin cambios, sigue funcionando.

## Out of scope

- Eliminar definitivamente la ruta y `getOrgIdAsync()` del código → follow-up issue cuando confirmemos 0 hits al endpoint legacy en logs por 60 días.
- Generar invites email para owners legacy: no hay owners legacy. Si en el futuro se descubre alguno sin `user_id`, se ejecuta UPDATE manual + invite vía `/admin`.

## Reglas

- Single-line commit ✅
- Sin "scrape" en código ni copy ✅
- **NO auto-merge.** Requiere review humano.
