### PR TITLE
Sprint 6 followups: BawGrid en AppShell + fix /settings loading + bulk visible en Configurar cuenta

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,6 +115,12 @@ html.dark {
   --baw-sidebar-bg:     #0F0F12;
   --baw-sidebar-border: #2A2A32;
   --baw-on-primary:     #FFFFFF;
+
+  /* BawGrid (retícula 32×32 en login + AppShell). Opacity por tema:
+     en dark, --baw-text es claro contra fondo oscuro → 0.045 alcanza.
+     En light se override más abajo (--baw-text es oscuro contra fondo
+     blanco, necesita más densidad para ser perceptible sin ruido). */
+  --baw-grid-opacity: 0.045;
 }
 
 /* ── Modo light ─────────────────────────────────────────────────────── */
@@ -146,6 +152,9 @@ html.light {
   --baw-text:         var(--text);
   --baw-muted:        var(--text-2);
   --baw-faint:        var(--text-3);
+  /* En light mode --baw-text es oscuro: contra fondo blanco la retícula
+     necesita más opacity para ser perceptible sin invadir. */
+  --baw-grid-opacity: 0.07;
 }
 
 /* Sidebar mantiene su chrome oscuro independiente del tema de la app:

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import BawGrid from '@/components/BawGrid'
 
 // Sprint 4 / S4-2: useSearchParams requiere Suspense boundary en Next.js 14
 export default function LoginPage() {
@@ -76,17 +77,10 @@ function LoginForm() {
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-[--baw-bg]">
-      {/* Subtle grid background — comunica precisión técnica de la marca */}
-      <div
-        aria-hidden
-        className="absolute inset-0 opacity-[0.035] pointer-events-none"
-        style={{
-          backgroundImage:
-            'linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)',
-          backgroundSize: '32px 32px',
-          color: 'var(--baw-text)',
-        }}
-      />
+      {/* Subtle grid background — comunica precisión técnica de la marca.
+          Sprint 6 followup: migrado al componente reutilizable BawGrid para
+          que /login y AppShell usen exactamente la misma retícula. */}
+      <BawGrid position="absolute" />
 
       <div className="relative w-full max-w-sm mx-auto px-6">
         {/* Mark + wordmark */}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -188,9 +188,26 @@ export default function OnboardingPage() {
 
       {/* Atajos para agregar */}
       <section>
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-          Agregar nuevos activos
-        </h3>
+        <div className="flex items-baseline justify-between mb-3 gap-3">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+            Agregar nuevos activos
+          </h3>
+          {/*
+            Sprint 6 followup: link "Importar masivo" también en el header,
+            además de la card destacada abajo. Para PM Pros con cientos de
+            unidades, agregar uno a uno es un pain — el bulk debe estar
+            visible desde el primer scroll. Antes solo vivía al final como
+            sección separada "Importar datos".
+          */}
+          <Link
+            href="/onboarding/bulk"
+            className="inline-flex items-center gap-1 text-xs font-medium hover:underline"
+            style={{ color: 'var(--baw-primary)' }}
+          >
+            <Upload className="w-3 h-3" />
+            Importar masivo (CSV)
+          </Link>
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <ShortcutCard
             icon={Building2}
@@ -219,17 +236,55 @@ export default function OnboardingPage() {
         </div>
       </section>
 
-      {/* Importar / Bulk */}
+      {/* Importar / Bulk — card destacada para PM Pros
+          Sprint 6 followup: el wizard de onboarding inicial ya soporta bulk,
+          pero "Configurar cuenta" (post-onboarding) solo permitía 1-a-1, lo
+          cual es un pain para Professional PMs con grandes portafolios.
+          Card de ancho completo + bg destacado para subrayar la opción. */}
       <section>
         <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-          Importar datos
+          Importar masivamente
         </h3>
-        <ShortcutCard
-          icon={Upload}
-          title="Importar unidades desde CSV"
-          description="Carga masiva de unidades, ocupantes y contratos vigentes."
+        <Link
           href="/onboarding/bulk"
-        />
+          className="card p-5 flex items-start justify-between gap-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+          style={{
+            backgroundColor: 'var(--baw-agent-bg-soft)',
+            borderColor: 'var(--baw-agent-border-soft)',
+          }}
+        >
+          <div className="flex items-start gap-3 min-w-0">
+            <div
+              className="flex items-center justify-center w-10 h-10 rounded-md shrink-0"
+              style={{
+                backgroundColor: 'var(--baw-agent-bg)',
+                color: 'var(--baw-primary)',
+              }}
+            >
+              <Upload className="w-5 h-5" />
+            </div>
+            <div className="min-w-0">
+              <div className="text-sm font-semibold text-gray-900 dark:text-white">
+                Importar unidades, propietarios y contratos desde CSV
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Carga masiva con preview, validación por columna y assignment
+                a edificio existente. Recomendado para portafolios con 10+ unidades.
+              </div>
+            </div>
+          </div>
+          <span
+            className="text-[10px] uppercase tracking-wider font-semibold px-2 py-1 rounded shrink-0 self-start"
+            style={{
+              backgroundColor: 'var(--baw-agent-bg)',
+              color: 'var(--baw-agent-fg)',
+              border: '1px solid var(--baw-agent-border)',
+              fontFamily: 'var(--font-mono)',
+            }}
+          >
+            Bulk
+          </span>
+        </Link>
       </section>
 
       {/* Equipo */}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -23,26 +23,45 @@ export default function SettingsPage() {
 
   async function load(activeOrgId: string) {
     setLoading(true)
-    const { data: sessionData } = await supabase.auth.getSession()
-    const sessionUser = sessionData.session?.user || null
-    setUserId(sessionUser?.id || null)
+    try {
+      const { data: sessionData } = await supabase.auth.getSession()
+      const sessionUser = sessionData.session?.user || null
+      setUserId(sessionUser?.id || null)
 
-    const [profileRes, orgRes, membersRes] = await Promise.all([
-      sessionUser?.id ? supabase.from('user_profiles').select('*').eq('id', sessionUser.id).maybeSingle() : Promise.resolve({ data: null }),
-      supabase.from('organizations').select('*').eq('id', activeOrgId).single(),
-      supabase.from('org_members').select('*').eq('org_id', activeOrgId).order('created_at'),
-    ])
+      // Sprint 6 followup fix: usar .maybeSingle() en lugar de .single() para
+      // organizations — si por alguna razón el row no existe (org id stale,
+      // RLS niega, etc.) `.single()` rechaza con PGRST116 y deja al usuario
+      // atorado en "Cargando configuración…" para siempre. Con maybeSingle
+      // recibimos `{data: null}` y caemos a la rama vacía en línea de abajo.
+      //
+      // Además envolvemos todo en try/finally: aunque supabase-js no rechaza
+      // por errores de query, otras causas (timeout de red, fallo en
+      // getSession, etc.) sí pueden lanzar. Sin esto, setLoading(false) nunca
+      // se ejecuta y el spinner queda eterno (bug pattern conocido en BaW OS).
+      const [profileRes, orgRes, membersRes] = await Promise.all([
+        sessionUser?.id
+          ? supabase.from('user_profiles').select('*').eq('id', sessionUser.id).maybeSingle()
+          : Promise.resolve({ data: null }),
+        supabase.from('organizations').select('*').eq('id', activeOrgId).maybeSingle(),
+        supabase.from('org_members').select('*').eq('org_id', activeOrgId).order('created_at'),
+      ])
 
-    setProfile({
-      id: sessionUser?.id,
-      full_name: profileRes.data?.full_name || sessionUser?.user_metadata?.full_name || '',
-      phone: profileRes.data?.phone || '',
-      job_title: profileRes.data?.job_title || '',
-      avatar_url: profileRes.data?.avatar_url || '',
-    })
-    setOrganization(orgRes.data || {})
-    setMembers((membersRes.data || []) as OrgMember[])
-    setLoading(false)
+      setProfile({
+        id: sessionUser?.id,
+        full_name: profileRes.data?.full_name || sessionUser?.user_metadata?.full_name || '',
+        phone: profileRes.data?.phone || '',
+        job_title: profileRes.data?.job_title || '',
+        avatar_url: profileRes.data?.avatar_url || '',
+      })
+      setOrganization(orgRes.data || {})
+      setMembers((membersRes.data || []) as OrgMember[])
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Settings: error cargando configuración', err)
+      setMessage(err instanceof Error ? `Error: ${err.message}` : 'Error cargando configuración')
+    } finally {
+      setLoading(false)
+    }
   }
 
   useEffect(() => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -11,6 +11,7 @@ import ProfileMenu from '@/components/ProfileMenu'
 import ThemeProvider from '@/components/ThemeProvider'
 import { ToastProvider } from '@/components/Toast'
 import ContractAlertsBanner from '@/components/ContractAlertsBanner'
+import BawGrid from '@/components/BawGrid'
 import { findSection } from '@/lib/navigation'
 
 // Sprint 4 / S4-0 + S4-1.5: estos prefijos son rutas públicas con su propio
@@ -197,6 +198,13 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     <ThemeProvider>
       <ToastProvider>
         <AuthGuard>
+          {/*
+            Sprint 6 followup: retícula BaW homologada a TODA la plataforma.
+            Antes solo se veía en /login. Va `fixed` al viewport detrás de
+            todo (z=0, pointer-events-none) y opacity theme-aware via CSS
+            var --baw-grid-opacity (0.045 dark / 0.07 light).
+          */}
+          <BawGrid position="fixed" />
           <Sidebar />
           {/*
             Sprint 3 / S7: el `paddingLeft` del main lee el CSS var
@@ -212,8 +220,15 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             así que el contenido debe ocupar 100% del ancho. La var
             `--sidebar-effective-width` se aplica solo desde `md`.
           */}
+          {/*
+            Sprint 6 followup: `relative` + bg transparente en `<main>` para
+            que la BawGrid (fixed inset-0 z-0) sea visible a través del
+            contenido. Cards, header sticky y banners conservan sus bg
+            opacos en sus propias capas; solo el wrapper del shell deja
+            pasar la retícula del body.
+          */}
           <main
-            className="min-h-screen md:transition-[padding] md:duration-200 md:[padding-left:var(--sidebar-effective-width,0px)]"
+            className="relative min-h-screen md:transition-[padding] md:duration-200 md:[padding-left:var(--sidebar-effective-width,0px)]"
           >
             <GlobalHeader pathname={pathname} />
             <SectionTopNav />

--- a/src/components/BawGrid.tsx
+++ b/src/components/BawGrid.tsx
@@ -1,0 +1,48 @@
+// BaW OS — Retícula 32×32 (Sprint 6 / fix sprint6-followups)
+//
+// Background pattern distintivo de la marca: refuerza la voz "precisión técnica"
+// que ya está presente en /login. Acuerdo Sprint 6: la retícula debe verse en
+// TODAS las pantallas autenticadas como elemento de continuidad visual.
+//
+// Implementación:
+//   - Position: `fixed inset-0` por defecto (queda anclado al viewport, no
+//     hace scroll con el contenido). Pasar `absolute` para layouts que lo
+//     necesiten (ej. /login que vive dentro de un overlay z-[100]).
+//   - z-index 0 + pointer-events-none → nunca bloquea interacción.
+//   - currentColor + opacity vía CSS var `--baw-grid-opacity` (0.045 dark,
+//     0.06 light, ver globals.css). Usa `var(--baw-text)` como tinta para
+//     que herede del tema activo.
+//   - Para que sea visible, el contenedor padre NO debe tener un background
+//     opaco encima. El AppShell debe usar `bg-transparent` en el `<main>`.
+
+interface BawGridProps {
+  /** Layout strategy. `fixed` para shell global, `absolute` para overlays. */
+  position?: 'fixed' | 'absolute'
+  /** Override opacity. Si no se pasa, usa --baw-grid-opacity (theme-aware). */
+  opacity?: number
+  /** Tamaño de celda en px. Default 32. */
+  cellSize?: number
+  className?: string
+}
+
+export default function BawGrid({
+  position = 'fixed',
+  opacity,
+  cellSize = 32,
+  className = '',
+}: BawGridProps) {
+  return (
+    <div
+      aria-hidden
+      className={`${position} inset-0 pointer-events-none ${className}`}
+      style={{
+        backgroundImage:
+          'linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)',
+        backgroundSize: `${cellSize}px ${cellSize}px`,
+        color: 'var(--baw-text)',
+        opacity: opacity ?? 'var(--baw-grid-opacity, 0.045)' as unknown as number,
+        zIndex: 0,
+      }}
+    />
+  )
+}


### PR DESCRIPTION
## Sprint 6 followups — 3 observaciones de QA del usuario

Tras mergear los 5 PRs del visual rollout, el usuario reportó 3 observaciones probando la plataforma. Este PR las cierra todas.

### (a) Bug: `/settings` atorado en "Cargando configuración…"

**Causa raíz:** `Promise.all([...])` con `supabase.from('organizations').single()`. Si el row no existe o RLS niega, `.single()` rechaza con `PGRST116` → `Promise.all` rechaza → como NO había try/catch, `setLoading(false)` nunca se ejecuta → spinner eterno.

**Fix:**
- `.single()` → `.maybeSingle()` en organizations (pattern conocido — supabase-js NO rechaza por row vacío con maybeSingle).
- `try/finally` envolviendo todo `load()` para garantizar `setLoading(false)` aunque algo lance.
- Catch que muestra mensaje de error en UI en lugar de quedarse colgado.

### (b) Falta bulk add en "Configurar cuenta" (`/onboarding` post-onboardeado)

**Contexto:** El wizard de first-run sí permite bulk via `/onboarding/bulk`, pero después de onboardearse, el page de "Configurar cuenta" enterraba el bulk como sección secundaria al final ("Importar datos") con texto pequeño. Pain real para PM Pros con 50-500 unidades.

**Fix (sin código nuevo, solo UX):**
- Link "Importar masivo (CSV)" en el header de la sección "Agregar nuevos activos" — visible al primer scroll.
- La sección "Importar datos" se transformó en card destacada con accent color BaW (`--baw-agent-*`), título más explícito ("Importar unidades, propietarios y contratos desde CSV"), badge "Bulk", icono más grande (10×10 vs 9×9). Recomendación explícita "10+ unidades".
- Apunta a la ruta existente `/onboarding/bulk` (no se duplicó código).

### (c) Retícula BawGrid invisible en dashboard (solo se veía en /login)

**Causa raíz:** El context summary del Sprint 6 reportaba que existía `<BawGrid>` y se aplicaba en AppShell, **pero nunca existió**. El grid solo vivía inline en `/login`. Además los tokens de opacity (0.035) están calibrados para fondo oscuro (login fixed con `bg-[--baw-bg]`); en light mode contra fondo blanco era invisible.

**Fix:**
1. **Creado `src/components/BawGrid.tsx`** — componente reutilizable con prop `position: 'fixed' | 'absolute'`, `cellSize`, `opacity`. Lee `--baw-grid-opacity` para ser theme-aware.
2. **Tokens nuevos en globals.css:**
   - `--baw-grid-opacity: 0.045` (dark — text claro contra bg oscuro)
   - `--baw-grid-opacity: 0.07` en `html.light` (text oscuro contra bg blanco necesita más densidad)
3. **AppShell.tsx:** `<BawGrid position="fixed" />` dentro de AuthGuard, ANTES del Sidebar. `<main>` pasa a `relative` (sin override de `bg`) para que la retícula del body se vea a través del wrapper. Header sticky y cards conservan sus bg opacos.
4. **`/login`:** Reemplazado el `<div>` inline con `<BawGrid position="absolute" />` para que ambos shells usen exactamente la misma retícula (single source of truth).

### Verificación

- `npx tsc --noEmit` → sin errores.
- 0 HEX nuevos hardcoded — todo via tokens existentes.
- Single source of truth: 1 componente, 1 token de opacity por tema.

### Archivos tocados (6, +180 / -40)

| Archivo | Cambio |
|---|---|
| `src/components/BawGrid.tsx` | NEW — componente reutilizable |
| `src/app/globals.css` | +9 — tokens `--baw-grid-opacity` por tema |
| `src/components/AppShell.tsx` | +BawGrid + main relative |
| `src/app/login/page.tsx` | Inline → BawGrid (-10) |
| `src/app/settings/page.tsx` | try/finally + maybeSingle |
| `src/app/onboarding/page.tsx` | Bulk visible + card destacada |

### Manual QA sugerido

- [ ] `/` (Dashboard) y `/me`: la retícula 32×32 se ve sutil en light y dark.
- [ ] `/login`: la retícula sigue viéndose igual (no regresión).
- [ ] `/settings`: carga aunque la org tenga RLS rara o falte (no más spinner eterno).
- [ ] `/onboarding` post-onboardeado: aparece "Importar masivo (CSV)" al lado del título "Agregar nuevos activos" + card destacada al final.

NO auto-merge — esperar revisión manual.
