### PR TITLE
Sprint 6 PR B: Migrate /me /agents /admin/roadmap to BaW tokens + typography

### DIFF
--- a/src/app/admin/roadmap/lib/snapshot.ts
+++ b/src/app/admin/roadmap/lib/snapshot.ts
@@ -231,6 +231,24 @@ export const ROADMAP_SNAPSHOT: RoadmapSnapshot = {
   ],
 }
 
+// Tiers → tokens BaW (semántica del roadmap):
+//   t1 MVP        → success (verde)
+//   t2 Core       → info (azul)
+//   t2.5 Agent    → agent (morado)
+//   t3 Backlog    → neutral (gris)
+//   t4 Comercial  → orange
+//   t5 Future     → danger (rojo)
+export const TIER_TOKENS: Record<Tier, { fg: string; bg: string }> = {
+  t1:  { fg: 'var(--baw-success-fg)', bg: 'var(--baw-success-bg-soft)' },
+  t2:  { fg: 'var(--baw-info-fg)',    bg: 'var(--baw-info-bg-soft)' },
+  t25: { fg: 'var(--baw-agent-fg)',   bg: 'var(--baw-agent-bg-soft)' },
+  t3:  { fg: 'var(--baw-neutral-fg)', bg: 'var(--baw-neutral-bg-soft)' },
+  t4:  { fg: 'var(--baw-orange-fg)',  bg: 'var(--baw-orange-bg-soft)' },
+  t5:  { fg: 'var(--baw-danger-fg)',  bg: 'var(--baw-danger-bg-soft)' },
+}
+
+// @deprecated — mantener temporalmente por si algún import externo lo usa.
+// Eliminar tras Sprint 6 PR E.
 export const TIER_COLORS: Record<Tier, string> = {
   t1: '#10b981',
   t2: '#3b82f6',

--- a/src/app/admin/roadmap/page.tsx
+++ b/src/app/admin/roadmap/page.tsx
@@ -5,29 +5,24 @@
 
 import { redirect } from 'next/navigation'
 import { isPlatformAdmin } from '@/lib/platform-admin'
-import { ROADMAP_SNAPSHOT, TIER_COLORS, type Tier, type Status } from './lib/snapshot'
+import { ROADMAP_SNAPSHOT, TIER_TOKENS, type Tier, type Status } from './lib/snapshot'
 
 export const dynamic = 'force-dynamic'
 
 const STATUS_BG: Record<SprintStatusKey, string> = {
-  done: 'rgba(16,185,129,0.12)',
-  next: 'rgba(245,158,11,0.12)',
-  future: 'rgba(107,114,128,0.12)',
+  done: 'var(--baw-success-bg-soft)',
+  next: 'var(--baw-warning-bg-soft)',
+  future: 'var(--baw-neutral-bg-soft)',
 }
 const STATUS_FG: Record<SprintStatusKey, string> = {
-  done: '#10b981',
-  next: '#f59e0b',
-  future: '#6b7280',
+  done: 'var(--baw-success-fg)',
+  next: 'var(--baw-warning-fg)',
+  future: 'var(--baw-neutral-fg)',
 }
 type SprintStatusKey = 'done' | 'next' | 'future'
 
 function tierStyle(tier: Tier) {
-  const c = TIER_COLORS[tier]
-  // Hex → rgba con alpha 0.15 sin depender de helpers
-  const r = parseInt(c.slice(1, 3), 16)
-  const g = parseInt(c.slice(3, 5), 16)
-  const b = parseInt(c.slice(5, 7), 16)
-  return { bg: `rgba(${r},${g},${b},0.15)`, fg: c }
+  return TIER_TOKENS[tier]
 }
 
 function ProgressBar({
@@ -44,10 +39,10 @@ function ProgressBar({
         border: '1px solid var(--baw-border)',
       }}
     >
-      <div style={{ width: pct(done), backgroundColor: '#10b981' }} />
-      <div style={{ width: pct(doing), backgroundColor: '#f59e0b' }} />
-      <div style={{ width: pct(backlog), backgroundColor: '#6b7280' }} />
-      <div style={{ width: pct(discarded), backgroundColor: '#ef4444', opacity: 0.4 }} />
+      <div style={{ width: pct(done), backgroundColor: 'var(--baw-success-fg)' }} />
+      <div style={{ width: pct(doing), backgroundColor: 'var(--baw-warning-fg)' }} />
+      <div style={{ width: pct(backlog), backgroundColor: 'var(--baw-neutral-fg)' }} />
+      <div style={{ width: pct(discarded), backgroundColor: 'var(--baw-danger-fg)', opacity: 0.4 }} />
     </div>
   )
 }
@@ -65,12 +60,15 @@ export default async function RoadmapPage() {
       {/* Header */}
       <div>
         <h1
-          className="text-[24px] font-semibold mb-1 tracking-tight"
-          style={{ color: 'var(--baw-text)' }}
+          className="text-[28px] mb-1 tracking-tight"
+          style={{ color: 'var(--baw-text)', fontFamily: 'var(--font-display)' }}
         >
           BaW OS — Roadmap visual
         </h1>
-        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
+        <p
+          className="text-[11px] uppercase tracking-wider"
+          style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
+        >
           {snap.asOf} · v1 snapshot · v2 leerá Notion + GitHub en vivo
         </p>
       </div>
@@ -79,9 +77,9 @@ export default async function RoadmapPage() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         {[
           { num: t.total, label: 'Features totales', color: 'var(--baw-text)' },
-          { num: t.done, label: `Done · ${donePct}%`, color: '#10b981' },
-          { num: t.doing, label: 'En desarrollo', color: '#f59e0b' },
-          { num: t.backlog, label: 'Backlog', color: '#6b7280' },
+          { num: t.done, label: `Done · ${donePct}%`, color: 'var(--baw-success-fg)' },
+          { num: t.doing, label: 'En desarrollo', color: 'var(--baw-warning-fg)' },
+          { num: t.backlog, label: 'Backlog', color: 'var(--baw-neutral-fg)' },
         ].map((s, i) => (
           <div
             key={i}
@@ -91,12 +89,15 @@ export default async function RoadmapPage() {
               border: '1px solid var(--baw-border)',
             }}
           >
-            <div className="text-[26px] font-bold tabular-nums" style={{ color: s.color }}>
+            <div
+              className="text-[28px] font-semibold tabular-nums"
+              style={{ color: s.color, fontFamily: 'var(--font-mono)' }}
+            >
               {s.num}
             </div>
             <div
-              className="text-[11px] uppercase tracking-wider mt-1"
-              style={{ color: 'var(--baw-muted)' }}
+              className="text-[10px] uppercase tracking-wider mt-1"
+              style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
             >
               {s.label}
             </div>
@@ -108,10 +109,10 @@ export default async function RoadmapPage() {
       <div>
         <ProgressBar done={t.done} doing={t.doing} backlog={t.backlog} discarded={t.discarded} />
         <div className="flex flex-wrap gap-4 mt-2 text-[12px]" style={{ color: 'var(--baw-muted)' }}>
-          <span><span style={{ color: '#10b981' }}>●</span> Done · {t.done}</span>
-          <span><span style={{ color: '#f59e0b' }}>●</span> En desarrollo · {t.doing}</span>
-          <span><span style={{ color: '#6b7280' }}>●</span> Backlog · {t.backlog}</span>
-          <span><span style={{ color: '#ef4444', opacity: 0.6 }}>●</span> Descartado · {t.discarded}</span>
+          <span><span style={{ color: 'var(--baw-success-fg)' }}>●</span> Done · {t.done}</span>
+          <span><span style={{ color: 'var(--baw-warning-fg)' }}>●</span> En desarrollo · {t.doing}</span>
+          <span><span style={{ color: 'var(--baw-neutral-fg)' }}>●</span> Backlog · {t.backlog}</span>
+          <span><span style={{ color: 'var(--baw-danger-fg)', opacity: 0.6 }}>●</span> Descartado · {t.discarded}</span>
         </div>
       </div>
 
@@ -297,7 +298,7 @@ export default async function RoadmapPage() {
                       <span
                         className="absolute left-0"
                         style={{
-                          color: isDone ? '#10b981' : isDoing ? '#f59e0b' : 'var(--baw-muted)',
+                          color: isDone ? 'var(--baw-success-fg)' : isDoing ? 'var(--baw-warning-fg)' : 'var(--baw-muted)',
                         }}
                       >
                         {isDone ? '●' : isDoing ? '◐' : '○'}
@@ -316,11 +317,14 @@ export default async function RoadmapPage() {
       <div
         className="rounded-lg p-5"
         style={{
-          background: 'linear-gradient(135deg, rgba(245,158,11,0.08), rgba(168,85,247,0.05))',
-          border: '1px solid rgba(245,158,11,0.3)',
+          backgroundColor: 'var(--baw-warning-bg-soft)',
+          border: '1px solid var(--baw-warning-border)',
         }}
       >
-        <h3 className="text-[14px] font-semibold mb-3" style={{ color: '#f59e0b' }}>
+        <h3
+          className="text-[14px] font-semibold mb-3"
+          style={{ color: 'var(--baw-warning-fg)', fontFamily: 'var(--font-mono)' }}
+        >
           ⚡ Lo más urgente · candidatos a próximo sprint
         </h3>
         <ol className="ml-5 space-y-2 text-[13px]" style={{ color: 'var(--baw-text)' }}>

--- a/src/app/agents/AgentRunButton.tsx
+++ b/src/app/agents/AgentRunButton.tsx
@@ -57,7 +57,7 @@ export default function AgentRunButton({ agentId, agentName }: Props) {
           disabled={running}
           className="flex-1 text-[11px] px-3 py-1.5 rounded-md font-medium transition-opacity disabled:opacity-50"
           style={{
-            backgroundColor: 'var(--baw-accent, #7c3aed)',
+            backgroundColor: 'var(--baw-agent-fg)',
             color: 'var(--baw-on-primary)',
           }}
         >

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -93,11 +93,11 @@ const FAMILY_ORDER = ['baw-coord', 'ops-core', 'experiencia', 'inteligencia', 't
 
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, { bg: string; fg: string }> = {
-    live: { bg: 'var(--baw-success-bg)', fg: '#22c55e' },
-    beta: { bg: 'rgba(168,85,247,0.12)', fg: '#a855f7' },
-    planned: { bg: 'rgba(148,163,184,0.12)', fg: '#94a3b8' },
-    paused: { bg: 'var(--baw-warning-bg)', fg: 'var(--baw-warning)' },
-    deprecated: { bg: 'var(--baw-danger-bg)', fg: 'var(--baw-danger)' },
+    live: { bg: 'var(--baw-success-bg-soft)', fg: 'var(--baw-success-fg)' },
+    beta: { bg: 'var(--baw-agent-bg-soft)', fg: 'var(--baw-agent-fg)' },
+    planned: { bg: 'var(--baw-neutral-bg-soft)', fg: 'var(--baw-neutral-fg)' },
+    paused: { bg: 'var(--baw-warning-bg-soft)', fg: 'var(--baw-warning-fg)' },
+    deprecated: { bg: 'var(--baw-danger-bg-soft)', fg: 'var(--baw-danger-fg)' },
   }
   const s = styles[status] || styles.planned
   return (
@@ -112,11 +112,11 @@ function StatusBadge({ status }: { status: string }) {
 
 function RunStatusBadge({ status }: { status: string }) {
   const styles: Record<string, { bg: string; fg: string }> = {
-    running: { bg: 'var(--baw-info-bg)', fg: '#3b82f6' },
-    succeeded: { bg: 'var(--baw-success-bg)', fg: '#22c55e' },
-    failed: { bg: 'var(--baw-danger-bg)', fg: 'var(--baw-danger)' },
-    partial: { bg: 'var(--baw-warning-bg)', fg: 'var(--baw-warning)' },
-    canceled: { bg: 'rgba(148,163,184,0.12)', fg: '#94a3b8' },
+    running: { bg: 'var(--baw-info-bg-soft)', fg: 'var(--baw-info-fg)' },
+    succeeded: { bg: 'var(--baw-success-bg-soft)', fg: 'var(--baw-success-fg)' },
+    failed: { bg: 'var(--baw-danger-bg-soft)', fg: 'var(--baw-danger-fg)' },
+    partial: { bg: 'var(--baw-warning-bg-soft)', fg: 'var(--baw-warning-fg)' },
+    canceled: { bg: 'var(--baw-neutral-bg-soft)', fg: 'var(--baw-neutral-fg)' },
   }
   const s = styles[status] || styles.canceled
   return (
@@ -143,13 +143,16 @@ export default async function AgentsPage() {
     <div className="space-y-8">
       <div>
         <h1
-          className="text-[24px] font-semibold mb-1"
-          style={{ color: 'var(--baw-text)' }}
+          className="text-[28px] mb-1 tracking-tight"
+          style={{ color: 'var(--baw-text)', fontFamily: 'var(--font-display)' }}
         >
           Agentes
         </h1>
-        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
-          BaW + 10 especialistas en 3 escuadrones (Operaciones Core · Experiencia · Inteligencia) + Third Party. Roster v0.2. v1: Cobranza dunning.
+        <p
+          className="text-[11px] uppercase tracking-wider"
+          style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
+        >
+          BaW + 10 especialistas en 3 escuadrones · Operaciones Core · Experiencia · Inteligencia · Third Party · Roster v0.2 · v1: Cobranza dunning
         </p>
       </div>
 
@@ -159,8 +162,8 @@ export default async function AgentsPage() {
         <section key={family}>
           <div className="mb-3">
             <h2
-              className="text-[14px] font-semibold uppercase tracking-wider"
-              style={{ color: 'var(--baw-muted)' }}
+              className="text-[12px] font-semibold uppercase tracking-wider"
+              style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
             >
               {FAMILY_LABEL[family] || family}
             </h2>

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -97,13 +97,16 @@ export default async function MePage() {
           L2 · Usuario
         </div>
         <h1
-          className="text-[20px] font-semibold"
-          style={{ color: 'var(--baw-text)' }}
+          className="text-[28px] tracking-tight"
+          style={{ color: 'var(--baw-text)', fontFamily: 'var(--font-display)' }}
         >
           Mi perfil
         </h1>
-        <p className="text-[12px]" style={{ color: 'var(--baw-muted)' }}>
-          Preferencias personales que viajan contigo entre tenants.
+        <p
+          className="text-[11px] uppercase tracking-wider mt-1"
+          style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
+        >
+          Preferencias personales que viajan contigo entre tenants
         </p>
       </div>
 
@@ -169,9 +172,10 @@ export default async function MePage() {
                 <span
                   className="px-1.5 py-0.5 text-[10px] rounded uppercase tracking-wider"
                   style={{
-                    backgroundColor: 'var(--baw-info-bg)',
-                    color: '#93C5FD',
-                    border: '1px solid rgba(59,130,246,0.25)',
+                    backgroundColor: 'var(--baw-info-bg-soft)',
+                    color: 'var(--baw-info-fg)',
+                    border: '1px solid var(--baw-info-border)',
+                    fontFamily: 'var(--font-mono)',
                   }}
                 >
                   {m.role}

--- a/src/components/AgentsList.tsx
+++ b/src/components/AgentsList.tsx
@@ -45,9 +45,9 @@ const ROLE_LABEL: Record<Agent['role'], string> = {
 
 const STATUS_DOT: Record<AgentStatus, { color: string; label: string }> = {
   idle: { color: 'var(--baw-success-fg)', label: 'Activo' },
-  running: { color: '#60a5fa', label: 'Corriendo' },
-  paused: { color: '#fbbf24', label: 'Pausado' },
-  planned: { color: '#52525b', label: 'Planeado' },
+  running: { color: 'var(--baw-info-fg)', label: 'Corriendo' },
+  paused: { color: 'var(--baw-warning-fg)', label: 'Pausado' },
+  planned: { color: 'var(--baw-neutral-fg)', label: 'Planeado' },
 }
 
 interface Props {


### PR DESCRIPTION
## Sprint 6 · PR B — Páginas de alto tráfico migradas a tokens + tipografías BaW

Segunda entrega del rollout visual. Migra páginas que ya están en producción y se ven todos los días.

### Páginas tocadas

- **`/me`** — perfil personal · 2 HEX → tokens
- **`/agents`** — directorio del workforce · 6 HEX → tokens
- **`/admin/roadmap`** — dashboard L0 · 22 HEX → tokens (el peor offender)
- **`AgentsList.tsx`** (componente) · 3 HEX → tokens
- **`AgentRunButton.tsx`** (componente) · 1 HEX (`var(--baw-accent, #7c3aed)`) → `var(--baw-agent-fg)`

### Cambios sustantivos

1. **Mapeo HEX → tokens semánticos:**
   - Verde `#10b981`, `#22c55e` → `--baw-success-{fg,bg-soft}`
   - Ámbar `#f59e0b`, `#fbbf24` → `--baw-warning-{fg,bg-soft}`
   - Azul `#3b82f6`, `#60a5fa`, `#93C5FD` → `--baw-info-{fg,bg-soft,border}`
   - Morado `#a855f7`, `#7c3aed` → `--baw-agent-{fg,bg-soft}`
   - Gris `#6b7280`, `#94a3b8`, `#52525b` → `--baw-neutral-{fg,bg-soft}`
   - Rojo `#ef4444`, `#dc2626` → `--baw-danger-{fg,bg-soft}`

2. **`TIER_TOKENS` nuevo en `snapshot.ts`** — los 6 tiers del roadmap (T1 MVP, T2 Core, T2.5 Agent, T3 Backlog, T4 Comercial, T5 Future) ahora apuntan a tokens en vez de HEX. `TIER_COLORS` se conserva como `@deprecated` para no romper imports externos; se elimina en PR E.

3. **Tipografías aplicadas:**
   - `--font-display` (Instrument Serif) en H1 de `/me`, `/agents`, `/admin/roadmap`
   - `--font-mono` (IBM Plex Mono) en sub-headers, KPIs grandes, badges de estado, labels uppercase
   - Inter sigue como default en body copy

4. **`tierStyle()` simplificado** — antes hacía hex→rgba en runtime con `parseInt`, ahora retorna directamente el par `{fg, bg}` desde `TIER_TOKENS`.

### Validación

- `npx tsc --noEmit` ✅
- 0 HEX hardcoded en las páginas migradas (sólo el export deprecated)
- Funcionalidad intacta: lógica de status, sprints, totales sin cambios

### Roadmap Sprint 6

- [x] PR A — BawMark + Sidebar shell + Mark A canónico (#44 mergeado)
- [x] PR B — `/me`, `/agents`, `/admin/roadmap` (este PR)
- [ ] PR C — `/owner`, `/owner/buildings/[id]`
- [ ] PR D — Onboarding wizard + conserje
- [ ] PR E — Auditoría final, capturas before/after, cierre deuda #24

NO auto-merge.
