### PR TITLE
Correct logo to Mark B (aligned cube, not desfasado Plates)

### DIFF
--- a/public/baw-logo.svg
+++ b/public/baw-logo.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 64" fill="none" aria-label="BaW OS">
-  <!-- Mark · 02 Cube -->
+  <!-- Mark · B · Alineado a cubo -->
   <g transform="translate(0,12)">
-    <path d="M28 8 L48 16 L28 24 L8 16 Z" fill="currentColor" opacity="0.55"/>
-    <path d="M8 16 L28 24 L28 40 L8 32 Z" fill="currentColor" opacity="0.8"/>
-    <path d="M48 16 L28 24 L28 40 L48 32 Z" fill="currentColor"/>
+    <path d="M8 32 L28 40 L48 32 L28 24 Z" fill="currentColor"/>
+    <path d="M8 24 L28 32 L48 24 L28 16 Z" fill="currentColor" opacity="0.7"/>
+    <path d="M8 16 L28 24 L48 16 L28 8 Z" fill="currentColor" opacity="0.5"/>
   </g>
   <text x="64" y="40" font-family="'IBM Plex Mono', ui-monospace, monospace" font-size="28" font-weight="500" fill="currentColor" letter-spacing="-0.5">BaW</text>
   <text x="146" y="40" font-family="'IBM Plex Mono', ui-monospace, monospace" font-size="14" font-weight="400" fill="currentColor" opacity="0.55" letter-spacing="0.5">/ OS</text>

--- a/public/baw-mark.svg
+++ b/public/baw-mark.svg
@@ -1,9 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" fill="none" aria-label="BaW">
-  <!-- BaW Mark · 02 Cube · 30° iso · 3 caras alineadas -->
-  <!-- top face -->
-  <path d="M120 40 L200 80 L120 120 L40 80 Z" fill="currentColor" opacity="0.55"/>
-  <!-- left face -->
-  <path d="M40 80 L120 120 L120 200 L40 160 Z" fill="currentColor" opacity="0.8"/>
-  <!-- right face -->
-  <path d="M200 80 L120 120 L120 200 L200 160 Z" fill="currentColor"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none" aria-label="BaW">
+  <!-- BaW Mark · B · Alineado a cubo (3 placas apiladas sobre eje vertical) -->
+  <!-- Wordmark Explorations v2 / Mark B -->
+  <path d="M10 82 L60 100 L110 82 L60 64 Z" fill="currentColor"/>
+  <path d="M10 58 L60 76 L110 58 L60 40 Z" fill="currentColor" opacity="0.7"/>
+  <path d="M10 34 L60 52 L110 34 L60 16 Z" fill="currentColor" opacity="0.5"/>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
-  <!-- BaW Mark · Cube · favicon size -->
-  <path d="M24 6 L42 15 L24 24 L6 15 Z" fill="#0a0a0a" opacity="0.55"/>
-  <path d="M6 15 L24 24 L24 42 L6 33 Z" fill="#0a0a0a" opacity="0.8"/>
-  <path d="M42 15 L24 24 L24 42 L42 33 Z" fill="#0a0a0a"/>
+  <!-- BaW Mark · B (favicon) -->
+  <path d="M6 33 L24 40.5 L42 33 L24 25.5 Z" fill="#0a0a0a"/>
+  <path d="M6 25.5 L24 33 L42 25.5 L24 18 Z" fill="#0a0a0a" opacity="0.7"/>
+  <path d="M6 18 L24 25.5 L42 18 L24 10.5 Z" fill="#0a0a0a" opacity="0.5"/>
 </svg>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -92,21 +92,19 @@ function LoginForm() {
         {/* Mark + wordmark */}
         <div className="flex flex-col items-center mb-12">
           <div className="text-[--baw-text] mb-5">
-            {/* Mark: 02 Cube — 3 caras isométricas alineadas (design/baw-design/references/Mark Final.html) */}
+            {/* Mark · B — Alineado a cubo (3 placas apiladas sobre eje vertical) */}
+            {/* design/baw-design/references/Wordmark Explorations v2.html */}
             <svg
-              viewBox="0 0 240 240"
+              viewBox="0 0 120 120"
               width="56"
               height="56"
               fill="none"
               aria-label="BaW"
               className="block"
             >
-              {/* top */}
-              <path d="M120 40 L200 80 L120 120 L40 80 Z" fill="currentColor" opacity="0.55" />
-              {/* left */}
-              <path d="M40 80 L120 120 L120 200 L40 160 Z" fill="currentColor" opacity="0.8" />
-              {/* right */}
-              <path d="M200 80 L120 120 L120 200 L200 160 Z" fill="currentColor" />
+              <path d="M10 82 L60 100 L110 82 L60 64 Z" fill="currentColor" />
+              <path d="M10 58 L60 76 L110 58 L60 40 Z" fill="currentColor" opacity="0.7" />
+              <path d="M10 34 L60 52 L110 34 L60 16 Z" fill="currentColor" opacity="0.5" />
             </svg>
           </div>
 


### PR DESCRIPTION
## Corrección post-merge de PR #42

PR #42 mergeó una versión del logo basada en "Mark Final · 02 Cube" (3 caras isométricas formando un cubo sólido). Fran clarificó que el logo correcto es **Mark · B** del archivo `Wordmark Explorations v2.html`: 3 placas apiladas sobre eje vertical alineado, leyéndose como un edificio de 3 niveles en isométrico.

### Diferencia
- **Mark A** (desfase pronunciado): paths con offset X de 12px → placas desfasadas horizontalmente
- **Mark B** (alineado a cubo): paths con mismo X → eje vertical limpio, lee como volumen apilado

### Archivos actualizados
- `public/baw-mark.svg` → viewBox 120×120, 3 placas alineadas
- `public/baw-logo.svg` → wordmark con Mark B
- `public/favicon.svg` → versión 48×48
- `src/app/login/page.tsx` → SVG inline alineado

### Test plan
1. Abrir /login → comparar contra `design/baw-design/references/Wordmark Explorations v2.html` sección "Mark · B"
2. Las 3 placas deben estar centradas verticalmente, apiladas sobre el mismo eje X