### PR TITLE
Sprint 6 PR A: BawMark component + Sidebar shell + Mark A canonical

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -103,8 +103,8 @@ function LoginForm() {
               className="block"
             >
               <path d="M10 82 L60 100 L110 82 L60 64 Z" fill="currentColor" />
-              <path d="M10 58 L60 76 L110 58 L60 40 Z" fill="currentColor" opacity="0.7" />
-              <path d="M10 34 L60 52 L110 34 L60 16 Z" fill="currentColor" opacity="0.5" />
+              <path d="M16 58 L66 76 L116 58 L66 40 Z" fill="currentColor" opacity="0.7" />
+              <path d="M4 34 L54 52 L104 34 L54 16 Z" fill="currentColor" opacity="0.5" />
             </svg>
           </div>
 

--- a/src/components/BawMark.tsx
+++ b/src/components/BawMark.tsx
@@ -1,7 +1,13 @@
-// BaW OS — Mark B (Wordmark Explorations v2) — componente reutilizable
+// BaW OS — Mark A (Wordmark Explorations v2) — componente reutilizable
 //
-// 3 placas apiladas sobre eje vertical alineado, leyéndose como un edificio
-// de 3 niveles visto en isométrico. Color hereda de currentColor.
+// 3 placas con desfase pronunciado en X (offsets +6 / -6) que se asume como
+// decisión de diseño: rompe la lectura de "cubo mal dibujado" y comunica
+// capas operativas / floors de software / jerarquía. Color hereda de
+// currentColor.
+//
+// Histórico: durante Sprint 5.5 se probó Mark B (placas alineadas a eje
+// vertical) en /login. Tras verlo en producción se eligió volver a Mark A
+// — el desfase es la voz de la marca.
 //
 // Uso:
 //   <BawMark size={32} />              // mark solo
@@ -44,8 +50,8 @@ export default function BawMark({
         className="block shrink-0"
       >
         <path d="M10 82 L60 100 L110 82 L60 64 Z" fill="currentColor" />
-        <path d="M10 58 L60 76 L110 58 L60 40 Z" fill="currentColor" opacity="0.7" />
-        <path d="M10 34 L60 52 L110 34 L60 16 Z" fill="currentColor" opacity="0.5" />
+        <path d="M16 58 L66 76 L116 58 L66 40 Z" fill="currentColor" opacity="0.7" />
+        <path d="M4 34 L54 52 L104 34 L54 16 Z" fill="currentColor" opacity="0.5" />
       </svg>
 
       {withWordmark && (

--- a/src/components/BawMark.tsx
+++ b/src/components/BawMark.tsx
@@ -1,0 +1,66 @@
+// BaW OS — Mark B (Wordmark Explorations v2) — componente reutilizable
+//
+// 3 placas apiladas sobre eje vertical alineado, leyéndose como un edificio
+// de 3 niveles visto en isométrico. Color hereda de currentColor.
+//
+// Uso:
+//   <BawMark size={32} />              // mark solo
+//   <BawMark size={32} withWordmark /> // mark + "BaW OS" en IBM Plex Mono
+//   <BawMark size={32} withWordmark wordmarkSize="sm" />
+
+import { cn } from '@/lib/utils'
+
+interface BawMarkProps {
+  size?: number
+  withWordmark?: boolean
+  wordmarkSize?: 'sm' | 'md' | 'lg'
+  showOS?: boolean
+  className?: string
+}
+
+const WORDMARK_SIZES = {
+  sm: { brand: 'text-[13px]', os: 'text-[10px]' },
+  md: { brand: 'text-[16px]', os: 'text-[12px]' },
+  lg: { brand: 'text-[20px]', os: 'text-[14px]' },
+}
+
+export default function BawMark({
+  size = 24,
+  withWordmark = false,
+  wordmarkSize = 'md',
+  showOS = true,
+  className,
+}: BawMarkProps) {
+  const sizes = WORDMARK_SIZES[wordmarkSize]
+
+  return (
+    <div className={cn('flex items-center gap-2.5', className)}>
+      <svg
+        viewBox="0 0 120 120"
+        width={size}
+        height={size}
+        fill="none"
+        aria-label="BaW"
+        className="block shrink-0"
+      >
+        <path d="M10 82 L60 100 L110 82 L60 64 Z" fill="currentColor" />
+        <path d="M10 58 L60 76 L110 58 L60 40 Z" fill="currentColor" opacity="0.7" />
+        <path d="M10 34 L60 52 L110 34 L60 16 Z" fill="currentColor" opacity="0.5" />
+      </svg>
+
+      {withWordmark && (
+        <span
+          style={{ fontFamily: 'var(--font-mono)' }}
+          className={cn('font-medium leading-none tracking-tight', sizes.brand)}
+        >
+          BaW
+          {showOS && (
+            <span className={cn('ml-1.5 font-normal opacity-55 tracking-wide', sizes.os)}>
+              / OS
+            </span>
+          )}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import WorkspaceSwitcher from '@/components/WorkspaceSwitcher'
+import BawMark from '@/components/BawMark'
 import {
   SIDEBAR_SECTIONS,
   isSectionActive,
@@ -190,27 +191,36 @@ export default function Sidebar() {
           borderRight: '1px solid var(--baw-sidebar-border)',
         }}
       >
-        {/* Brand */}
+        {/* Brand — Mark B + IBM Plex Mono wordmark */}
         <div
           className="flex items-center gap-3 px-3 h-14 shrink-0"
           style={{ borderBottom: '1px solid var(--baw-sidebar-border)' }}
         >
           <div
-            className="flex items-center justify-center rounded-md shrink-0"
-            style={{
-              width: 32,
-              height: 32,
-              backgroundColor: 'var(--baw-primary)',
-              color: 'var(--baw-on-primary)',
-            }}
+            className="shrink-0"
+            style={{ color: 'var(--baw-text)' }}
           >
-            <span className="font-bold text-[14px] leading-none">B</span>
+            <BawMark size={28} />
           </div>
           {expanded && (
             <div className="flex items-center justify-between flex-1 min-w-0">
               <div className="min-w-0">
-                <div className="text-[14px] font-semibold text-white truncate">BaW OS</div>
-                <div className="text-[11px] truncate" style={{ color: 'var(--baw-muted)' }}>
+                <div
+                  style={{ fontFamily: 'var(--font-mono)', color: 'var(--baw-text)' }}
+                  className="text-[14px] font-medium tracking-tight leading-none truncate"
+                >
+                  BaW
+                  <span
+                    className="ml-1.5 text-[11px] font-normal opacity-55"
+                    style={{ color: 'var(--baw-muted)' }}
+                  >
+                    / OS
+                  </span>
+                </div>
+                <div
+                  className="text-[10px] mt-1 truncate uppercase tracking-wider"
+                  style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
+                >
                   Building Always Working
                 </div>
               </div>


### PR DESCRIPTION
## Sprint 6 · PR A — BawMark component + Sidebar shell + vuelta a Mark A

Primera entrega del rollout visual: lleva la identidad BaW (que vivía solo en `/login`) al chrome compartido por toda la plataforma, **y devuelve el Mark A (desfase pronunciado)** como mark canónico tras revisión de diseño.

### Cambios

- **`src/components/BawMark.tsx` (nuevo)** — componente reutilizable con SVG **Mark A** del Wordmark Explorations v2 (placa media `+6` X, placa superior `-6` X). Acepta `size`, `withWordmark`, `wordmarkSize`, `showOS`. Color hereda de `currentColor`.
- **`src/components/Sidebar.tsx`** — reemplaza el cuadrado con letra "B" del brand block por `<BawMark size={28} />`, wordmark "BaW / OS" en `var(--font-mono)` (IBM Plex Mono), tagline "Building Always Working" en mono uppercase.
- **`src/app/login/page.tsx`** — actualiza los path del SVG de Mark B a Mark A, manteniendo la lógica del componente intacta.

### Decisión Mark A vs B

- **Mark A** (este PR): placas con offset horizontal (+6 / -6). Lee como capas operativas / floors de software. Más voz, más movimiento.
- Mark B (PR #43): placas alineadas a eje vertical. Lee como cubo isométrico simétrico.

Tras verlo en producción se eligió volver al Mark A — el desfase es la intención, no el accidente.

### Lo que NO cambia

- AppShell, ProfileMenu, WorkspaceSwitcher ya usan tokens — sin cambios estructurales.
- Tagline, tipografías, tokens: idénticos.

### Validación

- `npx tsc --noEmit` ✅
- Hooks Sidebar intactos (`pinned`, `hovering`, `mobileOpen`)
- 0 HEX nuevos, 0 tokens paralelos creados

### Roadmap Sprint 6

- [x] PR A — BawMark + Sidebar shell + Mark A canónico (este PR)
- [ ] PR B — `/me`, `/agents`, `/admin`, `/admin/roadmap` (HEX → tokens + tipografías)
- [ ] PR C — `/owner`, `/owner/buildings/[id]`
- [ ] PR D — Onboarding wizard + conserje
- [ ] PR E — Auditoría final, capturas before/after, cierre deuda #24

NO auto-merge.
