### PR TITLE
docs: multi-agent handoff (CLAUDE.md + PROJECT_STATE + MIGRATION_GUIDE + COLAB_ANDRES)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md — Briefing para Claude Code en BaW OS
+
+> Este archivo lo lee automáticamente **Claude Code** (CLI, VS Code y Desktop) al abrir este repo. Si llegas aquí como Claude, **lee primero `AGENTS.md`** — es la fuente de verdad operacional compartida con todos los demás agentes (Codex, Cursor, Computer, etc.). Aquí solo va lo específico de Claude.
+
+---
+
+## 0 · Primer paso obligatorio
+
+```
+Lee AGENTS.md completo antes de tocar código.
+```
+
+`AGENTS.md` cubre:
+- Contexto del proyecto en 1 página (sección 0)
+- Pre-flight obligatorio: `git fetch`, `gh pr list`, build verde local (sección 1)
+- Invariantes que no se tocan sin PR dedicado (sección 2)
+- Lenguaje, convenciones, reglas de merge (secciones 3-4)
+- Source of truth en Notion (sección 5)
+- Anti-patrones que disparan rechazo (sección 7)
+
+**No dupliques esa información aquí. Si necesitas extender algo, edítalo en AGENTS.md y agrega el delta a este archivo.**
+
+---
+
+## 1 · Lo específico de Claude Code
+
+### 1.1 — Cómo arrancar una sesión nueva
+
+**Prompt inicial recomendado** (cópialo tal cual la primera vez en cada sesión):
+
+```
+Lee CLAUDE.md y AGENTS.md completos. Después lee docs/PROJECT_STATE.md para saber en qué sprint estamos y cuáles son las prioridades vivas. Confirma que entendiste el estado actual antes de proponer trabajo.
+```
+
+Claude Code respeta los archivos `CLAUDE.md` automáticamente, pero el prompt explícito asegura que también lea `PROJECT_STATE.md` que cambia más seguido.
+
+### 1.2 — Tools obligatorios
+
+Claude Code en este repo debe usar:
+
+- **`gh` CLI** para todo lo de GitHub (issues, PRs, releases). Está autenticado en la máquina del usuario.
+- **Supabase MCP** si está disponible en la sesión, para queries de DB. Si no, `psql` con la cadena de `.env.local`.
+- **Notion MCP** para logs de avance (ver `AGENTS.md` §6). No uses `browser_task` para Notion.
+- **Vercel CLI** (`npx vercel`) para deploys y logs runtime cuando los necesites.
+
+### 1.3 — Política de commits y PRs (recordatorio)
+
+- Single-line commit messages, imperativo, en inglés cuando son técnicos puros.
+- **Nunca mergees a `main` solo.** Crea el PR, pega el link en el chat, y espera aprobación humana de Fran.
+- TS check (`npx tsc --noEmit`) antes de push, sin excepción.
+- Branch naming: `fix/<descriptor>`, `feat/<descriptor>`, `docs/<descriptor>`, `sprint<N>/<scope>`.
+
+### 1.4 — Cuándo pedir confirmación al usuario
+
+Antes de:
+- Mergear cualquier PR
+- Tocar migraciones de Supabase (carpeta `supabase/migrations/`)
+- Cambiar tokens de diseño en `design/baw-design/tokens/`
+- Modificar `src/lib/navigation.ts` o `src/lib/platform-admin.ts`
+- Crear un feature nuevo que no esté en `docs/PROJECT_STATE.md` ni en el Feature Board
+
+### 1.5 — Modo "plan" antes de modo "execute"
+
+Para tareas multi-archivo o multi-step, **propón un plan primero** (lista de archivos a tocar + qué cambia + qué validas). Espera el OK de Fran antes de ejecutar. Esto evita PRs gigantes que se vuelven irrevisables.
+
+### 1.6 — Cuando heredas trabajo de Computer (Perplexity) o de otra herramienta
+
+Si el chat anterior fue en Perplexity Computer / Codex / Cursor / Andrés Discord:
+
+1. Lee `docs/PROJECT_STATE.md` para saber qué se cerró ya.
+2. Corre `gh pr list --state all --limit 15` para ver qué PRs están abiertos o se mergearon recientemente.
+3. Si hay un PR abierto que parezca tuyo (rama `fix/...` o `feat/...`), `gh pr view <N>` antes de crear nada nuevo. Quizá solo falte rebase + merge.
+
+---
+
+## 2 · Diferencias entre Claude Code CLI / VS Code / Desktop
+
+| Versión | Cuándo usarla |
+|---|---|
+| **Claude Code CLI** (terminal) | Cambios rápidos, scripts, CI tasks, cuando ya tienes claro el plan |
+| **Claude Code en VS Code** (panel lateral) | Edición visible, ver diffs en tiempo real, sesiones largas |
+| **Claude Code Desktop** (app standalone) | Sesiones de planificación o discusión sin editar código directamente; MCPs centralizados |
+
+Las tres comparten el mismo `CLAUDE.md` y `AGENTS.md` porque están en el repo.
+
+---
+
+## 3 · MCPs configurados (esperados)
+
+Claude Code lee `~/.claude/mcp.json` o `.claude/mcp.json` del repo. Los MCPs que este proyecto asume disponibles:
+
+- `notion` (para logs y SOT)
+- `supabase` (para queries directas a la DB)
+- `github` (alternativa a `gh` CLI)
+- `vercel` (para deploys y logs)
+
+Si un MCP falta, **no detengas el trabajo** — usa el equivalente CLI (`gh`, `npx vercel`, `psql`). Pero avisa a Fran que falta para que lo agregue.
+
+---
+
+## 4 · Cuando NO sabes qué hacer
+
+Sigue el orden:
+
+1. Buscar en `AGENTS.md` (invariantes, anti-patrones)
+2. Buscar en `docs/PROJECT_STATE.md` (estado vivo)
+3. Buscar en `docs/EXECUTION-TIER1.md`, `docs/PRD.md`, `docs/ROADMAP-v2.md`
+4. Buscar en código: `git log` del archivo, comentarios inline
+5. Buscar en Notion (links en `AGENTS.md` §5)
+6. **Preguntar a Fran** en el chat o como comentario en el PR. Mejor un PR pausado que una regresión.
+
+---
+
+**Mantenido por:** Fran Durán (`@franduranv`)
+**Última revisión:** ver `docs/PROJECT_STATE.md` para fecha.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Un PMS (Property Management System) construido para el futuro de la operación i
 
 ## Documentación
 
+### Para agentes (Claude Code, Codex, Cursor, Computer)
+- 🤖 [`AGENTS.md`](./AGENTS.md) — **Léelo primero.** Protocolo operacional canónico.
+- 🤖 [`CLAUDE.md`](./CLAUDE.md) — Específico de Claude Code.
+- 📊 [`docs/PROJECT_STATE.md`](./docs/PROJECT_STATE.md) — Estado vivo del sprint actual.
+- 🚀 [`docs/MIGRATION_GUIDE.md`](./docs/MIGRATION_GUIDE.md) — Cómo arrancar en cada plataforma.
+- 🤝 [`docs/COLAB_ANDRES.md`](./docs/COLAB_ANDRES.md) — Protocolo de colaboración con Andrés CTO.
+
+### Producto y datos
 - 📋 [PRD v0.1](./docs/PRD.md) — Product Requirements Document completo
 - 🗄️ [Schema SQL](./docs/schema.sql) — Estructura de base de datos
 

--- a/docs/COLAB_ANDRES.md
+++ b/docs/COLAB_ANDRES.md
@@ -1,0 +1,171 @@
+# COLAB_ANDRES.md — Protocolo para colaborar con Andrés (Agente CTO de OpenClaw via Discord)
+
+> Andrés es uno de los agentes ZXY shared definidos en `AGENTS.md` §2.7 ("Andres-Tech"). Históricamente la colaboración con él en BaW OS no ha salido bien. Este documento codifica un protocolo que aumenta las probabilidades de éxito.
+
+---
+
+## 1 · Por qué la colaboración previa falló (hipótesis)
+
+Sin un post-mortem formal, las causas más probables fueron:
+
+1. **Andrés no tenía acceso al estado real del repo.** Operaba con el handoff de Notion (que se desactualiza) en vez de con `git log origin/main` y `gh pr list`.
+2. **No había un canal estructurado para validación.** Discord es bueno para conversación pero malo para flujo de PRs — las decisiones se diluyen en chat.
+3. **Falta de criterio compartido sobre qué PR mergear y cuándo.** Sin reglas explícitas, las versiones colisionaban.
+4. **Cero trazabilidad de qué decidió Andrés vs. qué decidiste tú.** Sin commits firmados o PRs separados, era imposible auditar.
+
+Si la próxima ronda con Andrés repite cualquiera de estos cuatro errores, va a fallar igual. Este protocolo los ataca uno por uno.
+
+---
+
+## 2 · Pre-condiciones antes de invitar a Andrés
+
+### 2.1 — Acceso a herramientas
+
+Confirma que Andrés tiene:
+
+- [ ] Acceso de **collaborator** (no solo read) al repo `zxy-vc/baw-os`. Configúralo en Settings → Collaborators.
+- [ ] `gh` CLI autenticado en su entorno con su propia cuenta GitHub (no la tuya).
+- [ ] Acceso al canal Discord donde se coordina (idealmente uno dedicado a BaW OS, no el general de OpenClaw).
+- [ ] **Lectura** de las páginas Notion linkeadas en `AGENTS.md` §5. No edición — Notion no es source of truth.
+- [ ] Si va a tocar Supabase: acceso al project `zlcgxmllaeweypyodvzk` con rol limitado a `developer` (no `owner`).
+
+### 2.2 — Mensaje de onboarding (mándaselo en Discord antes de la primera tarea)
+
+```
+Andrés, te toca BaW OS. Antes de tocar nada lee, en este orden:
+
+1. https://github.com/zxy-vc/baw-os/blob/main/AGENTS.md
+2. https://github.com/zxy-vc/baw-os/blob/main/CLAUDE.md
+3. https://github.com/zxy-vc/baw-os/blob/main/docs/PROJECT_STATE.md
+4. https://github.com/zxy-vc/baw-os/blob/main/docs/COLAB_ANDRES.md (este doc)
+
+Después corre:
+
+  git fetch origin && gh pr list --state all --limit 15
+
+y dime qué entendiste del estado actual antes de proponer cualquier trabajo. Si tu plan choca con algo de AGENTS.md, dímelo en lugar de improvisar.
+```
+
+---
+
+## 3 · Reglas operacionales para Andrés
+
+Estas son **adicionales** a las de `AGENTS.md`. Aplican solo a Andrés porque son una capa extra de control hasta que la colaboración sea estable.
+
+### 3.1 — Una tarea, un PR, un commit-author identificable
+
+- Cada tarea Andrés la ejecuta en su propia rama: `andres/<scope>` (ej: `andres/cobranza-mateos`).
+- Sus commits deben tener `git config user.name="Andres CTO"` y `user.email=<email-suyo>`.
+- Un PR = una tarea. No bundles.
+
+### 3.2 — Discord = conversación, GitHub = decisiones
+
+- **Toda decisión técnica vinculante** se documenta como comentario en el PR de GitHub, no en Discord.
+- Discord puede usarse para preguntas rápidas o para "voy a empezar X". Pero el plan, el diff y el merge viven en GitHub.
+- Si Discord muere o se pierde el thread, el PR debe ser auto-explicativo.
+
+### 3.3 — Plan en el PR antes de código en el PR
+
+- Andrés abre el PR con título + body explicando el plan, **sin código todavía** (commit vacío o solo `docs/` con la propuesta).
+- Tú das OK explícito en el PR.
+- Recién entonces empuja los commits con código.
+- Esto fuerza alineación temprana y evita PRs gigantes que hay que rechazar.
+
+### 3.4 — Tu único merge
+
+- **Solo Fran mergea a main.** Andrés nunca corre `gh pr merge` en este repo, sin importar la urgencia.
+- Si Andrés está bloqueado esperando merge, el cuello de botella es real y útil — fuerza priorización.
+
+### 3.5 — Conflictos con sprint en curso
+
+Si la rama de Andrés se quedó atrás de main mientras esperaba review:
+
+- Andrés rebasea sobre `origin/main` actualizado (ver `AGENTS.md` §4)
+- Resuelve conflictos él, no tú
+- Hace `--force-with-lease` (no `--force` a ciegas)
+- Vuelve a pedir review
+
+### 3.6 — Scope discipline (refuerzo)
+
+`AGENTS.md` §1.4 ya lo dice, pero con Andrés se enfatiza: **si encuentra algo que mejorar fuera del scope del PR, abre issue en GitHub, no commit**. Históricamente este fue uno de los puntos de fricción.
+
+---
+
+## 4 · Tareas iniciales recomendadas para reabrir colaboración
+
+Estas son tareas con scope cerrado, riesgo bajo y entregables claros. Buenas para reconstruir confianza:
+
+### 4.1 — Tier "warm-up" (riesgo bajo)
+
+- **Cerrar issue [#22](https://github.com/zxy-vc/baw-os/issues/22)** (`getOrgIdAsync()` shim en webhooks) — migración mecánica con tests claros.
+- **Limpieza de HEX residuales en componentes legacy** (issue [#24](https://github.com/zxy-vc/baw-os/issues/24)) — visual diff fácil de revisar.
+
+### 4.2 — Tier "test de criterio" (riesgo medio)
+
+- **Eliminación de `member_role` enum legacy** (issue [#23](https://github.com/zxy-vc/baw-os/issues/23)) — toca DB + código + RLS, requiere plan cuidadoso.
+- **Hardening de deploy Vercel con submodule baw-design** — debugging real, requiere razonar sobre CI.
+
+### 4.3 — Tier "ownership" (después de 2-3 PRs limpios)
+
+- Liderar Sprint 7 con un módulo entero (ej: Gestión de edificios y propietarios), con tu rol como reviewer humano.
+
+**No saltes tiers.** Si Andrés rompe algo en warm-up, no le des tier 2.
+
+---
+
+## 5 · Señales de que la colaboración está funcionando
+
+Después de cada PR de Andrés evalúa:
+
+- [ ] ¿El plan inicial coincidió con el código final? (sin "creep")
+- [ ] ¿TS verde al primer push? (sin tener que pedirlo)
+- [ ] ¿Respetó invariantes de `AGENTS.md`? (sin tokens paralelos, sin tocar navegación canónica, etc.)
+- [ ] ¿El commit message es descriptivo en una línea?
+- [ ] ¿Documentó el cambio en Notion (`AGENTS.md` §6)?
+
+Si los 5 son ✅ tres PRs seguidos, sube de tier. Si falla el mismo punto 2 veces, **detén la colaboración** y revisa el protocolo con Andrés antes de continuar.
+
+---
+
+## 6 · Señales de que algo va mal
+
+Detén el PR si ves cualquiera de estas:
+
+- Andrés mergea solo a main (regla §3.4 violada)
+- PR mezcla scopes (cobranza + estilos + DB en uno)
+- Cambios en `design/baw-design/tokens/` sin PR dedicado y sin design rationale
+- Cambios en `src/lib/navigation.ts`, `src/lib/platform-admin.ts`, o `src/lib/org-context.ts` sin issue previo
+- Commits con `--force` (no `--force-with-lease`) sobre ramas compartidas
+- "Lo arreglé en producción" — no se hot-fixea producción sin PR
+
+---
+
+## 7 · Plantilla de feedback para Andrés post-PR
+
+Usa este template como comentario al PR cuando lo apruebes o rechaces:
+
+```
+**Review BaW OS · PR #<N>**
+
+✅ / ❌ Plan vs. código
+✅ / ❌ TS verde
+✅ / ❌ AGENTS.md respetado
+✅ / ❌ Scope disciplinado
+✅ / ❌ Commit message
+✅ / ❌ Log Notion
+
+Comentarios:
+- ...
+
+Próximo:
+- [ ] Si verde 5/5: subir a tier siguiente
+- [ ] Si rojo en 1+: arreglar antes de mergear
+```
+
+Esto le da a Andrés señal explícita y a ti trazabilidad de su evolución.
+
+---
+
+**Mantenido por:** Fran Durán
+**Última revisión:** 2026-05-02
+**Siguiente revisión:** después de los próximos 3 PRs de Andrés, ajustar protocolo.

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,0 +1,214 @@
+# MIGRATION_GUIDE.md — Cómo trabajar BaW OS desde Claude Code, Codex, Cursor, o Perplexity Computer
+
+> **Para Fran.** Este doc explica cómo arrancar una sesión de desarrollo en cada herramienta de forma que el agente entre con el contexto correcto desde el primer prompt. Funciona porque todas las herramientas leen automáticamente `AGENTS.md` (estándar abierto) o `CLAUDE.md` (Claude Code) cuando abren el repo.
+
+---
+
+## 0 · Pre-requisito común
+
+Antes de migrarte a cualquier plataforma, asegura que:
+
+1. Tienes el repo clonado: `git clone --recurse-submodules https://github.com/zxy-vc/baw-os.git`
+2. `.env.local` está copiado (pídeselo a Fran o regenera desde `.env.example` + Supabase dashboard)
+3. `npm install` corrió sin errores
+4. `npm run dev` levanta `localhost:3000` y puedes loguearte con `fran@zxy.vc`
+
+---
+
+## 1 · Claude Code en VS Code (extensión, panel lateral)
+
+### 1.1 — Setup inicial
+
+- Instala la extensión "Claude Code" desde el marketplace de VS Code.
+- Abre la carpeta del repo en VS Code.
+- En el panel lateral de Claude Code, presiona **New session**.
+- Claude detectará `CLAUDE.md` automáticamente.
+
+### 1.2 — Primer prompt recomendado
+
+```
+Lee CLAUDE.md, AGENTS.md y docs/PROJECT_STATE.md completos. Confirma que entendiste el sprint actual y los patrones de bug ya documentados antes de proponer trabajo.
+
+Mi tarea: [DESCRIBE LO QUE QUIERES HACER]
+
+Antes de tocar código, propón un plan: archivos a tocar, qué cambia, qué validas. Espera mi OK antes de ejecutar.
+```
+
+### 1.3 — Flow típico
+
+1. Pides plan → Claude responde plan
+2. Apruebas / corriges
+3. Claude edita archivos visibles en el editor
+4. Pides `npx tsc --noEmit`
+5. Pides commit + push + `gh pr create`
+6. Claude te pasa el link del PR
+7. **Tú mergeas manualmente** (regla canónica)
+
+### 1.4 — Cuando Claude se atasca
+
+Si propone algo que ya está mergeado o contradice un acuerdo: dile **"revisa AGENTS.md §X y `git log origin/main --oneline -10`"** — eso lo regresa al estado real.
+
+---
+
+## 2 · Claude Code Desktop (app standalone)
+
+### 2.1 — Cuándo usarla en lugar de VS Code
+
+- Sesiones de planificación largas sin editar código directamente
+- Cuando quieres que el agente trabaje en background con MCPs centralizados
+- Cuando vas a tener múltiples sesiones paralelas (sidebar de Sessions)
+
+### 2.2 — Configuración de proyecto
+
+- En Desktop, agrega el folder del repo como **Project / Workspace**
+- En **Customize**, asegura que los MCPs estén conectados: GitHub, Notion, Supabase, Vercel
+- Activa **worktree mode** si vas a tener varias sesiones modificando ramas distintas (lo veo activo en tu screenshot)
+
+### 2.3 — Sobre la sesión "Design: BaW OS · Requiere información"
+
+En tu image-4 veo una sesión esperando input tuyo. Para retomarla:
+
+1. Abre la sesión
+2. Pega este mensaje:
+
+```
+Reanudemos. Contexto: el Sprint 6 (visual rollout) cerró el 2026-05-02 con PRs #44 al #51. Lee CLAUDE.md, AGENTS.md y docs/PROJECT_STATE.md para ponerte al día. ¿Qué información necesitabas de mí para continuar?
+```
+
+3. Eso le da al agente el estado real (porque `1w` significa que la sesión es de antes del Sprint 6).
+
+### 2.4 — Pull Request "Improve website best practices" (image-4)
+
+Lo veo como **Listo para revisión** desde hace 1 semana. Antes de mergear:
+
+```bash
+gh pr view <numero> --json title,body,files,checks
+git fetch origin && git log origin/main..pr/<numero> --oneline
+```
+
+Si toca cosas del Sprint 6 que ya cambiaron, pídele a Claude que rebasee y reabra.
+
+---
+
+## 3 · Codex (OpenAI, en VS Code o web)
+
+### 3.1 — Particularidad: Codex respeta AGENTS.md automáticamente
+
+Codex es el que **inventó el estándar `AGENTS.md`**. Lo leerá solo. No necesitas un `CODEX.md` aparte.
+
+### 3.2 — Primer prompt recomendado
+
+En la barra de input de Codex (image-3 lo muestra: "Pregúntale a Codex lo que sea"):
+
+```
+Lee AGENTS.md y docs/PROJECT_STATE.md completos. Confirma sprint actual y patrones de bug documentados antes de proponer.
+
+Tarea: [DESCRIBE]
+
+Reglas no negociables:
+- Single-line commits
+- TypeScript check antes de push (`npx tsc --noEmit`)
+- NO mergear a main, solo abrir PR
+- Branch name: fix/<scope> o feat/<scope>
+- Plan primero, ejecución después de mi OK
+```
+
+### 3.3 — Modo "Trabajar localmente" vs "Trabajar en la nube"
+
+Veo en tu image-3 que tienes "Trabajar localmente" activo + branch `feat/seed-mateos`. Eso significa que Codex va a editar tu copia local del repo. Bien para desarrollo rápido.
+
+Para tareas largas en background (mientras tú haces otra cosa), cambia a **Trabajar en la nube** — Codex levanta su propio sandbox y te abre el PR cuando termina. Útil para refactors grandes o seed scripts.
+
+### 3.4 — Tareas sugeridas que ya viste en Codex (image-3)
+
+- "Cerrar el tablero de cobranza real de Mateos" → Sprint 7 candidato
+- "Agregar gestión de edificios y propietarios" → Sprint 7 candidato
+- "Blindar el deploy de Vercel con baw-design" → deuda técnica de submodule
+- "Conecta tus aplicaciones favoritas a Codex" → MCPs
+
+Antes de aceptar cualquiera, pídele plan + valida que no choque con `PROJECT_STATE.md`.
+
+### 3.5 — Limitación conocida
+
+Codex Web a veces no ve el último commit si lo acabas de pushear. Si Codex te dice que algo "no está en main" cuando sí está, pídele:
+
+```
+Refresca el repo. Corre `git fetch origin && git log origin/main --oneline -5`. Confirma el SHA actual.
+```
+
+---
+
+## 4 · Cursor (IDE con agente integrado)
+
+### 4.1 — Setup
+
+- Cursor lee `AGENTS.md` y `CLAUDE.md` automáticamente.
+- Para proyectos grandes, configura `.cursorrules` (opcional) — pero con `AGENTS.md` ya tienes lo esencial.
+- Activa "Composer" para tareas multi-archivo, "Chat" para preguntas puntuales.
+
+### 4.2 — Primer prompt
+
+Mismo template del prompt de Claude Code §1.2, sirve igual.
+
+### 4.3 — Modelo recomendado
+
+Para BaW OS (TypeScript + Next.js + Supabase): Claude Sonnet 4.6 o GPT-5 Pro. Evita modelos "fast" baratos para refactors o migraciones de tokens — son propensos a romper invariantes de `AGENTS.md`.
+
+---
+
+## 5 · Perplexity Computer (lo que estás usando ahora)
+
+### 5.1 — Cuándo seguir aquí
+
+- Tareas que requieren navegar Vercel/Supabase/GitHub al mismo tiempo (los conectores ya están configurados)
+- Sesiones largas de debugging con análisis de logs y screenshots
+- Cuando necesitas que el agente lea PDFs, capturas o documentos del workspace
+
+### 5.2 — Cómo reanudar después de migrar
+
+Si trabajaste en otra plataforma y vuelves a Computer, usa este prompt:
+
+```
+Reanudemos en BaW OS. Lee desde GitHub:
+- AGENTS.md
+- CLAUDE.md
+- docs/PROJECT_STATE.md
+
+Después corre `gh pr list --state all --limit 10` para ver qué se mergeó mientras no estaba aquí. Después dime qué encontraste antes de proponer trabajo.
+```
+
+### 5.3 — Limitación
+
+Perplexity Computer no edita archivos directamente en tu máquina — trabaja sobre `/tmp/baw-os-work` (clon temporal). Cuando hace push, el cambio aparece en GitHub remoto pero no en tu Mac local hasta que hagas `git pull`.
+
+---
+
+## 6 · Comparativa rápida — cuándo usar cuál
+
+| Tarea | Mejor herramienta | Por qué |
+|---|---|---|
+| Bug fix de 1-3 archivos | **Claude Code VS Code** | Edición visible, diffs en tiempo real |
+| Refactor multi-archivo | **Cursor Composer** o **Codex (nube)** | Multi-file editing nativo |
+| Tarea autónoma background | **Codex en la nube** | Levanta sandbox, abre PR solo |
+| Planning + arquitectura | **Claude Code Desktop** | Sesiones largas, MCPs centralizados |
+| Debug con logs/screenshots/multi-app | **Perplexity Computer** | Conectores y navegación nativa |
+| Pair programming en vivo | **Claude Code VS Code** | UI inmediata |
+| Andrés (CTO OpenClaw via Discord) | Ver `docs/COLAB_ANDRES.md` | Protocolo aparte |
+
+---
+
+## 7 · Reglas que aplican en TODAS las plataformas
+
+1. **`git fetch origin && gh pr list` antes de proponer trabajo.**
+2. **Plan antes de ejecución.** Lista de archivos + qué cambia + qué validas.
+3. **`npx tsc --noEmit` verde antes de push.**
+4. **NO mergear a main solo.** Abrir PR, esperar tu OK.
+5. **Single-line commit messages.** Imperativo.
+6. **Si hay duda, preguntar a Fran.** Mejor PR pausado que regresión.
+
+Si una herramienta empieza a romper estas reglas, recuérdaselas con: **"lee AGENTS.md §1, §3, §4"**.
+
+---
+
+**Mantenido por:** Fran Durán
+**Última revisión:** 2026-05-02

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,0 +1,128 @@
+# PROJECT_STATE.md — Estado vivo de BaW OS
+
+> **Este archivo cambia seguido.** Cualquier agente que vaya a tocar el repo debe leerlo después de `AGENTS.md` y antes de empezar.
+> **Última actualización:** 2026-05-02 (Sprint 6 cerrado, post PR #51 mergeado)
+
+---
+
+## 1 · Sprint en curso
+
+**Sprint 6 — Visual Rollout & Bug Bash · CERRADO el 2026-05-02.**
+
+PRs cerrados en el sprint:
+- #44 BaW Mark + Sidebar shell + Mark A canónico
+- #45 Migrar `/me`, `/agents`, `/admin/roadmap` a tokens BaW
+- #46 Owner Portal a tokens BaW
+- #47 Onboarding wizard a tokens BaW
+- #48 Visual audit final + cierre HEX residual
+- #49 Sprint 6 followups (BawGrid en AppShell + bulk visible en Configurar cuenta)
+- #50 Sprint 6 followups #2 (`/settings` real fix + bulk en `/units` + login race fix)
+- #51 Hotfix login: `sync-session` cookie roundtrip + probe loop graceful fallback
+
+**Resultado:** producción `baw-os.vercel.app` con visual unificado (Mark A + retícula de fondo + tokens `--baw-*`), wizard onboarding con bulk de unidades, `/units` con bulk también, login funcional con `?next=/admin`.
+
+---
+
+## 2 · Próximo sprint (Sprint 7) — propuestas a confirmar con Fran
+
+Estas son hipótesis derivadas de issues abiertos y conversaciones recientes. **Confirmar con Fran antes de empezar.**
+
+| Tema | Justificación | Issue/Doc |
+|---|---|---|
+| Cierre del tablero de cobranza real (Mateos) | Aparece como sugerencia en Codex (image-3); cliente piloto activo | Por crear issue |
+| Gestión de edificios y propietarios | Backlog del PRD; CRUD aún incompleto | `docs/PRD.md` |
+| Blindar deploy Vercel con `baw-design` | Build inestable cuando `design/baw-design/` cambia | Por crear issue |
+| Migración legacy `member_role` enum | Deuda heredada de Sprint 3 | [#23](https://github.com/zxy-vc/baw-os/issues/23) |
+| Migración HEX residual a tokens BaW | Deuda heredada Sprint 4-5 | [#24](https://github.com/zxy-vc/baw-os/issues/24) |
+| `getOrgIdAsync()` shim en webhooks | Deuda heredada | [#22](https://github.com/zxy-vc/baw-os/issues/22) |
+
+---
+
+## 3 · Bugs conocidos abiertos
+
+(Ninguno crítico al cierre del Sprint 6. Si encuentras uno, agrégalo aquí o abre issue.)
+
+---
+
+## 4 · Decisiones canónicas vigentes (refresco)
+
+> Versión condensada. La fuente completa es `AGENTS.md` §2.
+
+- **Logo:** Mark A (desfase pronunciado). Componente `BawMark` en `src/components/brand/BawMark.tsx`.
+- **Retícula de fondo:** `BawGrid` debe estar visible en TODAS las pantallas como distintivo (decisión de Fran post Sprint 6 PR D).
+- **Visual unificado:** toda la app debería verse como `/login` (decisión de Fran).
+- **Tokens:** todos `--baw-*` desde `design/baw-design/tokens/index.css`. Nunca tokens paralelos.
+- **Tipografía:** Inter via `next/font/google` en `src/app/layout.tsx`. No tocar.
+- **Navegación:** 6 secciones top + 2 footer en `src/lib/navigation.ts`. Ver `AGENTS.md` §2.3.
+- **Admin 3 capas:** L0 `/admin` (solo `fran@zxy.vc`) · L1 `/settings/account` · L2 `/me`. Ver `AGENTS.md` §2.4.
+- **Org context:** `resolveOrgId()` en `src/lib/org-context.ts` es la única fuente de verdad de `org_id`. Cualquier query a Supabase filtra por `org_id`.
+
+---
+
+## 5 · Patrones de bug ya documentados (NO repetir)
+
+Estos bugs ya pasaron una vez. Si los ves de nuevo, hay solución conocida:
+
+### 5.1 — Loading eterno en pages que dependen de `useOrgContext()`
+
+**Síntoma:** página queda en "Cargando…" infinito.
+**Causa:** `useEffect(() => { if (orgId) load(orgId) }, [orgId])` — si `orgId === null` el `load()` jamás corre y `useState(true)` queda eterno.
+**Fix canónico:** distinguir 3 estados:
+
+```tsx
+useEffect(() => {
+  if (orgLoading) return
+  if (orgId) { load(orgId); return }
+  setLoading(false)  // sin org, no spinear
+}, [orgId, orgLoading])
+```
+
+Y rama "no hay org" debe mostrar UI con CTAs, no `<div>` plano.
+**Caso histórico:** PR #50 (`/settings`).
+
+### 5.2 — Race condition en login con `?next=/admin`
+
+**Síntoma:** infinite loop entre `/login` y la página destino.
+**Causa:** `window.location.href` se ejecuta antes de que el browser commit el `Set-Cookie`.
+**Fix canónico:** probe loop a `/api/me/whoami` con backoff antes de navegar; si falla, navegar igual con warn (no bloquear con error visible).
+**Caso histórico:** PRs #50 + #51.
+
+### 5.3 — Cookies a medio setear en endpoints de auth
+
+**Síntoma:** browser recibe `Set-Cookie` sin `path` / `httpOnly` / `sameSite`.
+**Causa:** crear un `NextResponse` nuevo y copiar cookies de otro response con `cookies.set(name, value, c)` donde `c` es el `ResponseCookie` original (shape incorrecto para `CookieOptions`).
+**Fix canónico:** devolver el response original con `{ headers: response.headers }` en vez de reconstruir.
+**Caso histórico:** PR #51 (`/api/auth/sync-session`).
+
+### 5.4 — `Promise.all` que rechaza deja `setLoading(false)` sin ejecutar
+
+**Síntoma:** spinner eterno cuando una de N queries falla.
+**Causa:** `setLoading(false)` solo en `.then()`, no en `.finally()`.
+**Fix:** siempre `try/finally` o `.finally(() => setLoading(false))`.
+
+### 5.5 — `supabase-js` `.single()` rechaza con `PGRST116` cuando no hay row
+
+**Fix:** usar `.maybeSingle()` cuando la row puede no existir.
+
+---
+
+## 6 · Stack y URLs vivas
+
+- **Repo:** https://github.com/zxy-vc/baw-os
+- **Producción:** https://baw-os.vercel.app
+- **Supabase project:** `zlcgxmllaeweypyodvzk`
+- **Org producción:** `BaW Operations` · slug `baw-operations` · id `81a011c4-4ea6-4b79-924d-73dbe6d35e14`
+- **Owner humano:** Fran Durán · `fran@zxy.vc` (prod) · `franduranv@gmail.com` (personal)
+- **Stack:** Next.js 14 App Router + TypeScript + Tailwind 3 + Supabase 2.43 + Vercel
+
+---
+
+## 7 · Cómo actualizar este archivo
+
+Cualquier agente que cierre un sprint, mergee un PR mayor, o descubra un nuevo patrón de bug:
+
+1. Edita la sección correspondiente de este archivo.
+2. Actualiza la fecha al inicio.
+3. Inclúyelo en el mismo PR que cierra el cambio (no PR separado).
+
+Si el cambio es grande (nuevo sprint, nueva arquitectura), también actualiza `AGENTS.md`.


### PR DESCRIPTION
## Multi-agent handoff: CLAUDE.md + PROJECT_STATE + MIGRATION_GUIDE + COLAB_ANDRES

### Por qué
Hasta ahora el contexto vivía en mi cabeza (Computer / Perplexity) y en el `AGENTS.md` un poco desfasado (última fecha 2026-04-30, pre Sprint 6). Cuando me migro a Claude Code, Codex, Cursor, o invito a Andrés (CTO OpenClaw), el agente arranca a ciegas y rompe invariantes.

Este PR establece **el contexto compartido en el repo**, así cualquier herramienta moderna que abre el folder lee el mismo briefing automáticamente (`CLAUDE.md` para Claude Code, `AGENTS.md` para Codex/Cursor/etc).

### Qué incluye

| Archivo | Audiencia | Contenido |
|---|---|---|
| `CLAUDE.md` (raíz) | Claude Code (CLI, VS Code, Desktop) | Apunta a `AGENTS.md`, agrega prompts de arranque, política de PRs, MCPs esperados |
| `docs/PROJECT_STATE.md` | Todos los agentes | Estado vivo: sprint cerrado, próximo sprint candidato, bugs conocidos, **patrones de bug ya documentados** (loading eterno con `useOrgContext`, race condition en login con `?next=`, cookies a medio setear, `Promise.all` sin `finally`, `.single()` vs `.maybeSingle()`) |
| `docs/MIGRATION_GUIDE.md` | Fran | Cómo arrancar una sesión en Claude Code (VS Code + Desktop), Codex, Cursor, y Perplexity Computer. Comparativa de cuándo usar cuál |
| `docs/COLAB_ANDRES.md` | Fran + Andrés | Protocolo para reabrir colaboración con Andrés. Hipótesis de por qué falló antes + reglas adicionales (1 tarea = 1 PR, plan en PR antes de código, solo Fran mergea, tiers de confianza warm-up → ownership) |
| `README.md` | Todos | Sección "Para agentes" con links a los 5 docs |

### No toca
- `AGENTS.md` (sigue siendo source of truth canónico, no lo duplico)
- Código de producción
- Migraciones, tokens, navegación

### QA
- `npx tsc --noEmit` ✅ (no hay cambios de código pero confirmé)
- Links internos verificados manualmente

### Próximo
Después de mergear, mandar a Andrés el bloque de onboarding de `COLAB_ANDRES.md` §2.2 cuando Fran quiera reabrir esa colaboración.
