### PR TITLE
Restructure agents catalog: BaW Coord / PM Operations / Third Party

### DIFF
--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -62,11 +62,26 @@ async function loadData() {
   return { agents: (agentsData || []) as AgentRow[], runs, orgId }
 }
 
+// Modelo de agentes (decisión Fran 2026-05-02):
+//   - baw-coord: BaW Coordinador (agente principal del producto)
+//   - pm-ops: PM Operations (agentes nativos del producto BaW OS)
+//   - third-party: Third Party Operations (agentes externos conectables — ZXY entra aquí)
 const FAMILY_LABEL: Record<string, string> = {
   'baw-coord': 'BaW · Coordinador',
   'pm-ops': 'PM Operations',
-  'zxy-shared': 'ZXY Shared',
+  'third-party': 'Third Party Operations',
+  // Legacy alias durante migración
+  'zxy-shared': 'Third Party Operations',
 }
+
+const FAMILY_DESC: Record<string, string> = {
+  'baw-coord': 'Orquestador raíz del sistema',
+  'pm-ops': 'Agentes nativos del producto BaW OS',
+  'third-party': 'Agentes externos conectables (ZXY, otros proveedores)',
+  'zxy-shared': 'Agentes externos conectables (ZXY, otros proveedores)',
+}
+
+const FAMILY_ORDER = ['baw-coord', 'pm-ops', 'third-party', 'zxy-shared']
 
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, { bg: string; fg: string }> = {
@@ -126,18 +141,27 @@ export default async function AgentsPage() {
           Agentes
         </h1>
         <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
-          10+1 agentes BaW OS · BaW coordinador + 4 PM-Ops + 6 ZXY shared. v1: Cobranza dunning.
+          BaW Coordinador + PM Operations (nativos) + Third Party Operations (conectables). v1: Cobranza dunning.
         </p>
       </div>
 
-      {Object.entries(grouped).map(([family, list]) => (
+      {Object.entries(grouped)
+        .sort(([a], [b]) => FAMILY_ORDER.indexOf(a) - FAMILY_ORDER.indexOf(b))
+        .map(([family, list]) => (
         <section key={family}>
-          <h2
-            className="text-[14px] font-semibold mb-3 uppercase tracking-wider"
-            style={{ color: 'var(--baw-muted)' }}
-          >
-            {FAMILY_LABEL[family] || family}
-          </h2>
+          <div className="mb-3">
+            <h2
+              className="text-[14px] font-semibold uppercase tracking-wider"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              {FAMILY_LABEL[family] || family}
+            </h2>
+            {FAMILY_DESC[family] && (
+              <p className="text-[11px] mt-0.5" style={{ color: 'var(--baw-faint)' }}>
+                {FAMILY_DESC[family]}
+              </p>
+            )}
+          </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
             {list.map((a) => {
               const isImpl = implemented.has(a.id)

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -62,26 +62,34 @@ async function loadData() {
   return { agents: (agentsData || []) as AgentRow[], runs, orgId }
 }
 
-// Modelo de agentes (decisión Fran 2026-05-02):
-//   - baw-coord: BaW Coordinador (agente principal del producto)
-//   - pm-ops: PM Operations (agentes nativos del producto BaW OS)
-//   - third-party: Third Party Operations (agentes externos conectables — ZXY entra aquí)
+// Modelo de agentes según Roster v0.2 (Notion canónico):
+//   - baw-coord: BaW Coordinador (cara única del workforce)
+//   - ops-core: Operaciones Core (Cobranza, Facturación, Mantenimiento) — Tier Starter+
+//   - experiencia: Experiencia (Atención, Reservas, Tarifas, Renovaciones) — Tier Professional+
+//   - inteligencia: Inteligencia (Reportes, Auditoría, Fiscal) — Tier Enterprise/Max
+//   - third-party: Third Party Operations (agentes externos conectables — ZXY Agent OS)
 const FAMILY_LABEL: Record<string, string> = {
   'baw-coord': 'BaW · Coordinador',
-  'pm-ops': 'PM Operations',
+  'ops-core': 'Operaciones Core',
+  'experiencia': 'Experiencia',
+  'inteligencia': 'Inteligencia',
   'third-party': 'Third Party Operations',
   // Legacy alias durante migración
+  'pm-ops': 'PM Operations (legacy)',
   'zxy-shared': 'Third Party Operations',
 }
 
 const FAMILY_DESC: Record<string, string> = {
-  'baw-coord': 'Orquestador raíz del sistema',
-  'pm-ops': 'Agentes nativos del producto BaW OS',
-  'third-party': 'Agentes externos conectables (ZXY, otros proveedores)',
+  'baw-coord': 'Cara única del workforce. Coordina los 10 especialistas, recibe todos los inputs del PM.',
+  'ops-core': 'Tier Starter+ · Cobro, facturación y operación del edificio',
+  'experiencia': 'Tier Professional+ · Comunicación, captación y ciclo de vida del residente',
+  'inteligencia': 'Tier Enterprise/Max · Reporting, governance y compliance',
+  'third-party': 'Agentes externos conectables (ZXY Agent OS, otros proveedores). No son parte del producto BaW OS.',
+  'pm-ops': 'Familia legacy — migrada a escuadrones',
   'zxy-shared': 'Agentes externos conectables (ZXY, otros proveedores)',
 }
 
-const FAMILY_ORDER = ['baw-coord', 'pm-ops', 'third-party', 'zxy-shared']
+const FAMILY_ORDER = ['baw-coord', 'ops-core', 'experiencia', 'inteligencia', 'third-party', 'pm-ops', 'zxy-shared']
 
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, { bg: string; fg: string }> = {
@@ -141,7 +149,7 @@ export default async function AgentsPage() {
           Agentes
         </h1>
         <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
-          BaW Coordinador + PM Operations (nativos) + Third Party Operations (conectables). v1: Cobranza dunning.
+          BaW + 10 especialistas en 3 escuadrones (Operaciones Core · Experiencia · Inteligencia) + Third Party. Roster v0.2. v1: Cobranza dunning.
         </p>
       </div>
 

--- a/supabase/migrations/20260502_agents_roster_v02.sql
+++ b/supabase/migrations/20260502_agents_roster_v02.sql
@@ -1,0 +1,61 @@
+-- BaW OS — Roster de Agentes v0.2 (Notion canónico)
+-- Reestructura para alinear con "BaW OS — Roster de Agentes y Arquitectura del Workforce" v0.2
+-- 3 escuadrones (Operaciones Core / Experiencia / Inteligencia) + BaW Coordinador + Third Party
+-- Total: 10 + 1 especialistas + 6 third-party
+
+BEGIN;
+
+-- 1. Reasignar agentes existentes según escuadrón canónico
+-- Cobranza y Mantenimiento -> Operaciones Core
+UPDATE agents SET family = 'ops-core' WHERE id IN ('cobranza', 'mantenimiento');
+
+-- Reservas -> Experiencia (canónico)
+UPDATE agents SET family = 'experiencia' WHERE id = 'reservas';
+
+-- Huésped -> renombrar a Atención (canónico v0.2) y mover a Experiencia
+UPDATE agents SET
+  id = 'atencion',
+  display_name = 'Atención',
+  full_name = 'Agente Atención',
+  family = 'experiencia',
+  domain = 'cx',
+  description = 'Comunicación 24/7 con residentes y huéspedes. FAQs, anuncios, surveys, manejo de quejas no críticas.'
+WHERE id = 'huesped';
+
+-- 2. Sembrar agentes faltantes del roster v0.2
+INSERT INTO agents (id, display_name, full_name, family, domain, description, capability_level, feedback_level, status, is_shared_zxy)
+VALUES
+  -- Operaciones Core (3)
+  ('facturacion', 'Facturación', 'Agente Facturación', 'ops-core', 'finanzas',
+   'CFDI 4.0 vía PAC, conciliación bancaria, recibos electrónicos. Moat regulatorio LATAM.',
+   1, 1, 'planned', false),
+
+  -- Experiencia (4) — Atención y Reservas ya existen
+  ('tarifas', 'Tarifas', 'Agente Tarifas', 'experiencia', 'revenue',
+   'Dynamic pricing STR/MTR. Optimización por temporada, eventos locales, ocupación, FX.',
+   1, 1, 'planned', false),
+  ('renovaciones', 'Renovaciones', 'Agente Renovaciones', 'experiencia', 'cx',
+   'Outreach 60/30/15 días pre-vencimiento, propuestas de renovación con pricing actualizado.',
+   1, 1, 'planned', false),
+
+  -- Inteligencia (3)
+  ('reportes', 'Reportes', 'Agente Reportes', 'inteligencia', 'analytics',
+   'Dashboards de propietario, narrativa LLM, briefings. Síntesis de KPIs y anomaly detection.',
+   1, 1, 'planned', false),
+  ('auditoria', 'Auditoría', 'Agente Auditoría', 'inteligencia', 'governance',
+   'Audit trail inmutable, detección de anomalías operativas. Capa de governance interna.',
+   1, 1, 'planned', false),
+  ('fiscal', 'Fiscal', 'Agente Fiscal', 'inteligencia', 'compliance',
+   'Validación CFDI/SAT, monitoreo regulatorio, verificación documental. LATAM tax compliance.',
+   1, 1, 'planned', false)
+ON CONFLICT (id) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  full_name = EXCLUDED.full_name,
+  family = EXCLUDED.family,
+  domain = EXCLUDED.domain,
+  description = EXCLUDED.description;
+
+-- 3. Verificación: 10 + 1 especialistas + 6 third-party = 17 totales
+-- (1 baw-coord + 3 ops-core + 4 experiencia + 3 inteligencia + 6 third-party)
+
+COMMIT;

--- a/supabase/migrations/20260502_agents_third_party_family.sql
+++ b/supabase/migrations/20260502_agents_third_party_family.sql
@@ -1,0 +1,18 @@
+-- BaW OS — Agents family taxonomy update
+-- Decisión Fran 2026-05-02: el modelo correcto es 3 categorías
+--   - baw-coord     · BaW Coordinador (orquestador raíz)
+--   - pm-ops        · PM Operations (agentes nativos del producto)
+--   - third-party   · Third Party Operations (agentes externos conectables; ZXY entra aquí)
+--
+-- Los agentes ZXY se mueven de family='zxy-shared' a family='third-party'.
+-- El flag is_shared_zxy se mantiene para identificar específicamente los
+-- de ZXY (subset de third-party).
+
+UPDATE public.agents
+SET family = 'third-party'
+WHERE family = 'zxy-shared';
+
+-- Asegura que cualquier agente con is_shared_zxy=true esté en third-party
+UPDATE public.agents
+SET family = 'third-party'
+WHERE is_shared_zxy = true AND family != 'third-party';


### PR DESCRIPTION
## Modelo nuevo (decisión Fran)

> 'BaW Coordinador (Agente Principal) → PM Operations (10 Agentes) → Third Party Operations (no parte del producto, externos conectables; ZXY entra aquí)'

## Cambios

### Migración `20260502_agents_third_party_family`
- `UPDATE agents SET family='third-party' WHERE family='zxy-shared'`
- Aplicada a producción ✓
- Los 6 ZXY (Alicia-Ops, Andres-Tech, Conta-Beto, Hugo-COS, Luis-Growth, Maribel-Law) ahora son family='third-party' con `is_shared_zxy=true` (flag se mantiene para distinguirlos de otros third-party futuros)

### `/agents` page
- Header de página actualizado: 'BaW Coordinador + PM Operations (nativos) + Third Party Operations (conectables)'
- `FAMILY_LABEL`: añade `third-party → 'Third Party Operations'` (alias `zxy-shared` para compat durante deploy)
- `FAMILY_DESC`: subtítulo bajo cada sección que explica qué tipo de agente es
- `FAMILY_ORDER`: orden estable BaW → PM Ops → Third Party

## Estado del catálogo

| Family | Count | Status |
|---|---|---|
| baw-coord | 1 (BaW) | beta |
| pm-ops | 4 (Cobranza, Huésped, Mantenimiento, Reservas) | 1 beta + 3 planned |
| third-party | 6 (todos ZXY shared) | planned |
| **Total** | **11** | |

## Siguiente

Faltan **6 agentes pm-ops** para llegar al '10+1 nativos' que Fran tiene en BRAND_FOUNDATIONS. Los nombres canónicos en el doc son: Rumbo, Pulso, Trazo, Eco, Brisa, Alcance, Sello (7) — no exactamente 10 todavía. **Decision pendiente: cerrar el roster final de 10 PM Operations antes de seedear DB.**