### PR TITLE
Fix Sprint 5.5 followups: login loop + Mark Cube

### DIFF
--- a/public/baw-logo.svg
+++ b/public/baw-logo.svg
@@ -1,8 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 64" fill="none" aria-label="BaW OS">
+  <!-- Mark · 02 Cube -->
   <g transform="translate(0,12)">
-    <path d="M8 32 L28 40 L48 32 L28 24 Z" fill="currentColor"/>
-    <path d="M11 24 L31 32 L51 24 L31 16 Z" fill="currentColor" opacity="0.7"/>
-    <path d="M8 16 L28 24 L48 16 L28 8 Z" fill="currentColor" opacity="0.5"/>
+    <path d="M28 8 L48 16 L28 24 L8 16 Z" fill="currentColor" opacity="0.55"/>
+    <path d="M8 16 L28 24 L28 40 L8 32 Z" fill="currentColor" opacity="0.8"/>
+    <path d="M48 16 L28 24 L28 40 L48 32 Z" fill="currentColor"/>
   </g>
   <text x="64" y="40" font-family="'IBM Plex Mono', ui-monospace, monospace" font-size="28" font-weight="500" fill="currentColor" letter-spacing="-0.5">BaW</text>
   <text x="146" y="40" font-family="'IBM Plex Mono', ui-monospace, monospace" font-size="14" font-weight="400" fill="currentColor" opacity="0.55" letter-spacing="0.5">/ OS</text>

--- a/public/baw-mark.svg
+++ b/public/baw-mark.svg
@@ -1,5 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" fill="none" aria-label="BaW">
-  <path d="M40 168 L120 200 L200 168 L120 136 Z" fill="currentColor"/>
-  <path d="M52 128 L132 160 L212 128 L132 96 Z" fill="currentColor" opacity="0.7"/>
-  <path d="M40 88 L120 120 L200 88 L120 56 Z" fill="currentColor" opacity="0.5"/>
+  <!-- BaW Mark · 02 Cube · 30° iso · 3 caras alineadas -->
+  <!-- top face -->
+  <path d="M120 40 L200 80 L120 120 L40 80 Z" fill="currentColor" opacity="0.55"/>
+  <!-- left face -->
+  <path d="M40 80 L120 120 L120 200 L40 160 Z" fill="currentColor" opacity="0.8"/>
+  <!-- right face -->
+  <path d="M200 80 L120 120 L120 200 L200 160 Z" fill="currentColor"/>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <rect width="32" height="32" rx="6" fill="#0F172A"/>
-  <path d="M4 22 L16 27 L28 22 L16 17 Z" fill="#FFFFFF"/>
-  <path d="M5 17 L17 22 L29 17 L17 12 Z" fill="#FFFFFF" opacity="0.7"/>
-  <path d="M4 12 L16 17 L28 12 L16 7 Z" fill="#FFFFFF" opacity="0.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- BaW Mark · Cube · favicon size -->
+  <path d="M24 6 L42 15 L24 24 L6 15 Z" fill="#0a0a0a" opacity="0.55"/>
+  <path d="M6 15 L24 24 L24 42 L6 33 Z" fill="#0a0a0a" opacity="0.8"/>
+  <path d="M42 15 L24 24 L24 42 L42 33 Z" fill="#0a0a0a"/>
 </svg>

--- a/src/app/api/auth/sync-session/route.ts
+++ b/src/app/api/auth/sync-session/route.ts
@@ -1,16 +1,67 @@
+// BaW OS — Sync browser session into HTTP cookies (SSR-safe)
+// Sprint 5.5 fix: route handlers can write cookies via NextResponse,
+// but Supabase SSR's setSession needs cookies to round-trip back to the
+// response. Build a NextResponse and pass it explicitly to the cookie
+// adapter so Set-Cookie headers actually ship.
+
 import { NextResponse } from 'next/server'
-import { createSupabaseServer } from '@/lib/supabase-server'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(request: Request) {
-  const { access_token, refresh_token } = await request.json().catch(() => ({}))
+  const { access_token, refresh_token } = await request
+    .json()
+    .catch(() => ({}))
 
   if (!access_token || !refresh_token) {
-    return NextResponse.json({ error: 'Missing session tokens' }, { status: 400 })
+    return NextResponse.json(
+      { error: 'Missing session tokens' },
+      { status: 400 },
+    )
   }
 
-  const supabase = createSupabaseServer()
+  // Prepare the response so the cookie adapter can write Set-Cookie on it.
+  const response = NextResponse.json({ ok: true })
+
+  const cookieStore = cookies()
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(
+          cookiesToSet: {
+            name: string
+            value: string
+            options?: Record<string, unknown>
+          }[],
+        ) {
+          // Ship cookies on BOTH the request cookie store (so subsequent
+          // calls in this handler see them) and the response (so the
+          // browser actually receives them).
+          cookiesToSet.forEach(({ name, value, options }) => {
+            try {
+              cookieStore.set(name, value, options)
+            } catch {
+              // Server Component context — ignore, response handles it.
+            }
+            response.cookies.set(
+              name,
+              value,
+              options as Parameters<typeof response.cookies.set>[2],
+            )
+          })
+        },
+      },
+    },
+  )
+
   const { data, error } = await supabase.auth.setSession({
     access_token,
     refresh_token,
@@ -20,5 +71,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: error.message }, { status: 401 })
   }
 
-  return NextResponse.json({ email: data.user?.email ?? null })
+  // Override default body with the email confirmation while keeping cookies.
+  const ok = NextResponse.json({ email: data.user?.email ?? null })
+  // Copy Set-Cookie headers from `response` to `ok` so the browser receives them.
+  response.cookies.getAll().forEach((c) => {
+    ok.cookies.set(c.name, c.value, c)
+  })
+
+  return ok
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -28,6 +28,16 @@ function LoginForm() {
     setError(null)
     setLoading(true)
 
+    // Sprint 5.5 fix: clear any stale split-session (localStorage tokens
+    // without matching sb-* cookies) before signing in. Otherwise the
+    // browser keeps a UI-only session while middleware sees no cookies
+    // and redirects every protected route back to /login.
+    try {
+      await supabase.auth.signOut({ scope: 'local' })
+    } catch {
+      // Best-effort cleanup; proceed regardless.
+    }
+
     const { data, error } = await supabase.auth.signInWithPassword({ email, password })
 
     if (error) {
@@ -82,7 +92,7 @@ function LoginForm() {
         {/* Mark + wordmark */}
         <div className="flex flex-col items-center mb-12">
           <div className="text-[--baw-text] mb-5">
-            {/* Mark: 3 placas isométricas apiladas — design/baw-design/references/Mark Final.html */}
+            {/* Mark: 02 Cube — 3 caras isométricas alineadas (design/baw-design/references/Mark Final.html) */}
             <svg
               viewBox="0 0 240 240"
               width="56"
@@ -91,9 +101,12 @@ function LoginForm() {
               aria-label="BaW"
               className="block"
             >
-              <path d="M40 168 L120 200 L200 168 L120 136 Z" fill="currentColor" />
-              <path d="M52 128 L132 160 L212 128 L132 96 Z" fill="currentColor" opacity="0.7" />
-              <path d="M40 88 L120 120 L200 88 L120 56 Z" fill="currentColor" opacity="0.5" />
+              {/* top */}
+              <path d="M120 40 L200 80 L120 120 L40 80 Z" fill="currentColor" opacity="0.55" />
+              {/* left */}
+              <path d="M40 80 L120 120 L120 200 L40 160 Z" fill="currentColor" opacity="0.8" />
+              {/* right */}
+              <path d="M200 80 L120 120 L120 200 L200 160 Z" fill="currentColor" />
             </svg>
           </div>
 


### PR DESCRIPTION
## Sprint 5.5 followups — fixes post-merge

Fran reportó después del merge:
1. `/admin`, `/me?next=/dashboard`, `/owner` (con liz) → infinite login loop
2. Login muestra logotipo "Plates" (3 placas desfasadas) cuando debía ser "Cube" (3 caras alineadas)

### Causa raíz del loop (diagnosticada vía DevTools en producción)

**Split-session state:** el browser tiene tokens en `localStorage` pero NO tiene cookies `sb-*`. Sin cookies, el middleware SSR siempre ve "no session" y redirige a `/login`. Cuando llega a /login, el AuthGuard ve la sesión en localStorage y... no rescata cookies, así que vuelve a redirigir.

Origen probable: builds anteriores usaban solo localStorage; `sync-session` POST se introdujo en PR #32 pero estaba seteando cookies en el cookieStore SIN que se propagaran al `NextResponse.json()` de salida.

### Fixes en este PR

1. **`src/app/api/auth/sync-session/route.ts`**: reescrito para construir `NextResponse` primero y pasar el `response.cookies.set(...)` al adapter de @supabase/ssr. Las cookies `sb-*` ahora viajan en `Set-Cookie` al browser. Doble-write (cookieStore + response) para que el setSession vea la sesión inmediatamente.

2. **`src/app/login/page.tsx`**: `supabase.auth.signOut({scope:'local'})` antes de `signInWithPassword` para limpiar cualquier split-session viejo. Sin esto, sesiones zombie de builds previos perpetúan el loop.

3. **Mark Final · Cube** (en lugar de Plates): logo correcto según design/baw-design/references/Mark Final.html opción 02. Tres caras isométricas alineadas como cubo (top 0.55 / left 0.8 / right 1.0). Actualicé `public/baw-mark.svg`, `public/baw-logo.svg`, `public/favicon.svg` y el SVG inline de login.

### Test plan

1. Hard-reload el browser (Ctrl+Shift+R) o limpiar localStorage manualmente
2. Login con fran@zxy.vc → click "Entrar"
3. DevTools → Application → Cookies → debe haber `sb-zlcgxmllaeweypyodvzk-auth-token` (puede estar chunked en `.0`, `.1`)
4. Navegar a `/admin` → debe cargar el dashboard
5. Navegar a `/me?next=/dashboard` → debe cargar /me sin loopear
6. Navegar a `/owner` → 404 normal (fran no es property_owner)
7. Logout, login con lizvargas@icon.edu.mx / `BaW2026!Liz` → `/owner` debe cargar
8. Verificar logo en /login: debe verse el cubo isométrico (no las 3 placas paralelas)

### Notas para Fran

- `/owner` (singular, portal del propietario) vs `/owners` (plural, CRUD admin de owners) — sí pueden generar confusión. Es un rename grande, lo agendo para Sprint 6.
- Si después de este merge el loop sigue, el browser tiene caché de la versión vieja. Solución: `localStorage.clear()` en DevTools console + reload.
