### PR TITLE
Fix /me login loop: AuthGuard honors ?next= param

### DIFF
--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -15,11 +15,28 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (isPublic) { setChecking(false); return }
+
+    // Honor ?next= when leaving /login with a valid session (prevents redirect loops
+    // when a Server Component bounced the user here from a protected route).
+    const getNext = (): string => {
+      if (typeof window === 'undefined') return '/'
+      const param = new URLSearchParams(window.location.search).get('next')
+      if (param && param.startsWith('/') && !param.startsWith('//')) return param
+      return '/'
+    }
+
+    const buildLoginUrl = (): string => {
+      if (typeof window === 'undefined') return '/login'
+      const current = pathname + window.location.search
+      const safe = current && current.startsWith('/') && !current.startsWith('//') ? current : '/'
+      return `/login?next=${encodeURIComponent(safe)}`
+    }
+
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (!session && pathname !== '/login') {
-        router.replace('/login')
+        router.replace(buildLoginUrl())
       } else if (session && pathname === '/login') {
-        router.replace('/')
+        router.replace(getNext())
       } else {
         setChecking(false)
       }
@@ -28,9 +45,9 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (isPublic) return
       if (!session && pathname !== '/login') {
-        router.replace('/login')
+        router.replace(buildLoginUrl())
       } else if (session && pathname === '/login') {
-        router.replace('/')
+        router.replace(getNext())
       } else {
         setChecking(false)
       }


### PR DESCRIPTION
## Bug

Click 'Mi perfil' → infinite login loop.

## Causa raíz

`AuthGuard` redirigía a `/` cuando había sesión y pathname era `/login`, ignorando el parámetro `?next=`. Cuando `/me` (server component) bouncea al user a `/login?next=/me` por cookies SSR fuera de sync, AuthGuard mandaba a `/` perdiendo el destino — y al hacer click otra vez en 'Mi perfil', loop.

## Fix

AuthGuard ahora:
1. Al entrar a `/login` con sesión válida, lee `?next=` y redirige ahí (con validación contra open-redirect).
2. Al echar al user fuera de protected route, construye `/login?next=<current>` para que tras login regrese al destino.

## Test

- Cerrar sesión, click 'Mi perfil' → `/login?next=/me` → login → regresa a /me ✓
- Sesión activa, navegar a /me → si SSR cookie stale → `/login?next=/me` → AuthGuard ve sesión → vuelve a /me ✓
- Login normal sin next → va a / como antes ✓

Closes loop reportado por Fran tras merge de #32 (que arregló sólo /admin).

cc @franduranv