### PR TITLE
Add /admin/roadmap dashboard v1 (Sprint 5.5 #8)

### DIFF
--- a/docs/roadmap-snapshot-2026-05-01.html
+++ b/docs/roadmap-snapshot-2026-05-01.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>BaW OS — Roadmap visual</title>
+<style>
+:root{
+  --bg:#0a0a0a; --surface:#111; --surface-2:#1a1a1a;
+  --text:#e8e8e8; --muted:#8a8a8a; --border:#262626;
+  --done:#10b981; --doing:#f59e0b; --backlog:#6b7280; --discarded:#ef4444;
+  --t1:#10b981; --t2:#3b82f6; --t25:#a855f7; --t3:#6b7280; --t4:#f97316; --t5:#dc2626;
+  --accent:#fff;
+}
+*{box-sizing:border-box; margin:0; padding:0}
+body{
+  font-family:-apple-system,BlinkMacSystemFont,"Inter","Segoe UI",sans-serif;
+  background:var(--bg); color:var(--text); padding:32px 40px;
+  font-size:14px; line-height:1.5;
+}
+h1{font-size:28px; font-weight:700; letter-spacing:-0.02em; margin-bottom:6px}
+h2{font-size:18px; font-weight:600; margin:32px 0 14px; padding-bottom:8px; border-bottom:1px solid var(--border)}
+h3{font-size:14px; font-weight:600; margin-bottom:10px; color:var(--text)}
+.subtitle{color:var(--muted); margin-bottom:24px}
+
+/* Stats summary */
+.stats{display:grid; grid-template-columns:repeat(4,1fr); gap:14px; margin-bottom:8px}
+.stat{background:var(--surface); border:1px solid var(--border); border-radius:10px; padding:16px}
+.stat-num{font-size:26px; font-weight:700}
+.stat-lbl{font-size:11px; text-transform:uppercase; letter-spacing:0.06em; color:var(--muted); margin-top:4px}
+.stat.done .stat-num{color:var(--done)}
+.stat.doing .stat-num{color:var(--doing)}
+.stat.backlog .stat-num{color:var(--backlog)}
+.stat.total .stat-num{color:var(--accent)}
+
+/* Progress bar */
+.progress-wrap{margin:24px 0 8px}
+.progress-bar{height:10px; background:var(--surface-2); border-radius:6px; overflow:hidden; display:flex; border:1px solid var(--border)}
+.progress-bar > div{height:100%}
+.progress-done{background:var(--done)}
+.progress-doing{background:var(--doing)}
+.progress-backlog{background:var(--backlog)}
+.progress-discarded{background:var(--discarded); opacity:0.4}
+.progress-legend{display:flex; gap:18px; margin-top:8px; font-size:12px; color:var(--muted)}
+.progress-legend span::before{content:"●"; margin-right:6px}
+.legend-done::before{color:var(--done)}
+.legend-doing::before{color:var(--doing)}
+.legend-backlog::before{color:var(--backlog)}
+.legend-discarded::before{color:var(--discarded)}
+
+/* Sprint timeline */
+.timeline{position:relative; margin:20px 0 32px; padding-left:0}
+.sprint-row{display:grid; grid-template-columns:90px 1fr; gap:20px; padding:14px 0; border-bottom:1px solid var(--border)}
+.sprint-row:last-child{border-bottom:none}
+.sprint-label{font-weight:600; color:var(--muted); font-size:12px}
+.sprint-label .name{display:block; color:var(--text); font-size:14px; margin-bottom:2px}
+.sprint-label .status{font-size:10px; text-transform:uppercase; letter-spacing:0.08em; padding:2px 8px; border-radius:4px; display:inline-block}
+.sprint-label .status.done{background:rgba(16,185,129,0.12); color:var(--done)}
+.sprint-label .status.next{background:rgba(245,158,11,0.12); color:var(--doing)}
+.sprint-label .status.future{background:rgba(107,114,128,0.12); color:var(--backlog)}
+.sprint-pills{display:flex; flex-wrap:wrap; gap:6px}
+.pill{padding:4px 10px; background:var(--surface); border:1px solid var(--border); border-radius:6px; font-size:12px}
+.pill .num{color:var(--muted); font-weight:600; margin-right:4px}
+
+/* Kanban */
+.kanban{display:grid; grid-template-columns:repeat(3,1fr); gap:16px; margin-top:14px}
+.col{background:var(--surface); border:1px solid var(--border); border-radius:10px; padding:14px}
+.col-h{display:flex; justify-content:space-between; align-items:center; margin-bottom:12px; padding-bottom:10px; border-bottom:1px solid var(--border)}
+.col-h .count{background:var(--surface-2); padding:2px 8px; border-radius:10px; font-size:11px; color:var(--muted)}
+.card{background:var(--surface-2); border:1px solid var(--border); border-radius:6px; padding:10px 12px; margin-bottom:8px; font-size:13px}
+.card .tier{font-size:10px; text-transform:uppercase; letter-spacing:0.05em; padding:1px 6px; border-radius:3px; display:inline-block; margin-bottom:4px; font-weight:600}
+.tier-t1{background:rgba(16,185,129,0.15); color:var(--t1)}
+.tier-t2{background:rgba(59,130,246,0.15); color:var(--t2)}
+.tier-t25{background:rgba(168,85,247,0.15); color:var(--t25)}
+.tier-t3{background:rgba(107,114,128,0.15); color:var(--t3)}
+.tier-t4{background:rgba(249,115,22,0.15); color:var(--t4)}
+.tier-t5{background:rgba(220,38,38,0.15); color:var(--t5)}
+
+/* Tier breakdown */
+.tier-grid{display:grid; grid-template-columns:repeat(2,1fr); gap:14px; margin-top:14px}
+.tier-box{background:var(--surface); border:1px solid var(--border); border-radius:10px; padding:16px}
+.tier-box h3{display:flex; justify-content:space-between; align-items:center; margin-bottom:10px}
+.tier-box .progress-bar{height:6px; margin-bottom:12px}
+.tier-list{list-style:none; font-size:12.5px; color:var(--text)}
+.tier-list li{padding:5px 0; border-bottom:1px dashed var(--border); position:relative; padding-left:14px}
+.tier-list li:last-child{border-bottom:none}
+.tier-list li::before{content:"○"; position:absolute; left:0; color:var(--muted)}
+.tier-list li.done::before{content:"●"; color:var(--done)}
+.tier-list li.doing::before{content:"◐"; color:var(--doing)}
+.tier-list li.done{color:var(--muted); text-decoration:line-through}
+
+.next-up{background:linear-gradient(135deg, rgba(245,158,11,0.08), rgba(168,85,247,0.05)); border:1px solid rgba(245,158,11,0.3); border-radius:10px; padding:18px; margin-top:14px}
+.next-up h3{color:var(--doing); margin-bottom:10px}
+.next-up ol{margin-left:18px; font-size:13px}
+.next-up li{margin-bottom:6px}
+
+footer{margin-top:36px; padding-top:16px; border-top:1px solid var(--border); color:var(--muted); font-size:11px; text-align:center}
+</style>
+</head>
+<body>
+
+<h1>BaW OS — Roadmap visual</h1>
+<p class="subtitle">Foto al cierre Sprint 4 · 2026-05-01</p>
+
+<!-- Stats -->
+<div class="stats">
+  <div class="stat total"><div class="stat-num">100</div><div class="stat-lbl">Features totales</div></div>
+  <div class="stat done"><div class="stat-num">47</div><div class="stat-lbl">Done · 47%</div></div>
+  <div class="stat doing"><div class="stat-num">1</div><div class="stat-lbl">En desarrollo</div></div>
+  <div class="stat backlog"><div class="stat-num">47</div><div class="stat-lbl">Backlog</div></div>
+</div>
+
+<div class="progress-wrap">
+  <div class="progress-bar">
+    <div class="progress-done" style="width:47%"></div>
+    <div class="progress-doing" style="width:1%"></div>
+    <div class="progress-backlog" style="width:47%"></div>
+    <div class="progress-discarded" style="width:5%"></div>
+  </div>
+  <div class="progress-legend">
+    <span class="legend-done">Done · 47</span>
+    <span class="legend-doing">En desarrollo · 1</span>
+    <span class="legend-backlog">Backlog · 47</span>
+    <span class="legend-discarded">Descartado · 5</span>
+  </div>
+</div>
+
+<!-- Sprint timeline -->
+<h2>Sprints — lo recorrido y lo siguiente</h2>
+<div class="timeline">
+
+  <div class="sprint-row">
+    <div class="sprint-label"><span class="name">Sprint 1-2</span><span class="status done">Done</span></div>
+    <div class="sprint-pills">
+      <span class="pill"><span class="num">UX</span>Skeletons + Empty states + Toast + Modals</span>
+      <span class="pill"><span class="num">UX</span>Sidebar v2 + paleta Vercel</span>
+      <span class="pill"><span class="num">PWA</span>Vista Conserje (PIN + deptos + cobros)</span>
+    </div>
+  </div>
+
+  <div class="sprint-row">
+    <div class="sprint-label"><span class="name">Sprint 3</span><span class="status done">Done</span></div>
+    <div class="sprint-pills">
+      <span class="pill"><span class="num">Core</span>Webhooks + Notificaciones in-app</span>
+      <span class="pill"><span class="num">Core</span>API Docs (17 endpoints)</span>
+      <span class="pill"><span class="num">Core</span>Multi-tenant base</span>
+      <span class="pill"><span class="num">Core</span>Stripe checkout + webhook</span>
+      <span class="pill"><span class="num">Core</span>Channex channel manager</span>
+      <span class="pill"><span class="num">Core</span>Mora 5 niveles + Cotizador STR</span>
+    </div>
+  </div>
+
+  <div class="sprint-row">
+    <div class="sprint-label"><span class="name">Sprint 4</span><span class="status done">Done · 5 PRs</span></div>
+    <div class="sprint-pills">
+      <span class="pill"><span class="num">#14</span>S4-0 Sidebar 6 secciones + SectionTopNav</span>
+      <span class="pill"><span class="num">#15</span>S4-1 Refactor multi-tenant resolveOrgId()</span>
+      <span class="pill"><span class="num">#16</span>S4-1.5 Platform Admin /admin + 3 capas L0/L1/L2</span>
+      <span class="pill"><span class="num">#17</span>S4-2 Owner Portal v2 con login real</span>
+      <span class="pill"><span class="num">#18</span>S4-3 Agente Cobranza v1 + infra 10+1</span>
+      <span class="pill"><span class="num">#27</span>Hardening: AGENTS.md + PR template</span>
+    </div>
+  </div>
+
+  <div class="sprint-row">
+    <div class="sprint-label"><span class="name">Sprint 5</span><span class="status next">Siguiente</span></div>
+    <div class="sprint-pills">
+      <span class="pill"><span class="num">Deuda</span>#20 conserje /[orgSlug]</span>
+      <span class="pill"><span class="num">Deuda</span>#22 webhooks getOrgIdAsync</span>
+      <span class="pill"><span class="num">Deuda</span>#25 owners legacy OWNER_TOKEN</span>
+      <span class="pill"><span class="num">Deuda</span>#19 /admin → /login</span>
+      <span class="pill"><span class="num">Deuda</span>#24 206+ HEX → tokens BaW</span>
+    </div>
+  </div>
+
+  <div class="sprint-row">
+    <div class="sprint-label"><span class="name">Sprint 6+</span><span class="status future">Planeado</span></div>
+    <div class="sprint-pills">
+      <span class="pill"><span class="num">Agents</span>10+1 agentes (5 más)</span>
+      <span class="pill"><span class="num">Agents</span>Handoff UI · Decision trees · Escalation</span>
+      <span class="pill"><span class="num">Comercial</span>WhatsApp → ticket · Unified Inbox</span>
+      <span class="pill"><span class="num">Comercial</span>Pre-contrato /apply · INPC · SPEI</span>
+      <span class="pill"><span class="num">SaaS</span>Billing Stripe · Demo mode · Multi-property dashboard</span>
+    </div>
+  </div>
+
+</div>
+
+<!-- Kanban current -->
+<h2>Estado actual · Kanban abreviado</h2>
+<div class="kanban">
+
+  <div class="col">
+    <div class="col-h"><h3>✅ Done</h3><span class="count">47</span></div>
+    <div class="card"><span class="tier tier-t1">T1 MVP</span><br>Sprint 4 completo (#14-#18)</div>
+    <div class="card"><span class="tier tier-t1">T1 MVP</span><br>Channel Manager Channex</div>
+    <div class="card"><span class="tier tier-t1">T1 MVP</span><br>Stripe checkout inquilinos</div>
+    <div class="card"><span class="tier tier-t1">T1 MVP</span><br>Mora escalamiento 5 niveles</div>
+    <div class="card"><span class="tier tier-t1">T1 MVP</span><br>Owner Portal v2 con login</div>
+    <div class="card"><span class="tier tier-t1">T1 MVP</span><br>Vista Conserje PWA</div>
+    <div class="card"><span class="tier tier-t1">T1 MVP</span><br>Cotizador STR + Bulk CSV import</div>
+    <div class="card"><span class="tier tier-t2">T2 Core</span><br>Webhooks + Notificaciones in-app</div>
+    <div class="card"><span class="tier tier-t25">T2.5 Agent</span><br>Audit log con actor field</div>
+    <div class="card"><span class="tier tier-t4">T4 Comercial</span><br>Self check-in digital · Onboarding wizard</div>
+    <div class="card" style="text-align:center; color:var(--muted)">+ 37 features más</div>
+  </div>
+
+  <div class="col">
+    <div class="col-h"><h3>🔨 En desarrollo</h3><span class="count">1</span></div>
+    <div class="card"><span class="tier tier-t25">T2.5 Agent</span><br>S4-3 · Agente Cobranza v1 + infra común agentes (10+1)</div>
+    <div style="margin-top:12px; padding:10px; background:var(--surface-2); border-radius:6px; font-size:12px; color:var(--muted)">
+      <strong style="color:var(--text)">Próximo a entrar:</strong><br>
+      Hardening de deuda Sprint 4 (#19-#25)<br>antes de abrir Sprint 5 funcional.
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-h"><h3>📋 Backlog</h3><span class="count">47</span></div>
+    <div class="card"><span class="tier tier-t1">T1 MVP · 4</span><br>Deuda Sprint 4: #19, #20, #22, #25</div>
+    <div class="card"><span class="tier tier-t2">T2 Core · 1</span><br>#24 · Migrar 206+ HEX a tokens</div>
+    <div class="card"><span class="tier tier-t25">T2.5 Agent · 5</span><br>Handoff UI · Decision trees · Escalation rules</div>
+    <div class="card"><span class="tier tier-t3">T3 Backlog · 7</span><br>BaW Public website · Booking engine STR</div>
+    <div class="card"><span class="tier tier-t4">T4 Comercial · 19</span><br>WhatsApp ticket · Pre-contrato · SPEI · INPC · Billing SaaS</div>
+    <div class="card"><span class="tier tier-t5">T5 Escala · 11</span><br>3D Viewer · Smart locks · Community · Compliance</div>
+  </div>
+
+</div>
+
+<!-- Tier deep dive -->
+<h2>Desglose por Tier · qué falta</h2>
+<div class="tier-grid">
+
+  <div class="tier-box">
+    <h3>Tier 1 — MVP <span style="font-size:12px; color:var(--muted); font-weight:400">22 total · 18 done · 4 backlog</span></h3>
+    <div class="progress-bar"><div class="progress-done" style="width:82%"></div><div class="progress-backlog" style="width:18%"></div></div>
+    <ul class="tier-list">
+      <li class="done">Sprint 4 entero (S4-0 a S4-3)</li>
+      <li class="done">+ 14 features Tier 1 anteriores</li>
+      <li>Deuda #20 · /[orgSlug]/conserje (multi-tenant verdadero)</li>
+      <li>Deuda #22 · Webhooks externos getOrgIdAsync</li>
+      <li>Deuda #25 · Migrar owners legacy OWNER_TOKEN</li>
+      <li>Bug #19 · /admin redirige a /login</li>
+    </ul>
+  </div>
+
+  <div class="tier-box">
+    <h3>Tier 2 — Core <span style="font-size:12px; color:var(--muted); font-weight:400">14 total · 13 done · 1 backlog</span></h3>
+    <div class="progress-bar"><div class="progress-done" style="width:93%"></div><div class="progress-backlog" style="width:7%"></div></div>
+    <ul class="tier-list">
+      <li class="done">UX Polish · Webhooks · API Docs · Sidebar v2 · multi-tenant</li>
+      <li>Deuda #24 · Migrar 206+ HEX/rgba a tokens BaW</li>
+    </ul>
+  </div>
+
+  <div class="tier-box">
+    <h3>Tier 2.5 — Agent Ready <span style="font-size:12px; color:var(--muted); font-weight:400">10 total · 4 done · 6 pending</span></h3>
+    <div class="progress-bar"><div class="progress-done" style="width:40%"></div><div class="progress-doing" style="width:10%"></div><div class="progress-backlog" style="width:50%"></div></div>
+    <ul class="tier-list">
+      <li class="done">Audit log + actor field · Task creation API · Onboarding wizard · Conserje PWA</li>
+      <li class="doing">S4-3 · Agente Cobranza v1 (en review)</li>
+      <li>Agent handoff UI (botón "Automatizar esto")</li>
+      <li>Agent decision trees (occupancy/pricing)</li>
+      <li>Automated escalation rules (if X then Y)</li>
+      <li>Escalation rules configurables</li>
+      <li>Handoff protocol configurable</li>
+    </ul>
+  </div>
+
+  <div class="tier-box">
+    <h3>Tier 3 — Backlog <span style="font-size:12px; color:var(--muted); font-weight:400">8 total · 1 done · 7 pending</span></h3>
+    <div class="progress-bar"><div class="progress-done" style="width:13%"></div><div class="progress-backlog" style="width:87%"></div></div>
+    <ul class="tier-list">
+      <li>Bug #21 · /apply public_prefix sin ruta</li>
+      <li>Deuda #23 · Eliminar enum legacy member_role</li>
+      <li>BaW Public — SEO + mobile-first</li>
+      <li>BaW Public — Galería deptos LTR</li>
+      <li>BaW Public — Formulario interés LTR</li>
+      <li>BaW Public — Booking Engine público STR</li>
+      <li>BaW Public — Website STR público</li>
+    </ul>
+  </div>
+
+  <div class="tier-box" style="grid-column:1/-1">
+    <h3>Tier 4 — Comercial <span style="font-size:12px; color:var(--muted); font-weight:400">29 total · 10 done · 19 pending</span></h3>
+    <div class="progress-bar"><div class="progress-done" style="width:34%"></div><div class="progress-backlog" style="width:66%"></div></div>
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:20px">
+      <ul class="tier-list">
+        <li><strong>Legal/Fiscal:</strong> Acuerdos D201/D303 · INPC + carta convenio · Bitácora inmutable · Notificaciones acuse · Retenciones Airbnb · IVA STR/LTR/MTR</li>
+        <li><strong>Pagos:</strong> SPEI conciliación · P&L por unidad · Mora 12 días alertas</li>
+        <li><strong>Operaciones:</strong> WhatsApp → ticket auto · Mantenimiento ficha técnica · Housekeeping checkout</li>
+      </ul>
+      <ul class="tier-list">
+        <li><strong>UI/UX:</strong> Pre-contrato /apply · Multi-property dashboard · Demo mode</li>
+        <li><strong>Integraciones:</strong> Unified Inbox WhatsApp+OTAs · Mensajería auto WhatsApp · PriceLabs API</li>
+        <li><strong>SaaS:</strong> Billing Stripe (Starter/Pro/Enterprise)</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="tier-box" style="grid-column:1/-1">
+    <h3>Tier 5 — Escala <span style="font-size:12px; color:var(--muted); font-weight:400">17 total · 1 done · 11 pending · 5 descartados</span></h3>
+    <div class="progress-bar"><div class="progress-done" style="width:6%"></div><div class="progress-backlog" style="width:65%"></div><div class="progress-discarded" style="width:29%"></div></div>
+    <ul class="tier-list">
+      <li><strong>Compliance:</strong> LFPDPPP aviso privacidad (obligatorio antes SaaS externo)</li>
+      <li><strong>SaaS:</strong> Billing module · Demo mode · Sandbox</li>
+      <li><strong>Smart Building:</strong> Smart lock Igloohome/Yale · Moodpad guest controls · 3D Viewer + iOS LiDAR</li>
+      <li><strong>Community:</strong> Guest experience app · Perfil residente + eventos</li>
+      <li><strong>Asset-light:</strong> Management fee module (gestión de terceros)</li>
+    </ul>
+  </div>
+
+</div>
+
+<!-- Next up call-out -->
+<div class="next-up">
+  <h3>⚡ Lo más urgente · candidatos a Sprint 5</h3>
+  <ol>
+    <li><strong>Deuda #20</strong> · /(public)/conserje UUID hardcoded → /[orgSlug]/conserje. <em>Bloquea producción multi-tenant verdadera.</em></li>
+    <li><strong>Deuda #22</strong> · Webhooks externos siguen usando shim getOrgIdAsync. <em>Bug si hay 2+ tenants.</em></li>
+    <li><strong>Deuda #25</strong> · Migrar owners legacy del OWNER_TOKEN compartido. <em>Security: token único compartido.</em></li>
+    <li><strong>Bug #19</strong> · /admin redirige a / en lugar de /login. <em>UX confusa.</em></li>
+    <li><strong>Cierre #18</strong> · Mergear Agente Cobranza v1 (en review) + abrir 5 agentes restantes del 10+1.</li>
+  </ol>
+</div>
+
+<footer>
+  Datos: GitHub PRs/Issues · Notion Feature Board (100 features) · AGENTS.md
+</footer>
+
+</body>
+</html>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,7 +6,7 @@
 import { redirect } from 'next/navigation'
 import { getPlatformAdminContext } from '@/lib/platform-admin'
 import Link from 'next/link'
-import { LayoutDashboard, Building2, Users, Server, Activity } from 'lucide-react'
+import { LayoutDashboard, Building2, Users, Server, Activity, Map } from 'lucide-react'
 
 export const metadata = {
   title: 'Platform Admin · BaW OS',
@@ -67,6 +67,7 @@ export default async function AdminLayout({
         style={{ borderColor: 'var(--baw-border)' }}
       >
         <AdminTab href="/admin" icon={<LayoutDashboard size={14} />} label="Dashboard" />
+        <AdminTab href="/admin/roadmap" icon={<Map size={14} />} label="Roadmap" />
         <AdminTab href="/admin/tenants" icon={<Building2 size={14} />} label="Tenants" />
         <AdminTab href="/admin/users" icon={<Users size={14} />} label="Usuarios" />
         <AdminTab href="/admin/admins" icon={<Server size={14} />} label="Platform Admins" />

--- a/src/app/admin/roadmap/lib/snapshot.ts
+++ b/src/app/admin/roadmap/lib/snapshot.ts
@@ -1,0 +1,241 @@
+// BaW OS — Roadmap snapshot data
+// v1: estructura desde HTML mock 2026-05-01 (Notion: Internal Roadmap Dashboard)
+// v2 (futuro): fetchNotionBoard() + fetchGithubData() con ISR revalidate=300
+//
+// La spec en Notion (354169373e7281e7b4eef78ea5031e47) describe:
+//   - Features → Notion data source 330169373e7281e5b93beda50203b65f
+//   - Sprints recorridos → GitHub PRs mergeados
+//   - Deuda activa → GitHub issues abiertos
+//
+// Por ahora servimos el snapshot canónico para que el dashboard exista.
+// El snapshot es editable por L0 vía este archivo hasta que llegue v2.
+
+export type Status = 'done' | 'doing' | 'backlog' | 'discarded'
+export type Tier = 't1' | 't2' | 't25' | 't3' | 't4' | 't5'
+export type SprintStatus = 'done' | 'next' | 'future'
+
+export interface SprintItem {
+  num: string  // "UX", "Core", "#14", "Deuda"
+  text: string
+}
+
+export interface Sprint {
+  name: string
+  status: SprintStatus
+  statusLabel?: string  // override: "Done · 5 PRs", "Siguiente"
+  items: SprintItem[]
+}
+
+export interface KanbanCard {
+  tier: Tier
+  tierLabel: string  // "T1 MVP", "T2 Core"
+  text: string
+}
+
+export interface KanbanCol {
+  name: string
+  emoji: string
+  count: number
+  cards: KanbanCard[]
+  footer?: string  // "Próximo a entrar..."
+}
+
+export interface TierBox {
+  tier: Tier
+  name: string
+  total: number
+  done: number
+  doing?: number
+  backlog: number
+  discarded?: number
+  items: { text: string; status?: Status }[]
+  fullWidth?: boolean
+  twoCols?: boolean
+}
+
+export interface RoadmapSnapshot {
+  asOf: string
+  totals: { total: number; done: number; doing: number; backlog: number; discarded: number }
+  sprints: Sprint[]
+  kanban: KanbanCol[]
+  tiers: TierBox[]
+  nextUp: { id: string; text: string; reason: string }[]
+}
+
+export const ROADMAP_SNAPSHOT: RoadmapSnapshot = {
+  asOf: '2026-05-01 · Cierre Sprint 4',
+  totals: { total: 100, done: 47, doing: 1, backlog: 47, discarded: 5 },
+
+  sprints: [
+    {
+      name: 'Sprint 1-2', status: 'done',
+      items: [
+        { num: 'UX', text: 'Skeletons + Empty states + Toast + Modals' },
+        { num: 'UX', text: 'Sidebar v2 + paleta Vercel' },
+        { num: 'PWA', text: 'Vista Conserje (PIN + deptos + cobros)' },
+      ],
+    },
+    {
+      name: 'Sprint 3', status: 'done',
+      items: [
+        { num: 'Core', text: 'Webhooks + Notificaciones in-app' },
+        { num: 'Core', text: 'API Docs (17 endpoints)' },
+        { num: 'Core', text: 'Multi-tenant base' },
+        { num: 'Core', text: 'Stripe checkout + webhook' },
+        { num: 'Core', text: 'Channex channel manager' },
+        { num: 'Core', text: 'Mora 5 niveles + Cotizador STR' },
+      ],
+    },
+    {
+      name: 'Sprint 4', status: 'done', statusLabel: 'Done · 5 PRs',
+      items: [
+        { num: '#14', text: 'S4-0 Sidebar 6 secciones + SectionTopNav' },
+        { num: '#15', text: 'S4-1 Refactor multi-tenant resolveOrgId()' },
+        { num: '#16', text: 'S4-1.5 Platform Admin /admin + 3 capas L0/L1/L2' },
+        { num: '#17', text: 'S4-2 Owner Portal v2 con login real' },
+        { num: '#18', text: 'S4-3 Agente Cobranza v1 + infra 10+1' },
+        { num: '#27', text: 'Hardening: AGENTS.md + PR template' },
+      ],
+    },
+    {
+      name: 'Sprint 5', status: 'next', statusLabel: 'Siguiente',
+      items: [
+        { num: 'Deuda', text: '#20 conserje /[orgSlug]' },
+        { num: 'Deuda', text: '#22 webhooks getOrgIdAsync' },
+        { num: 'Deuda', text: '#25 owners legacy OWNER_TOKEN' },
+        { num: 'Deuda', text: '#19 /admin → /login' },
+        { num: 'Deuda', text: '#24 206+ HEX → tokens BaW' },
+      ],
+    },
+    {
+      name: 'Sprint 6+', status: 'future', statusLabel: 'Planeado',
+      items: [
+        { num: 'Agents', text: '10+1 agentes (5 más)' },
+        { num: 'Agents', text: 'Handoff UI · Decision trees · Escalation' },
+        { num: 'Comercial', text: 'WhatsApp → ticket · Unified Inbox' },
+        { num: 'Comercial', text: 'Pre-contrato /apply · INPC · SPEI' },
+        { num: 'SaaS', text: 'Billing Stripe · Demo mode · Multi-property dashboard' },
+      ],
+    },
+  ],
+
+  kanban: [
+    {
+      name: 'Done', emoji: '✅', count: 47,
+      cards: [
+        { tier: 't1', tierLabel: 'T1 MVP', text: 'Sprint 4 completo (#14-#18)' },
+        { tier: 't1', tierLabel: 'T1 MVP', text: 'Channel Manager Channex' },
+        { tier: 't1', tierLabel: 'T1 MVP', text: 'Stripe checkout inquilinos' },
+        { tier: 't1', tierLabel: 'T1 MVP', text: 'Mora escalamiento 5 niveles' },
+        { tier: 't1', tierLabel: 'T1 MVP', text: 'Owner Portal v2 con login' },
+        { tier: 't1', tierLabel: 'T1 MVP', text: 'Vista Conserje PWA' },
+        { tier: 't1', tierLabel: 'T1 MVP', text: 'Cotizador STR + Bulk CSV import' },
+        { tier: 't2', tierLabel: 'T2 Core', text: 'Webhooks + Notificaciones in-app' },
+        { tier: 't25', tierLabel: 'T2.5 Agent', text: 'Audit log con actor field' },
+        { tier: 't4', tierLabel: 'T4 Comercial', text: 'Self check-in digital · Onboarding wizard' },
+      ],
+      footer: '+ 37 features más',
+    },
+    {
+      name: 'En desarrollo', emoji: '🔨', count: 1,
+      cards: [
+        { tier: 't25', tierLabel: 'T2.5 Agent', text: 'S4-3 · Agente Cobranza v1 + infra común agentes (10+1)' },
+      ],
+      footer: 'Próximo a entrar: Hardening de deuda Sprint 4 (#19-#25) antes de abrir Sprint 5 funcional.',
+    },
+    {
+      name: 'Backlog', emoji: '📋', count: 47,
+      cards: [
+        { tier: 't1', tierLabel: 'T1 MVP · 4', text: 'Deuda Sprint 4: #19, #20, #22, #25' },
+        { tier: 't2', tierLabel: 'T2 Core · 1', text: '#24 · Migrar 206+ HEX a tokens' },
+        { tier: 't25', tierLabel: 'T2.5 Agent · 5', text: 'Handoff UI · Decision trees · Escalation rules' },
+        { tier: 't3', tierLabel: 'T3 Backlog · 7', text: 'BaW Public website · Booking engine STR' },
+        { tier: 't4', tierLabel: 'T4 Comercial · 19', text: 'WhatsApp ticket · Pre-contrato · SPEI · INPC · Billing SaaS' },
+        { tier: 't5', tierLabel: 'T5 Escala · 11', text: '3D Viewer · Smart locks · Community · Compliance' },
+      ],
+    },
+  ],
+
+  tiers: [
+    {
+      tier: 't1', name: 'Tier 1 — MVP', total: 22, done: 18, backlog: 4,
+      items: [
+        { text: 'Sprint 4 entero (S4-0 a S4-3)', status: 'done' },
+        { text: '+ 14 features Tier 1 anteriores', status: 'done' },
+        { text: 'Deuda #20 · /[orgSlug]/conserje (multi-tenant verdadero)' },
+        { text: 'Deuda #22 · Webhooks externos getOrgIdAsync' },
+        { text: 'Deuda #25 · Migrar owners legacy OWNER_TOKEN' },
+        { text: 'Bug #19 · /admin redirige a /login' },
+      ],
+    },
+    {
+      tier: 't2', name: 'Tier 2 — Core', total: 14, done: 13, backlog: 1,
+      items: [
+        { text: 'UX Polish · Webhooks · API Docs · Sidebar v2 · multi-tenant', status: 'done' },
+        { text: 'Deuda #24 · Migrar 206+ HEX/rgba a tokens BaW' },
+      ],
+    },
+    {
+      tier: 't25', name: 'Tier 2.5 — Agent Ready', total: 10, done: 4, doing: 1, backlog: 5,
+      items: [
+        { text: 'Audit log + actor field · Task creation API · Onboarding wizard · Conserje PWA', status: 'done' },
+        { text: 'S4-3 · Agente Cobranza v1 (en review)', status: 'doing' },
+        { text: 'Agent handoff UI (botón "Automatizar esto")' },
+        { text: 'Agent decision trees (occupancy/pricing)' },
+        { text: 'Automated escalation rules (if X then Y)' },
+        { text: 'Escalation rules configurables' },
+        { text: 'Handoff protocol configurable' },
+      ],
+    },
+    {
+      tier: 't3', name: 'Tier 3 — Backlog', total: 8, done: 1, backlog: 7,
+      items: [
+        { text: 'Bug #21 · /apply public_prefix sin ruta' },
+        { text: 'Deuda #23 · Eliminar enum legacy member_role' },
+        { text: 'BaW Public — SEO + mobile-first' },
+        { text: 'BaW Public — Galería deptos LTR' },
+        { text: 'BaW Public — Formulario interés LTR' },
+        { text: 'BaW Public — Booking Engine público STR' },
+        { text: 'BaW Public — Website STR público' },
+      ],
+    },
+    {
+      tier: 't4', name: 'Tier 4 — Comercial', total: 29, done: 10, backlog: 19, fullWidth: true, twoCols: true,
+      items: [
+        { text: 'Legal/Fiscal: Acuerdos D201/D303 · INPC + carta convenio · Bitácora inmutable · Notificaciones acuse · Retenciones Airbnb · IVA STR/LTR/MTR' },
+        { text: 'Pagos: SPEI conciliación · P&L por unidad · Mora 12 días alertas' },
+        { text: 'Operaciones: WhatsApp → ticket auto · Mantenimiento ficha técnica · Housekeeping checkout' },
+        { text: 'UI/UX: Pre-contrato /apply · Multi-property dashboard · Demo mode' },
+        { text: 'Integraciones: Unified Inbox WhatsApp+OTAs · Mensajería auto WhatsApp · PriceLabs API' },
+        { text: 'SaaS: Billing Stripe (Starter/Pro/Enterprise)' },
+      ],
+    },
+    {
+      tier: 't5', name: 'Tier 5 — Escala', total: 17, done: 1, backlog: 11, discarded: 5, fullWidth: true,
+      items: [
+        { text: 'Compliance: LFPDPPP aviso privacidad (obligatorio antes SaaS externo)' },
+        { text: 'SaaS: Billing module · Demo mode · Sandbox' },
+        { text: 'Smart Building: Smart lock Igloohome/Yale · Moodpad guest controls · 3D Viewer + iOS LiDAR' },
+        { text: 'Community: Guest experience app · Perfil residente + eventos' },
+        { text: 'Asset-light: Management fee module (gestión de terceros)' },
+      ],
+    },
+  ],
+
+  nextUp: [
+    { id: 'Deuda #20', text: '/(public)/conserje UUID hardcoded → /[orgSlug]/conserje', reason: 'Bloquea producción multi-tenant verdadera.' },
+    { id: 'Deuda #22', text: 'Webhooks externos siguen usando shim getOrgIdAsync', reason: 'Bug si hay 2+ tenants.' },
+    { id: 'Deuda #25', text: 'Migrar owners legacy del OWNER_TOKEN compartido', reason: 'Security: token único compartido.' },
+    { id: 'Bug #19', text: '/admin redirige a / en lugar de /login', reason: 'UX confusa.' },
+    { id: 'Cierre #18', text: 'Mergear Agente Cobranza v1 (en review) + abrir 5 agentes restantes del 10+1', reason: '' },
+  ],
+}
+
+export const TIER_COLORS: Record<Tier, string> = {
+  t1: '#10b981',
+  t2: '#3b82f6',
+  t25: '#a855f7',
+  t3: '#6b7280',
+  t4: '#f97316',
+  t5: '#dc2626',
+}

--- a/src/app/admin/roadmap/page.tsx
+++ b/src/app/admin/roadmap/page.tsx
@@ -1,0 +1,347 @@
+// BaW OS — Internal Roadmap Dashboard (L0 only)
+// Notion spec: 354169373e7281e7b4eef78ea5031e47
+// v1: snapshot estático canónico (Sprint 4 cierre)
+// v2 (futuro): fetchNotionBoard + fetchGithubData con ISR revalidate=300
+
+import { redirect } from 'next/navigation'
+import { isPlatformAdmin } from '@/lib/platform-admin'
+import { ROADMAP_SNAPSHOT, TIER_COLORS, type Tier, type Status } from './lib/snapshot'
+
+export const dynamic = 'force-dynamic'
+
+const STATUS_BG: Record<SprintStatusKey, string> = {
+  done: 'rgba(16,185,129,0.12)',
+  next: 'rgba(245,158,11,0.12)',
+  future: 'rgba(107,114,128,0.12)',
+}
+const STATUS_FG: Record<SprintStatusKey, string> = {
+  done: '#10b981',
+  next: '#f59e0b',
+  future: '#6b7280',
+}
+type SprintStatusKey = 'done' | 'next' | 'future'
+
+function tierStyle(tier: Tier) {
+  const c = TIER_COLORS[tier]
+  // Hex → rgba con alpha 0.15 sin depender de helpers
+  const r = parseInt(c.slice(1, 3), 16)
+  const g = parseInt(c.slice(3, 5), 16)
+  const b = parseInt(c.slice(5, 7), 16)
+  return { bg: `rgba(${r},${g},${b},0.15)`, fg: c }
+}
+
+function ProgressBar({
+  done, doing = 0, backlog, discarded = 0, height = 10,
+}: { done: number; doing?: number; backlog: number; discarded?: number; height?: number }) {
+  const total = done + doing + backlog + discarded || 1
+  const pct = (n: number) => `${(n / total) * 100}%`
+  return (
+    <div
+      className="rounded-md overflow-hidden flex"
+      style={{
+        height: `${height}px`,
+        backgroundColor: 'var(--baw-bg)',
+        border: '1px solid var(--baw-border)',
+      }}
+    >
+      <div style={{ width: pct(done), backgroundColor: '#10b981' }} />
+      <div style={{ width: pct(doing), backgroundColor: '#f59e0b' }} />
+      <div style={{ width: pct(backlog), backgroundColor: '#6b7280' }} />
+      <div style={{ width: pct(discarded), backgroundColor: '#ef4444', opacity: 0.4 }} />
+    </div>
+  )
+}
+
+export default async function RoadmapPage() {
+  const ok = await isPlatformAdmin()
+  if (!ok) redirect('/?forbidden=roadmap')
+
+  const snap = ROADMAP_SNAPSHOT
+  const t = snap.totals
+  const donePct = Math.round((t.done / t.total) * 100)
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div>
+        <h1
+          className="text-[24px] font-semibold mb-1 tracking-tight"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          BaW OS — Roadmap visual
+        </h1>
+        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          {snap.asOf} · v1 snapshot · v2 leerá Notion + GitHub en vivo
+        </p>
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {[
+          { num: t.total, label: 'Features totales', color: 'var(--baw-text)' },
+          { num: t.done, label: `Done · ${donePct}%`, color: '#10b981' },
+          { num: t.doing, label: 'En desarrollo', color: '#f59e0b' },
+          { num: t.backlog, label: 'Backlog', color: '#6b7280' },
+        ].map((s, i) => (
+          <div
+            key={i}
+            className="rounded-lg p-4"
+            style={{
+              backgroundColor: 'var(--baw-surface)',
+              border: '1px solid var(--baw-border)',
+            }}
+          >
+            <div className="text-[26px] font-bold tabular-nums" style={{ color: s.color }}>
+              {s.num}
+            </div>
+            <div
+              className="text-[11px] uppercase tracking-wider mt-1"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              {s.label}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Global progress */}
+      <div>
+        <ProgressBar done={t.done} doing={t.doing} backlog={t.backlog} discarded={t.discarded} />
+        <div className="flex flex-wrap gap-4 mt-2 text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+          <span><span style={{ color: '#10b981' }}>●</span> Done · {t.done}</span>
+          <span><span style={{ color: '#f59e0b' }}>●</span> En desarrollo · {t.doing}</span>
+          <span><span style={{ color: '#6b7280' }}>●</span> Backlog · {t.backlog}</span>
+          <span><span style={{ color: '#ef4444', opacity: 0.6 }}>●</span> Descartado · {t.discarded}</span>
+        </div>
+      </div>
+
+      {/* Sprint timeline */}
+      <section>
+        <h2
+          className="text-[18px] font-semibold pb-2 mb-3"
+          style={{ color: 'var(--baw-text)', borderBottom: '1px solid var(--baw-border)' }}
+        >
+          Sprints — lo recorrido y lo siguiente
+        </h2>
+        <div>
+          {snap.sprints.map((sprint, i) => (
+            <div
+              key={i}
+              className="grid gap-5 py-3"
+              style={{
+                gridTemplateColumns: '110px 1fr',
+                borderBottom: i === snap.sprints.length - 1 ? 'none' : '1px solid var(--baw-border)',
+              }}
+            >
+              <div>
+                <div className="text-[14px] font-semibold mb-1" style={{ color: 'var(--baw-text)' }}>
+                  {sprint.name}
+                </div>
+                <span
+                  className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded inline-block"
+                  style={{ backgroundColor: STATUS_BG[sprint.status], color: STATUS_FG[sprint.status] }}
+                >
+                  {sprint.statusLabel || sprint.status}
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {sprint.items.map((it, j) => (
+                  <span
+                    key={j}
+                    className="text-[12px] px-2.5 py-1 rounded-md"
+                    style={{
+                      backgroundColor: 'var(--baw-surface)',
+                      border: '1px solid var(--baw-border)',
+                      color: 'var(--baw-text)',
+                    }}
+                  >
+                    <span style={{ color: 'var(--baw-muted)', fontWeight: 600, marginRight: 4 }}>
+                      {it.num}
+                    </span>
+                    {it.text}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Kanban */}
+      <section>
+        <h2
+          className="text-[18px] font-semibold pb-2 mb-3"
+          style={{ color: 'var(--baw-text)', borderBottom: '1px solid var(--baw-border)' }}
+        >
+          Estado actual · Kanban abreviado
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {snap.kanban.map((col, i) => (
+            <div
+              key={i}
+              className="rounded-lg p-3"
+              style={{
+                backgroundColor: 'var(--baw-surface)',
+                border: '1px solid var(--baw-border)',
+              }}
+            >
+              <div
+                className="flex items-center justify-between pb-2 mb-2"
+                style={{ borderBottom: '1px solid var(--baw-border)' }}
+              >
+                <h3 className="text-[14px] font-semibold" style={{ color: 'var(--baw-text)' }}>
+                  {col.emoji} {col.name}
+                </h3>
+                <span
+                  className="text-[11px] px-2 py-0.5 rounded-full"
+                  style={{ backgroundColor: 'var(--baw-bg)', color: 'var(--baw-muted)' }}
+                >
+                  {col.count}
+                </span>
+              </div>
+              <div className="space-y-2">
+                {col.cards.map((c, j) => {
+                  const ts = tierStyle(c.tier)
+                  return (
+                    <div
+                      key={j}
+                      className="rounded-md p-2.5"
+                      style={{
+                        backgroundColor: 'var(--baw-bg)',
+                        border: '1px solid var(--baw-border)',
+                      }}
+                    >
+                      <div
+                        className="text-[10px] uppercase tracking-wider font-semibold inline-block px-1.5 py-0.5 rounded mb-1"
+                        style={{ backgroundColor: ts.bg, color: ts.fg }}
+                      >
+                        {c.tierLabel}
+                      </div>
+                      <div className="text-[13px]" style={{ color: 'var(--baw-text)' }}>
+                        {c.text}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+              {col.footer && (
+                <div
+                  className="mt-2 p-2 rounded text-[12px]"
+                  style={{
+                    backgroundColor: 'var(--baw-bg)',
+                    color: 'var(--baw-muted)',
+                  }}
+                >
+                  {col.footer}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Tier breakdown */}
+      <section>
+        <h2
+          className="text-[18px] font-semibold pb-2 mb-3"
+          style={{ color: 'var(--baw-text)', borderBottom: '1px solid var(--baw-border)' }}
+        >
+          Desglose por Tier · qué falta
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {snap.tiers.map((tb, i) => (
+            <div
+              key={i}
+              className="rounded-lg p-4"
+              style={{
+                backgroundColor: 'var(--baw-surface)',
+                border: '1px solid var(--baw-border)',
+                gridColumn: tb.fullWidth ? '1 / -1' : undefined,
+              }}
+            >
+              <div className="flex items-baseline justify-between mb-2">
+                <h3 className="text-[14px] font-semibold" style={{ color: 'var(--baw-text)' }}>
+                  {tb.name}
+                </h3>
+                <span className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+                  {tb.total} total · {tb.done} done
+                  {tb.doing ? ` · ${tb.doing} en review` : ''}
+                  {tb.backlog ? ` · ${tb.backlog} pending` : ''}
+                  {tb.discarded ? ` · ${tb.discarded} descartados` : ''}
+                </span>
+              </div>
+              <div className="mb-3">
+                <ProgressBar
+                  done={tb.done} doing={tb.doing || 0}
+                  backlog={tb.backlog} discarded={tb.discarded || 0}
+                  height={6}
+                />
+              </div>
+              <ul
+                className={tb.twoCols ? 'grid grid-cols-1 md:grid-cols-2 gap-x-5' : ''}
+                style={{ listStyle: 'none' }}
+              >
+                {tb.items.map((it, j) => {
+                  const isDone = it.status === 'done'
+                  const isDoing = it.status === 'doing'
+                  return (
+                    <li
+                      key={j}
+                      className="text-[12.5px] py-1.5 relative pl-4"
+                      style={{
+                        color: isDone ? 'var(--baw-muted)' : 'var(--baw-text)',
+                        textDecoration: isDone ? 'line-through' : 'none',
+                        borderBottom: '1px dashed var(--baw-border)',
+                      }}
+                    >
+                      <span
+                        className="absolute left-0"
+                        style={{
+                          color: isDone ? '#10b981' : isDoing ? '#f59e0b' : 'var(--baw-muted)',
+                        }}
+                      >
+                        {isDone ? '●' : isDoing ? '◐' : '○'}
+                      </span>
+                      {it.text}
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Next up */}
+      <div
+        className="rounded-lg p-5"
+        style={{
+          background: 'linear-gradient(135deg, rgba(245,158,11,0.08), rgba(168,85,247,0.05))',
+          border: '1px solid rgba(245,158,11,0.3)',
+        }}
+      >
+        <h3 className="text-[14px] font-semibold mb-3" style={{ color: '#f59e0b' }}>
+          ⚡ Lo más urgente · candidatos a próximo sprint
+        </h3>
+        <ol className="ml-5 space-y-2 text-[13px]" style={{ color: 'var(--baw-text)' }}>
+          {snap.nextUp.map((n, i) => (
+            <li key={i} style={{ listStyle: 'decimal' }}>
+              <strong>{n.id}</strong> · {n.text}.
+              {n.reason && (
+                <em style={{ color: 'var(--baw-muted)', marginLeft: 4 }}>{n.reason}</em>
+              )}
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      {/* Footer */}
+      <footer
+        className="text-[11px] text-center pt-4"
+        style={{ borderTop: '1px solid var(--baw-border)', color: 'var(--baw-muted)' }}
+      >
+        v1 snapshot · Datos: HTML mock 2026-05-01 · v2 (futuro): Notion Feature Board (100 features) + GitHub PRs/Issues + ISR 5min
+      </footer>
+    </div>
+  )
+}


### PR DESCRIPTION
## Sprint 5.5 / Item 8 — Internal Roadmap Dashboard

Implementa `/admin/roadmap` según spec Notion ([Internal Roadmap Dashboard](https://www.notion.so/zxyventures/354169373e7281e7b4eef78ea5031e47)).

### v1 (este PR)
- Server component gateado a `isPlatformAdmin()` (L0, fran@zxy.vc)
- Snapshot canónico Sprint 4 cierre (2026-05-01) hardcoded en `lib/snapshot.ts`
- Replica fiel del HTML mock: stats row, progress bar, sprint timeline, kanban, tier breakdown, next-up
- Usa tokens BaW exclusivamente (refuerza I2 — NO `--brand-*`, NO `--d-*`)
- Tab "Roadmap" añadido al nav `/admin`
- HTML mock guardado en `docs/roadmap-snapshot-2026-05-01.html` para referencia

### v2 (futuro · NO en este PR)
- `fetchNotionBoard()` desde data source `330169373e7281e5b93beda50203b65f`
- `fetchGithubData()` para PRs/issues abiertos
- ISR `revalidate: 300` (5 min)
- TODOs marcados en `lib/snapshot.ts`

### Test plan
1. Login como fran@zxy.vc → ir a `/admin` → click tab "Roadmap"
2. Verificar que renderiza: 4 KPIs (100/47/1/47), 5 sprints, 3 columnas kanban, 6 tier boxes, next-up
3. Login como otro usuario → `/admin/roadmap` debe redirigir a `/?error=forbidden`

### Tokens usados
Solo `--baw-*` existentes (bg, surface, text, muted, border). Tier colors via constantes hex en `snapshot.ts` por consistencia con HTML mock.
