### PR TITLE
Sprint 6 followups #2: /settings real fix + bulk en /units + login race fix

### DIFF
--- a/src/app/api/me/whoami/route.ts
+++ b/src/app/api/me/whoami/route.ts
@@ -1,0 +1,34 @@
+// BaW OS — /api/me/whoami (Sprint 6 followup #2)
+//
+// Endpoint MÍNIMO que confirma si la cookie de Supabase está viva en el
+// servidor. Lo usa /login después de signIn + sync-session para garantizar
+// que la cookie ya fue commiteada antes de navegar a una ruta protegida
+// (ej. /admin). Sin esto había race condition: el browser podía hacer
+// window.location.href = '/admin' antes de procesar el Set-Cookie del
+// sync-session response → server ve getUser()===null → redirect a /login
+// → loop infinito.
+//
+// Distinto de /api/admin/whoami: NO requiere ser platform admin, NO toca
+// service-role. Solo lee la cookie del request.
+
+import { NextResponse } from 'next/server'
+import { createSupabaseServer } from '@/lib/supabase-server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user?.email) {
+    return NextResponse.json({ email: null }, { status: 401 })
+  }
+
+  return NextResponse.json({
+    email: user.email,
+    user_id: user.id,
+  })
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -64,6 +64,47 @@ function LoginForm() {
         setLoading(false)
         return
       }
+
+      // Sprint 6 followup #2 fix: infinite login loop con ?next=/admin.
+      //
+      // Causa raíz: hacíamos `window.location.href = '/admin'` inmediatamente
+      // tras el sync-session response. El browser no garantiza que el
+      // Set-Cookie del response esté commiteado antes del navigate, sobre
+      // todo cuando hay redirect HTTP en cadena. Si la cookie aún no está
+      // sincronizada al GET /admin, el guard server-side ve `getUser()===null`
+      // y redirige a /login?next=/admin → el form ve session en localStorage
+      // y vuelve a redirigir → loop infinito.
+      //
+      // Fix: hacer un round-trip server explícito (`/api/me`) para CONFIRMAR
+      // que la cookie está viva antes de navegar. Si la cookie aún no
+      // commitea, retry hasta 3 veces con backoff. Si tras eso falla,
+      // mostramos error claro — no entramos al loop.
+      let cookieReady = false
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          const probe = await fetch('/api/me/whoami', {
+            credentials: 'include',
+            cache: 'no-store',
+          })
+          if (probe.ok) {
+            const j = await probe.json().catch(() => ({}))
+            if (j?.email) {
+              cookieReady = true
+              break
+            }
+          }
+        } catch {
+          // network blip; retry
+        }
+        await new Promise((r) => setTimeout(r, 150))
+      }
+      if (!cookieReady) {
+        setError(
+          'No se pudo establecer la sesión. Intenta una vez más o recarga la página.',
+        )
+        setLoading(false)
+        return
+      }
     }
 
     // Full reload so middleware and Server Components pick up the session cookie.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -64,9 +64,25 @@ export default function SettingsPage() {
     }
   }
 
+  // Sprint 6 followup #2 fix: el bug real de "Cargando configuración…" no era
+  // Promise.all rechazando — era que `useOrgContext` puede resolverse con
+  // `orgId === null` (sin org activa, /api/me/org devolvió 401/403, o el
+  // usuario no tiene memberships todavía). En ese caso `load()` JAMÁS se
+  // llamaba, `loading` quedaba en su default `true` para siempre, y el
+  // spinner se quedaba eterno aunque `orgLoading` ya hubiera terminado.
+  //
+  // Fix: cuando orgLoading termina, decidimos:
+  //   - hay orgId  → load(orgId) (igual que antes)
+  //   - no hay orgId → setLoading(false) para que renderice el mensaje
+  //     vacío de la línea ~135 en lugar del spinner.
   useEffect(() => {
-    if (orgId) load(orgId)
-  }, [orgId])
+    if (orgLoading) return
+    if (orgId) {
+      load(orgId)
+    } else {
+      setLoading(false)
+    }
+  }, [orgLoading, orgId])
 
   async function saveProfile() {
     if (!userId) return
@@ -136,7 +152,27 @@ export default function SettingsPage() {
   ] as const), [])
 
   if (orgLoading || loading) return <div className="text-sm page-subtitle">Cargando configuración…</div>
-  if (!orgId) return <div className="text-sm page-subtitle">No hay organización activa. Inicia sesión o completa el onboarding.</div>
+  if (!orgId) {
+    return (
+      <div className="max-w-2xl space-y-3">
+        <h1 className="text-2xl font-bold page-title">Configuración</h1>
+        <div className="card p-5 space-y-2">
+          <p className="text-sm page-subtitle">
+            No encontramos una organización activa para tu cuenta.
+          </p>
+          <p className="text-xs page-subtitle">
+            Esto suele pasar si tu sesión expiró o si todavía no completaste
+            el onboarding inicial. Intenta cerrar sesión y entrar de nuevo,
+            o configura tu cuenta desde el wizard.
+          </p>
+          <div className="flex gap-2 pt-2">
+            <a href="/onboarding" className="btn-primary text-xs">Configurar cuenta</a>
+            <a href="/login" className="btn-secondary text-xs">Cerrar sesión</a>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6 max-w-5xl">

--- a/src/app/units/BulkUnitsModal.tsx
+++ b/src/app/units/BulkUnitsModal.tsx
@@ -1,0 +1,440 @@
+'use client'
+
+// BaW OS — Bulk Units Modal (Sprint 6 followup #2)
+//
+// Permite generar varias unidades a la vez usando el mismo patrón que el
+// wizard de onboarding (`WizardFirstRun.tsx`): Cantidad / Prefijo /
+// Empezar en / Tipo. El piso se infiere del número siguiendo la convención
+// inmobiliaria estándar (101→piso 1, 205→piso 2, 1003→piso 10).
+//
+// Diferencias con el wizard:
+//   - Aquí ya hay un edificio activo (se recibe `buildingId` por prop).
+//   - El usuario puede iterar varios bulks (101–104, 201–204, 301–304) antes
+//     de confirmar; la lista crece con append + dedupe por `number`.
+//   - Al confirmar, hace una sola llamada `insert([...])` para minimizar
+//     round-trips a Supabase.
+//
+// NO toca el flujo de "Nueva unidad" individual (UnitModal sigue igual).
+
+import { useMemo, useState } from 'react'
+import { Plus, Trash2, X, Loader2 } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import type { UnitType } from '@/types'
+
+interface BulkUnitsModalProps {
+  orgId: string
+  buildingId: string | null
+  buildingName: string | null
+  onClose: () => void
+  onSuccess: (insertedCount: number) => void
+}
+
+interface UnitRow {
+  number: string
+  type: UnitType
+  floor: number
+}
+
+interface BulkConfig {
+  count: string
+  prefix: string
+  startNumber: string
+  type: UnitType
+}
+
+// Misma regla que WizardFirstRun: piso = todos los dígitos excepto los
+// últimos 2 (101→1, 205→2, 1003→10). ≤2 dígitos asume piso 1.
+function inferFloor(numberStr: string): number {
+  const digits = numberStr.replace(/[^0-9]/g, '')
+  if (digits.length <= 2) return 1
+  const floorStr = digits.slice(0, -2)
+  const floor = Number(floorStr)
+  return Number.isFinite(floor) && floor > 0 ? floor : 1
+}
+
+export default function BulkUnitsModal({
+  orgId,
+  buildingId,
+  buildingName,
+  onClose,
+  onSuccess,
+}: BulkUnitsModalProps) {
+  const [config, setConfig] = useState<BulkConfig>({
+    count: '4',
+    prefix: '',
+    startNumber: '101',
+    type: 'LTR',
+  })
+  const [units, setUnits] = useState<UnitRow[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function generate() {
+    const rows: UnitRow[] = []
+    const count = Math.max(1, Number(config.count) || 0)
+    const startNumber = Number(config.startNumber) || 101
+    const { prefix, type } = config
+    for (let i = 0; i < count; i++) {
+      const num = `${prefix}${startNumber + i}`
+      rows.push({ number: num, type, floor: inferFloor(num) })
+    }
+    // Append + dedupe por number (las nuevas filas ganan)
+    const byNumber = new Map<string, UnitRow>()
+    for (const u of units) byNumber.set(u.number, u)
+    for (const u of rows) byNumber.set(u.number, u)
+    setUnits(Array.from(byNumber.values()))
+
+    // Auto-sugerir el siguiente piso para el próximo bulk
+    setConfig({ ...config, startNumber: String(startNumber + 100) })
+  }
+
+  function addRow() {
+    setUnits([...units, { number: '', type: 'LTR', floor: 1 }])
+  }
+
+  function removeRow(idx: number) {
+    setUnits(units.filter((_, i) => i !== idx))
+  }
+
+  function updateRow(idx: number, field: keyof UnitRow, value: string | number) {
+    const copy = [...units]
+    copy[idx] = { ...copy[idx], [field]: value as never }
+    setUnits(copy)
+  }
+
+  const validRows = useMemo(
+    () => units.filter((u) => u.number.trim().length > 0),
+    [units],
+  )
+
+  async function handleSubmit() {
+    if (validRows.length === 0) {
+      setError('Genera o agrega al menos una unidad antes de guardar.')
+      return
+    }
+    if (!buildingId) {
+      setError('Selecciona un edificio activo antes de generar unidades en bulk.')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const payload = validRows.map((u) => ({
+        org_id: orgId,
+        building_id: buildingId,
+        number: u.number.trim(),
+        type: u.type,
+        floor: Number(u.floor) || 1,
+        status: 'available' as const,
+      }))
+      const { error: insertError, data } = await supabase
+        .from('units')
+        .insert(payload)
+        .select('id')
+      if (insertError) {
+        // Conflict típico: violación de unique (org_id, building_id, number)
+        // si el usuario re-intenta crear una unidad ya existente.
+        throw new Error(insertError.message)
+      }
+      onSuccess(data?.length ?? validRows.length)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'No se pudieron crear las unidades.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div
+        className="w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col rounded-xl"
+        style={{
+          backgroundColor: 'var(--baw-surface)',
+          border: '1px solid var(--baw-border)',
+        }}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-6 py-4 shrink-0"
+          style={{ borderBottom: '1px solid var(--baw-border)' }}
+        >
+          <div className="min-w-0">
+            <h2
+              className="text-lg font-semibold"
+              style={{ color: 'var(--baw-text)' }}
+            >
+              Generar varias unidades
+            </h2>
+            {buildingName && (
+              <p
+                className="text-xs mt-0.5 truncate"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                Edificio: {buildingName}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="shrink-0"
+            style={{ color: 'var(--baw-muted)' }}
+            aria-label="Cerrar"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body scrollable */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-5">
+          <p className="text-sm" style={{ color: 'var(--baw-muted)' }}>
+            Genera unidades en bloques. El piso se infiere del número (101 →
+            piso 1, 205 → piso 2, 1003 → piso 10). Puedes ejecutar varios
+            bulks (101-104, 201-204, etc.) y se irán sumando.
+          </p>
+
+          {/* Generador bulk */}
+          <div
+            className="rounded-md p-4 grid grid-cols-2 md:grid-cols-4 gap-3"
+            style={{
+              backgroundColor: 'var(--baw-bg)',
+              border: '1px solid var(--baw-border)',
+            }}
+          >
+            <BulkField label="Cantidad">
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={config.count}
+                onChange={(e) =>
+                  setConfig({
+                    ...config,
+                    count: e.target.value.replace(/[^0-9]/g, ''),
+                  })
+                }
+                placeholder="4"
+                className="w-full input-field"
+              />
+            </BulkField>
+            <BulkField label="Prefijo">
+              <input
+                type="text"
+                value={config.prefix}
+                onChange={(e) => setConfig({ ...config, prefix: e.target.value })}
+                placeholder="(opcional)"
+                className="w-full input-field"
+              />
+            </BulkField>
+            <BulkField label="Empezar en">
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={config.startNumber}
+                onChange={(e) =>
+                  setConfig({
+                    ...config,
+                    startNumber: e.target.value.replace(/[^0-9]/g, ''),
+                  })
+                }
+                placeholder="101"
+                className="w-full input-field"
+              />
+            </BulkField>
+            <BulkField label="Tipo">
+              <select
+                value={config.type}
+                onChange={(e) =>
+                  setConfig({ ...config, type: e.target.value as UnitType })
+                }
+                className="w-full input-field"
+              >
+                <option value="LTR">LTR — Larga estancia</option>
+                <option value="MTR">MTR — Media estancia</option>
+                <option value="STR">STR — Corta estancia</option>
+              </select>
+            </BulkField>
+          </div>
+
+          <div className="flex items-center gap-3 flex-wrap">
+            <button
+              type="button"
+              onClick={generate}
+              className="btn-primary text-sm"
+            >
+              {units.length > 0
+                ? `Agregar ${config.count || 0} más`
+                : `Generar ${config.count || 0} unidades`}
+            </button>
+            {units.length > 0 && (
+              <span className="text-xs" style={{ color: 'var(--baw-muted)' }}>
+                Listas para guardar: <strong>{validRows.length}</strong>
+              </span>
+            )}
+          </div>
+
+          {/* Lista editable */}
+          {units.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span
+                  className="text-sm font-medium"
+                  style={{ color: 'var(--baw-text)' }}
+                >
+                  {units.length} unidades
+                </span>
+                <button
+                  type="button"
+                  onClick={addRow}
+                  className="flex items-center gap-1 text-xs"
+                  style={{ color: 'var(--baw-primary)' }}
+                >
+                  <Plus className="w-3 h-3" /> Agregar fila
+                </button>
+              </div>
+              <div
+                className="rounded-md overflow-hidden"
+                style={{ border: '1px solid var(--baw-border)' }}
+              >
+                <table className="w-full text-xs">
+                  <thead
+                    style={{
+                      backgroundColor: 'var(--baw-bg)',
+                      color: 'var(--baw-muted)',
+                    }}
+                  >
+                    <tr>
+                      <th className="text-left px-3 py-2">Número</th>
+                      <th className="text-left px-3 py-2">Tipo</th>
+                      <th className="text-left px-3 py-2">Piso</th>
+                      <th className="px-3 py-2"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {units.map((u, idx) => (
+                      <tr
+                        key={idx}
+                        style={{ borderTop: '1px solid var(--baw-border)' }}
+                      >
+                        <td className="px-3 py-1.5">
+                          <input
+                            type="text"
+                            value={u.number}
+                            onChange={(e) =>
+                              updateRow(idx, 'number', e.target.value)
+                            }
+                            className="w-full input-field font-mono"
+                            style={{ padding: '4px 8px' }}
+                          />
+                        </td>
+                        <td className="px-3 py-1.5">
+                          <select
+                            value={u.type}
+                            onChange={(e) =>
+                              updateRow(idx, 'type', e.target.value)
+                            }
+                            className="input-field"
+                            style={{ padding: '4px 8px' }}
+                          >
+                            <option value="LTR">LTR</option>
+                            <option value="MTR">MTR</option>
+                            <option value="STR">STR</option>
+                          </select>
+                        </td>
+                        <td className="px-3 py-1.5">
+                          <input
+                            type="number"
+                            value={u.floor}
+                            onChange={(e) =>
+                              updateRow(idx, 'floor', Number(e.target.value) || 1)
+                            }
+                            className="w-20 input-field"
+                            style={{ padding: '4px 8px' }}
+                          />
+                        </td>
+                        <td className="px-3 py-1.5 text-right">
+                          <button
+                            type="button"
+                            onClick={() => removeRow(idx)}
+                            style={{ color: 'var(--baw-danger-fg)' }}
+                            aria-label="Eliminar"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div
+              className="rounded-md px-3 py-2 text-sm"
+              style={{
+                backgroundColor: 'var(--baw-danger-bg-soft)',
+                color: 'var(--baw-danger-fg)',
+                border: '1px solid var(--baw-danger-border)',
+              }}
+            >
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          className="flex items-center justify-between gap-3 px-6 py-4 shrink-0"
+          style={{ borderTop: '1px solid var(--baw-border)' }}
+        >
+          <span className="text-xs" style={{ color: 'var(--baw-muted)' }}>
+            {validRows.length > 0
+              ? `Se crearán ${validRows.length} unidades en una sola operación.`
+              : 'Genera unidades arriba o agrégalas una a una.'}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="btn-secondary text-sm disabled:opacity-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={submitting || validRows.length === 0}
+              className="btn-primary text-sm flex items-center gap-2 disabled:opacity-50"
+            >
+              {submitting && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+              {submitting ? 'Creando…' : `Crear ${validRows.length || ''} unidades`}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function BulkField({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="block">
+      <span
+        className="block text-[11px] uppercase tracking-wider mb-1 font-medium"
+        style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
+      >
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/src/app/units/page.tsx
+++ b/src/app/units/page.tsx
@@ -6,12 +6,13 @@
 // hay 2+, columna "Edificio" condicional, filtro real por org_id + building_id.
 
 import { useEffect, useMemo, useState } from 'react'
-import { Plus, Building2 } from 'lucide-react'
+import { Plus, Building2, Layers } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import type { Unit, UnitType, UnitStatus } from '@/types'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 import UnitModal from './UnitModal'
+import BulkUnitsModal from './BulkUnitsModal'
 import { StatusBadge, type StatusKind } from '@/components/ui/status'
 import { useActiveContext } from '@/lib/useActiveContext'
 
@@ -64,6 +65,11 @@ export default function UnitsPage() {
   const [buildingFilter, setBuildingFilter] = useState<string>(ALL_BUILDINGS)
   const [modalOpen, setModalOpen] = useState(false)
   const [editingUnit, setEditingUnit] = useState<Unit | null>(null)
+  // Sprint 6 followup #2: bulk generator (Cantidad/Prefijo/Empezar/Tipo)
+  // restaurado del wizard. Solo se habilita cuando hay un building activo
+  // (ALL_BUILDINGS no permite bulk — Supabase requiere building_id NOT NULL).
+  const [bulkOpen, setBulkOpen] = useState(false)
+  const [bulkBanner, setBulkBanner] = useState<string | null>(null)
 
   // Buildings de la org activa (lo que el user puede ver/elegir)
   const orgBuildings = useMemo(
@@ -199,14 +205,46 @@ export default function UnitsPage() {
           <h1 className="text-[22px] font-semibold">Unidades</h1>
           <p className="text-[13px] muted-text mt-0.5 truncate">{subtitle}</p>
         </div>
-        <button
-          onClick={handleNew}
-          className="btn-primary flex items-center gap-2 self-start sm:self-auto"
-        >
-          <Plus className="w-4 h-4" />
-          Nueva unidad
-        </button>
+        <div className="flex items-center gap-2 self-start sm:self-auto">
+          {/*
+            Sprint 6 followup #2: botón "Generar varias" portado del wizard
+            de onboarding (Cantidad / Prefijo / Empezar en / Tipo). Solo
+            visible cuando hay un building activo en el filtro — sin
+            building_id Supabase rechazaría el insert con NOT NULL.
+          */}
+          {buildingFilter !== ALL_BUILDINGS && (
+            <button
+              onClick={() => setBulkOpen(true)}
+              className="btn-secondary flex items-center gap-2"
+              title="Crear varias unidades a la vez"
+            >
+              <Layers className="w-4 h-4" />
+              Generar varias
+            </button>
+          )}
+          <button
+            onClick={handleNew}
+            className="btn-primary flex items-center gap-2"
+          >
+            <Plus className="w-4 h-4" />
+            Nueva unidad
+          </button>
+        </div>
       </div>
+
+      {/* Sprint 6 followup #2: banner de éxito tras bulk insert */}
+      {bulkBanner && (
+        <div
+          className="rounded-md px-3 py-2 text-sm"
+          style={{
+            backgroundColor: 'var(--baw-success-bg-soft)',
+            color: 'var(--baw-success-fg)',
+            border: '1px solid var(--baw-success-border)',
+          }}
+        >
+          {bulkBanner}
+        </div>
+      )}
 
       {/* Building selector pills (solo si hay 2+ buildings) */}
       {showBuildingPills && (
@@ -405,6 +443,23 @@ export default function UnitsPage() {
           onClose={() => {
             setModalOpen(false)
             setEditingUnit(null)
+          }}
+        />
+      )}
+
+      {/* Sprint 6 followup #2: bulk modal */}
+      {bulkOpen && activeOrgId && buildingFilter !== ALL_BUILDINGS && (
+        <BulkUnitsModal
+          orgId={activeOrgId}
+          buildingId={buildingFilter}
+          buildingName={activeFilterBuilding?.name ?? null}
+          onClose={() => setBulkOpen(false)}
+          onSuccess={(insertedCount) => {
+            setBulkOpen(false)
+            setBulkBanner(`✓ ${insertedCount} unidades creadas correctamente.`)
+            fetchUnits()
+            // Auto-clear banner tras 4s
+            setTimeout(() => setBulkBanner(null), 4000)
           }}
         />
       )}


### PR DESCRIPTION
## Sprint 6 followups #2 — bugs reales tras PR #49

PR #49 cerró 3 issues pero el usuario reportó que **2 seguían vivos** (`/settings` cargando eterno, infinite login loop) y descubrimos un **3ro nuevo** (no se pueden generar varias unidades en `/units`, solo en el wizard inicial). Este PR ataca las **causas raíz reales**.

---

### Fix #1 — `/settings` "Cargando configuración…" eterno (causa raíz real)

**Por qué PR #49 no lo arregló:** PR #49 envolvió `Promise.all` en try/finally para que `setLoading(false)` siempre corriera. Pero el bug real está antes: el `useEffect` de `/settings/page.tsx` solo llama a `load()` si `orgId` existe:

```tsx
useEffect(() => { if (orgId) load(orgId) }, [orgId])
```

Si `useOrgContext()` devuelve `orgId === null` (sin org activa, `/api/me/org` falló con 401/403, o el usuario aún no tiene membresía), **`load()` jamás se ejecuta** y el `useState(true)` inicial nunca baja. Spinner eterno.

**Fix:** el `useEffect` ahora distingue 3 estados:

```tsx
useEffect(() => {
  if (orgLoading) return            // esperar al context
  if (orgId) { load(orgId); return }
  setLoading(false)                 // sin org → no spinear
}, [orgId, orgLoading])
```

Y la rama "no hay org activa" ahora muestra UI completa con CTAs **Configurar cuenta** y **Cerrar sesión** en lugar del `<div>` plano anterior.

---

### Fix #2 — Bulk por bloques en `/units` (faltaba)

El usuario tenía razón: el generador "Cantidad / Prefijo / Empezar en / Tipo" existe en `WizardFirstRun.tsx` (líneas 216-820), pero `/units/page.tsx` solo expone el botón "Nueva unidad" (singular). Tras el onboarding no había forma de generar varias.

**Fix:**

- **NEW** `src/app/units/BulkUnitsModal.tsx` (~440 líneas) — porta toda la lógica del wizard: agregar/quitar bloques, prefijo + start + count + tipo por bloque, preview de los nombres generados, validación de duplicados, insert masivo a Supabase.
- `/units/page.tsx`: nuevo botón **Generar varias** al lado de "Nueva unidad", visible **solo cuando hay un edificio seleccionado** (`buildingFilter !== ALL_BUILDINGS`) porque `units.building_id` es `NOT NULL` en Supabase. Banner verde de éxito tras insert con conteo.

---

### Fix #3 — Infinite login loop con `?next=/admin`

**Síntoma:** `/login?next=/admin` → login OK → redirect a `/admin` → server ve cookie no propagada → redirect a `/login?next=/admin` → loop.

**Causa raíz (hipótesis basada en análisis del flujo):** race condition entre el `Set-Cookie` del POST a `/api/auth/sync-session` y el `window.location.href = next`. El navegador a veces dispara la navegación **antes de commit la cookie HTTPOnly**, así que el server component de `/admin` corre `getUser()` y obtiene `null`, dispara el redirect, y el form de `/login` con sesión activa en el cliente vuelve a ejecutar el flujo → loop.

> ⚠️ No se pudo confirmar con logs runtime de Vercel — `vercel logs` falló con `target host not allowed (403)` por el proxy. La hipótesis viene de leer el código del flujo y los hooks de `getUser()` / middleware.

**Fix:**

- **NEW** `src/app/api/me/whoami/route.ts` — endpoint que llama a `supabase.auth.getUser()` y devuelve `{email, user_id}` con 200, o 401 si la cookie no es válida.
- `src/app/login/page.tsx`: tras el `POST /api/auth/sync-session`, hace un **probe loop** a `/api/me/whoami` con hasta **3 reintentos** (backoff de 150ms) **antes de** navegar. Solo si el probe responde 200 → `window.location.href = next`. Si tras 3 intentos sigue 401 → error visible en la UI en lugar de loop infinito.

Esto rompe la carrera y, en el peor caso (cookie nunca se propaga), el usuario ve un error claro en vez de quedar atrapado.

---

### Archivos cambiados

| Archivo | Tipo |
|---|---|
| `src/app/settings/page.tsx` | mod — useEffect maneja `orgId === null` + UI mejor |
| `src/app/units/BulkUnitsModal.tsx` | **NEW** — bulk modal portado del wizard |
| `src/app/units/page.tsx` | mod — botón "Generar varias" + banner success |
| `src/app/login/page.tsx` | mod — probe loop a `/api/me/whoami` antes de navegar |
| `src/app/api/me/whoami/route.ts` | **NEW** — endpoint verificación de cookie |

### QA local

- `npx tsc --noEmit` ✅ sin errores
- Pendiente smoke en preview: `/settings` con y sin org, generar 4 unidades nivel 1 en `/units`, login con `?next=/admin`.
