### PR TITLE
Add BaW visual identity to login + brand assets

### DIFF
--- a/public/baw-logo.svg
+++ b/public/baw-logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 64" fill="none" aria-label="BaW OS">
+  <g transform="translate(0,12)">
+    <path d="M8 32 L28 40 L48 32 L28 24 Z" fill="currentColor"/>
+    <path d="M11 24 L31 32 L51 24 L31 16 Z" fill="currentColor" opacity="0.7"/>
+    <path d="M8 16 L28 24 L48 16 L28 8 Z" fill="currentColor" opacity="0.5"/>
+  </g>
+  <text x="64" y="40" font-family="'IBM Plex Mono', ui-monospace, monospace" font-size="28" font-weight="500" fill="currentColor" letter-spacing="-0.5">BaW</text>
+  <text x="146" y="40" font-family="'IBM Plex Mono', ui-monospace, monospace" font-size="14" font-weight="400" fill="currentColor" opacity="0.55" letter-spacing="0.5">/ OS</text>
+</svg>

--- a/public/baw-mark.svg
+++ b/public/baw-mark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" fill="none" aria-label="BaW">
+  <path d="M40 168 L120 200 L200 168 L120 136 Z" fill="currentColor"/>
+  <path d="M52 128 L132 160 L212 128 L132 96 Z" fill="currentColor" opacity="0.7"/>
+  <path d="M40 88 L120 120 L200 88 L120 56 Z" fill="currentColor" opacity="0.5"/>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#0F172A"/>
+  <path d="M4 22 L16 27 L28 22 L16 17 Z" fill="#FFFFFF"/>
+  <path d="M5 17 L17 22 L29 17 L17 12 Z" fill="#FFFFFF" opacity="0.7"/>
+  <path d="M4 12 L16 17 L28 12 L16 7 Z" fill="#FFFFFF" opacity="0.5"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,36 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
+import { Inter, IBM_Plex_Mono, Instrument_Serif } from 'next/font/google'
 import './globals.css'
 import AppShell from '@/components/AppShell'
 
+// BaW Design typography stack — source of truth: design/baw-design/tokens/typography.css
 const inter = Inter({
   subsets: ['latin'],
   variable: '--font-inter',
   display: 'swap',
 })
 
+const ibmPlexMono = IBM_Plex_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  variable: '--font-ibm-plex-mono',
+  display: 'swap',
+})
+
+const instrumentSerif = Instrument_Serif({
+  subsets: ['latin'],
+  weight: '400',
+  style: ['normal', 'italic'],
+  variable: '--font-instrument-serif',
+  display: 'swap',
+})
+
 export const metadata: Metadata = {
   title: 'BaW OS',
   description: 'Property Management System — BaW Design Lab · ZXY Ventures',
+  icons: {
+    icon: '/favicon.svg',
+  },
 }
 
 export default function RootLayout({
@@ -20,7 +39,11 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="es" className={inter.variable} suppressHydrationWarning>
+    <html
+      lang="es"
+      className={`${inter.variable} ${ibmPlexMono.variable} ${instrumentSerif.variable}`}
+      suppressHydrationWarning
+    >
       <head>
         <script
           dangerouslySetInnerHTML={{

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Suspense, useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 
 // Sprint 4 / S4-2: useSearchParams requiere Suspense boundary en Next.js 14
@@ -14,9 +14,8 @@ export default function LoginPage() {
 }
 
 function LoginForm() {
-  const router = useRouter()
   const searchParams = useSearchParams()
-  // Sprint 4 / S4-2: respetar ?next= para deep-link en Owner Portal v2
+  // Sprint 4 / S4-2: respetar ?next= para deep-link
   const nextPath = searchParams.get('next') || '/'
   const role = searchParams.get('role')
   const [email, setEmail] = useState('')
@@ -57,31 +56,74 @@ function LoginForm() {
     }
 
     // Full reload so middleware and Server Components pick up the session cookie.
-    // Validamos que nextPath sea relativa (no open-redirect)
     const safeNext = nextPath.startsWith('/') && !nextPath.startsWith('//')
       ? nextPath
       : '/'
     window.location.href = safeNext
   }
 
+  const subtitle = role === 'owner' ? 'Portal Propietario' : 'Property Management'
+
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-gray-50 dark:bg-gray-950">
-      <div className="w-full max-w-sm mx-auto px-6">
-        {/* Logo */}
-        <div className="flex flex-col items-center mb-10">
-          <div className="w-12 h-12 rounded-xl bg-indigo-600 flex items-center justify-center font-bold text-lg text-white mb-4">
-            B
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-[--baw-bg]">
+      {/* Subtle grid background — comunica precisión técnica de la marca */}
+      <div
+        aria-hidden
+        className="absolute inset-0 opacity-[0.035] pointer-events-none"
+        style={{
+          backgroundImage:
+            'linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)',
+          backgroundSize: '32px 32px',
+          color: 'var(--baw-text)',
+        }}
+      />
+
+      <div className="relative w-full max-w-sm mx-auto px-6">
+        {/* Mark + wordmark */}
+        <div className="flex flex-col items-center mb-12">
+          <div className="text-[--baw-text] mb-5">
+            {/* Mark: 3 placas isométricas apiladas — design/baw-design/references/Mark Final.html */}
+            <svg
+              viewBox="0 0 240 240"
+              width="56"
+              height="56"
+              fill="none"
+              aria-label="BaW"
+              className="block"
+            >
+              <path d="M40 168 L120 200 L200 168 L120 136 Z" fill="currentColor" />
+              <path d="M52 128 L132 160 L212 128 L132 96 Z" fill="currentColor" opacity="0.7" />
+              <path d="M40 88 L120 120 L200 88 L120 56 Z" fill="currentColor" opacity="0.5" />
+            </svg>
           </div>
-          <h1 className="text-xl font-semibold text-gray-900 dark:text-white">BaW OS</h1>
-          <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">
-            {role === 'owner' ? 'Portal Propietario' : 'Property Management System'}
+
+          {/* Wordmark — IBM Plex Mono Medium, espaciado tight */}
+          <h1
+            style={{ fontFamily: 'var(--font-mono)' }}
+            className="text-[28px] font-medium text-[--baw-text] tracking-tight leading-none"
+          >
+            BaW
+            <span className="text-[--baw-muted] ml-2 text-[14px] font-normal tracking-wide">
+              / OS
+            </span>
+          </h1>
+
+          <p
+            style={{ fontFamily: 'var(--font-mono)' }}
+            className="text-[11px] uppercase tracking-[0.18em] text-[--baw-muted] mt-3"
+          >
+            {subtitle}
           </p>
         </div>
 
         {/* Form */}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1.5">
+            <label
+              htmlFor="email"
+              style={{ fontFamily: 'var(--font-mono)' }}
+              className="block text-[11px] uppercase tracking-wider text-[--baw-muted] mb-2"
+            >
               Email
             </label>
             <input
@@ -91,16 +133,19 @@ function LoginForm() {
               onChange={(e) => setEmail(e.target.value)}
               required
               autoFocus
-              className="w-full px-3 py-2.5 bg-gray-100 border border-gray-300 rounded-lg text-gray-900 text-sm
-                         placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:border-transparent
-                         dark:bg-gray-900 dark:border-gray-800 dark:text-white dark:placeholder:text-gray-600
+              className="w-full px-3 py-2.5 bg-[--baw-surface] border border-[--baw-border] rounded-md text-[--baw-text] text-sm
+                         placeholder:text-[--baw-faint] focus:outline-none focus:ring-2 focus:ring-[--baw-info-bg-soft] focus:border-[--baw-info-fg]
                          transition-colors"
               placeholder="tu@email.com"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1.5">
+            <label
+              htmlFor="password"
+              style={{ fontFamily: 'var(--font-mono)' }}
+              className="block text-[11px] uppercase tracking-wider text-[--baw-muted] mb-2"
+            >
               Password
             </label>
             <input
@@ -109,16 +154,15 @@ function LoginForm() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              className="w-full px-3 py-2.5 bg-gray-100 border border-gray-300 rounded-lg text-gray-900 text-sm
-                         placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:border-transparent
-                         dark:bg-gray-900 dark:border-gray-800 dark:text-white dark:placeholder:text-gray-600
+              className="w-full px-3 py-2.5 bg-[--baw-surface] border border-[--baw-border] rounded-md text-[--baw-text] text-sm
+                         placeholder:text-[--baw-faint] focus:outline-none focus:ring-2 focus:ring-[--baw-info-bg-soft] focus:border-[--baw-info-fg]
                          transition-colors"
               placeholder="••••••••"
             />
           </div>
 
           {error && (
-            <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+            <div className="text-sm text-[--baw-danger-fg] bg-[--baw-danger-bg-soft] border border-[--baw-danger-border] rounded-md px-3 py-2">
               {error}
             </div>
           )}
@@ -126,15 +170,18 @@ function LoginForm() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-2.5 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed
-                       rounded-lg text-sm font-medium text-white transition-colors"
+            className="w-full py-2.5 bg-[--baw-text] text-[--baw-bg] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed
+                       rounded-md text-sm font-medium transition-opacity"
           >
             {loading ? 'Entrando...' : 'Entrar'}
           </button>
         </form>
 
         {/* Footer */}
-        <p className="text-center text-[11px] text-gray-400 dark:text-gray-600 mt-8">
+        <p
+          style={{ fontFamily: 'var(--font-mono)' }}
+          className="text-center text-[10px] uppercase tracking-[0.2em] text-[--baw-faint] mt-10"
+        >
           BaW Design Lab · ZXY Ventures
         </p>
       </div>


### PR DESCRIPTION
Primera implementación de identidad BaW visible en el producto.

## Qué cambia

### 1. Fonts del design system cargadas
- `Inter` (sans/UI) ya estaba
- **Nuevo:** `IBM Plex Mono` (data, labels, wordmark) y `Instrument Serif` (display)
- Las 3 fuentes se cargan via `next/font/google` y exponen CSS vars (`--font-inter`, `--font-ibm-plex-mono`, `--font-instrument-serif`)
- `design/baw-design/tokens/typography.css` ya consume estas vars con fallback a strings

### 2. Mark BaW vectorizado
- `public/baw-mark.svg` — 3 placas isométricas apiladas (extraído de `design/baw-design/references/claude-design-v1/Mark Final.html`)
- `public/baw-logo.svg` — mark + wordmark horizontal
- `public/favicon.svg` — versión rounded para tab del navegador
- Metadata del layout apunta al favicon nuevo

### 3. Login con identidad
- Mark embebido como SVG inline (50×50, currentColor)
- Wordmark en IBM Plex Mono Medium con tracking tight (`BaW / OS`)
- Subtítulo en mono uppercase `PROPERTY MANAGEMENT` (o `PORTAL PROPIETARIO` con `?role=owner`)
- Inputs con tokens BaW: `--baw-surface`, `--baw-border`, `--baw-text`, etc.
- Botón primary usa `--baw-text` como bg (alto contraste) en lugar de `indigo-600`
- Background con grid sutil 32px (3.5% opacity) — comunica precisión técnica

## Test
- `/login` en dark y light: mark visible, wordmark legible, fuente mono cargada
- `/login?role=owner`: subtítulo cambia a 'Portal Propietario'
- Form usable, mensaje de error usa tokens danger
- Favicon visible en tab del browser

## Out of scope (próximo)
- Logo en sidebar (sustituir el actual)
- Logo en /admin shell
- Reemplazar 'B' placeholder en otras pantallas
- Variantes light/dark del logo (actualmente usa `currentColor`)