### PR TITLE
Sprint 6 PR D: Migrate onboarding wizard to BaW tokens

### DIFF
--- a/src/app/onboarding/WizardFirstRun.tsx
+++ b/src/app/onboarding/WizardFirstRun.tsx
@@ -369,7 +369,10 @@ export default function WizardFirstRun() {
       <div className="max-w-3xl mx-auto">
         {/* Header */}
         <header className="mb-8 text-center">
-          <h1 className="text-[28px] font-semibold tracking-tight">
+          <h1
+            className="text-[32px] tracking-tight"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
             Bienvenido a BaW OS
           </h1>
           <p className="muted-text text-[14px] mt-2">
@@ -386,9 +389,9 @@ export default function WizardFirstRun() {
           <div
             className="mt-6 px-4 py-3 rounded-md flex items-start gap-2 text-[13px]"
             style={{
-              backgroundColor: 'rgba(248, 113, 113, 0.08)',
-              border: '1px solid rgba(248, 113, 113, 0.3)',
-              color: '#fca5a5',
+              backgroundColor: 'var(--baw-danger-bg-soft)',
+              border: '1px solid var(--baw-danger-border)',
+              color: 'var(--baw-danger-fg)',
             }}
           >
             <AlertTriangle size={16} className="mt-0.5 flex-shrink-0" />
@@ -585,7 +588,7 @@ function StepPMCompany({
       <p
         className="text-[12px] px-3 py-2 rounded-md"
         style={{
-          backgroundColor: 'rgba(59, 130, 246, 0.08)',
+          backgroundColor: 'var(--baw-info-bg-soft)',
           color: 'var(--baw-muted)',
         }}
       >
@@ -979,7 +982,7 @@ function StepOwner({
               className="text-left rounded-md p-4 transition"
               style={{
                 backgroundColor: active
-                  ? 'rgba(59, 130, 246, 0.08)'
+                  ? 'var(--baw-info-bg-soft)'
                   : 'var(--baw-bg)',
                 border: active
                   ? '1px solid var(--baw-primary)'
@@ -1015,7 +1018,7 @@ function StepOwner({
         <div
           className="text-[12px] px-3 py-2 rounded-md"
           style={{
-            backgroundColor: 'rgba(74, 222, 128, 0.08)',
+            backgroundColor: 'var(--baw-success-bg-soft)',
             color: 'var(--baw-muted)',
           }}
         >

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -112,11 +112,17 @@ export default function OnboardingPage() {
     <div className="max-w-4xl mx-auto space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+        <h1
+          className="text-[28px] tracking-tight"
+          style={{ color: 'var(--baw-text)', fontFamily: 'var(--font-display)' }}
+        >
           Configurar cuenta
         </h1>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Administra tu PM Company, agrega activos y gestiona el equipo desde un solo lugar.
+        <p
+          className="mt-1 text-[11px] uppercase tracking-wider"
+          style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
+        >
+          Administra tu PM Company · agrega activos · gestiona el equipo
         </p>
       </div>
 
@@ -255,8 +261,9 @@ export default function OnboardingPage() {
             className="text-[10px] uppercase tracking-wider font-semibold px-2 py-1 rounded shrink-0"
             style={{
               backgroundColor: 'var(--baw-warning-bg-soft)',
-              color: 'var(--baw-warning)',
-              border: '1px solid rgba(245, 158, 11, 0.25)',
+              color: 'var(--baw-warning-fg)',
+              border: '1px solid var(--baw-warning-border)',
+              fontFamily: 'var(--font-mono)',
             }}
           >
             Próximamente
@@ -320,8 +327,9 @@ export default function OnboardingPage() {
             className="text-[10px] uppercase tracking-wider font-semibold px-2 py-1 rounded shrink-0"
             style={{
               backgroundColor: 'var(--baw-warning-bg-soft)',
-              color: 'var(--baw-warning)',
-              border: '1px solid rgba(245, 158, 11, 0.25)',
+              color: 'var(--baw-warning-fg)',
+              border: '1px solid var(--baw-warning-border)',
+              fontFamily: 'var(--font-mono)',
             }}
           >
             Próximamente


### PR DESCRIPTION
## Sprint 6 · PR D — Onboarding wizard migrado a tokens BaW

Cuarta entrega del rollout visual. Migra el wizard de onboarding (primer experiencia del usuario al crear su PM Company).

### Archivos tocados

- **`src/app/onboarding/page.tsx`** — landing del onboarding · 2 instancias
- **`src/app/onboarding/WizardFirstRun.tsx`** — wizard de 4 pasos · 6 instancias

### Cambios

1. **Banner de error** del wizard (rojo): `rgba(248,113,113,*)` + `#fca5a5` → `--baw-danger-{fg,bg-soft,border}`
2. **Hint boxes informativos** (azul claro): `rgba(59,130,246,0.08)` → `--baw-info-bg-soft`
3. **Hint box de éxito** ("Property Owner self"): `rgba(74,222,128,0.08)` → `--baw-success-bg-soft`
4. **Botón modo activo** (selector "¿De quién es este edificio?"): rgba(59,130,246,*) → `--baw-info-bg-soft`
5. **Badge "Próximamente"** (2x): `rgba(245,158,11,0.25)` border → `--baw-warning-border`, color → `--baw-warning-fg` con `--font-mono`
6. **H1 "Configurar cuenta"** y **H1 "Bienvenido a BaW OS"** del wizard ahora usan `--font-display` (Instrument Serif) a 28-32px tracking-tight, alineado con el resto de páginas del rollout
7. **Subtítulo** del onboarding ahora usa `--font-mono` uppercase tracking-wider para consistencia con `/me`, `/agents`, `/admin/roadmap`

### Lo que NO toco aquí

- `text-gray-*`, `text-indigo-*` y otras clases Tailwind genéricas en onboarding/page.tsx (líneas 128-139, sección "Estado de la cuenta") — son deuda de tokens más amplia que rebasa el alcance de este PR. Se documenta y se aborda en un sprint posterior.
- Conserje (`/[orgSlug]/conserje/page.tsx`) — **0 HEX**, ya estaba limpio desde PR #38 (dark mode). No requiere cambios en este PR.
- `(public)/conserje/page.tsx` — solo es un redirect a `/baw-operations/conserje`, sin UI.

### Validación

- `npx tsc --noEmit` ✅
- 0 HEX hardcoded en archivos onboarding tocados
- Funcionalidad intacta: lógica de pasos, validación, submit

### Roadmap Sprint 6

- [x] PR A — BawMark + Sidebar shell + Mark A canónico (#44 mergeado)
- [x] PR B — `/me`, `/agents`, `/admin/roadmap` (#45 abierto)
- [x] PR C — `/owner`, `/owner/buildings/[buildingId]` (#46 abierto)
- [x] PR D — Onboarding wizard (este PR)
- [ ] PR E — Auditoría final, capturas before/after, cierre deuda #24

NO auto-merge.
