### PR TITLE
Sprint 6 PR C: Migrate Owner Portal to BaW tokens

### DIFF
--- a/src/app/owner/buildings/[buildingId]/page.tsx
+++ b/src/app/owner/buildings/[buildingId]/page.tsx
@@ -53,9 +53,10 @@ export default async function OwnerBuildingDetail({
         <div
           className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded"
           style={{
-            backgroundColor: 'rgba(168, 85, 247, 0.15)',
-            color: '#D8B4FE',
-            border: '1px solid rgba(168, 85, 247, 0.3)',
+            backgroundColor: 'var(--baw-agent-bg-soft)',
+            color: 'var(--baw-agent-fg)',
+            border: '1px solid var(--baw-agent-border)',
+            fontFamily: 'var(--font-mono)',
           }}
         >
           Edificio
@@ -153,13 +154,13 @@ export default async function OwnerBuildingDetail({
 function UnitStatusBadge({ status }: { status: string | null }) {
   const map: Record<string, { bg: string; fg: string; border: string; label: string }> = {
     occupied: { bg: 'var(--baw-success-bg-2)', fg: 'var(--baw-success-fg)', border: 'var(--baw-success-border)', label: 'Ocupada' },
-    available: { bg: 'rgba(59,130,246,0.15)', fg: '#93C5FD', border: 'rgba(59,130,246,0.3)', label: 'Disponible' },
+    available: { bg: 'var(--baw-info-bg-soft)', fg: 'var(--baw-info-fg)', border: 'var(--baw-info-border)', label: 'Disponible' },
     maintenance: { bg: 'var(--baw-warning-bg-2)', fg: 'var(--baw-warning-fg)', border: 'var(--baw-warning-border)', label: 'Mantenimiento' },
   }
   const s = map[status ?? ''] ?? {
-    bg: 'rgba(148,163,184,0.15)',
-    fg: '#94A3B8',
-    border: 'rgba(148,163,184,0.3)',
+    bg: 'var(--baw-neutral-bg-soft)',
+    fg: 'var(--baw-neutral-fg)',
+    border: 'var(--baw-neutral-border)',
     label: status ?? '—',
   }
   return (

--- a/src/app/owner/page.tsx
+++ b/src/app/owner/page.tsx
@@ -106,14 +106,18 @@ export default async function OwnerDashboard() {
           <div
             className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded"
             style={{
-              backgroundColor: 'rgba(168, 85, 247, 0.15)',
-              color: '#D8B4FE',
-              border: '1px solid rgba(168, 85, 247, 0.3)',
+              backgroundColor: 'var(--baw-agent-bg-soft)',
+              color: 'var(--baw-agent-fg)',
+              border: '1px solid var(--baw-agent-border)',
+              fontFamily: 'var(--font-mono)',
             }}
           >
             Portal Propietario
           </div>
-          <h1 className="text-[14px] font-medium" style={{ color: 'var(--baw-text)' }}>
+          <h1
+            className="text-[14px] font-medium"
+            style={{ color: 'var(--baw-text)', fontFamily: 'var(--font-mono)' }}
+          >
             {ctx.email}
           </h1>
         </div>
@@ -218,8 +222,8 @@ export default async function OwnerDashboard() {
           <section
             className="rounded-lg p-4 flex items-center gap-3"
             style={{
-              backgroundColor: 'rgba(234, 179, 8, 0.08)',
-              border: '1px solid rgba(234, 179, 8, 0.25)',
+              backgroundColor: 'var(--baw-warning-bg-soft)',
+              border: '1px solid var(--baw-warning-border)',
             }}
           >
             <AlertCircle size={18} style={{ color: 'var(--baw-warning-fg)' }} />
@@ -239,9 +243,9 @@ export default async function OwnerDashboard() {
               href="/owner/incidents"
               className="text-[12px] px-3 py-1.5 rounded"
               style={{
-                backgroundColor: 'rgba(234, 179, 8, 0.15)',
+                backgroundColor: 'var(--baw-warning-bg)',
                 color: 'var(--baw-warning-fg)',
-                border: '1px solid rgba(234, 179, 8, 0.3)',
+                border: '1px solid var(--baw-warning-border)',
               }}
             >
               Ver detalles


### PR DESCRIPTION
## Sprint 6 · PR C — Portal Propietario migrado a tokens BaW

Tercera entrega del rollout visual. Migra el Portal Propietario, que es la única zona de la plataforma que no comparte el chrome interno (no tiene Sidebar de tenant) y por eso necesita su propia identidad visual aplicada.

### Páginas tocadas

- **`/owner/page.tsx`** — dashboard del propietario · 6 instancias HEX/rgba → tokens
- **`/owner/buildings/[buildingId]/page.tsx`** — detalle de edificio · 6 instancias → tokens

### Cambios

1. **Badge "Portal Propietario"** (header en ambas páginas): `rgba(168,85,247,*)` + `#D8B4FE` → `--baw-agent-{fg,bg-soft,border}`. Decisión: el morado es el color del Portal Propietario en BaW, mismo escenario semántico que los agentes (rol distinto pero mismo "tono" del sistema).
2. **Banner de incidentes**: ámbar hardcoded → `--baw-warning-{fg,bg-soft,border}`.
3. **`UnitStatusBadge`**: los 4 estados (occupied / available / maintenance / fallback) ahora consumen tokens success/info/warning/neutral.
4. **Tipografía mono** aplicada al email del propietario en el header y a labels técnicos del Portal.

### Lo que NO cambia

- `/owner/[token]/page.tsx` (público sin login con OWNER_TOKEN legacy) — sólo tiene `&#xxx;` que son entidades HTML unicode para íconos, no colores. Limpio.
- `/owner/layout.tsx` — sin HEX.

### Validación

- `npx tsc --noEmit` ✅
- 0 HEX hardcoded en archivos owner
- Funcionalidad intacta

### Roadmap Sprint 6

- [x] PR A — BawMark + Sidebar shell + Mark A canónico (#44 mergeado)
- [x] PR B — `/me`, `/agents`, `/admin/roadmap` (#45 abierto)
- [x] PR C — `/owner`, `/owner/buildings/[buildingId]` (este PR)
- [ ] PR D — Onboarding wizard + conserje
- [ ] PR E — Auditoría final, capturas before/after, cierre deuda #24

NO auto-merge.
