### PR TITLE
feat(apply): public token-gated tenant application form (closes #21)

### DIFF
--- a/src/app/(public)/apply/[token]/ApplyForm.tsx
+++ b/src/app/(public)/apply/[token]/ApplyForm.tsx
@@ -1,0 +1,1031 @@
+'use client'
+
+// BaW OS — Formulario público de solicitud de arrendamiento (Client Component).
+//
+// - Estilo visual: BaW design tokens (`--baw-*`) + BawMark + BawGrid (regla
+//   canónica Sprint 6, ver AGENTS.md §2.2 y docs/PROJECT_STATE.md §4).
+// - Soporta los 5 tipos de contrato A/B/C/D/E:
+//     A — Individual                       (1 titular + aval)
+//     B — Coarrendatarios                  (2-4 titulares + aval)
+//     C — Empresa                          (empresa + representante)
+//     D — Tercero pagador                  (titular + tercero pagador)
+//     E — Institucional                    (empresa)
+// - Status:
+//     draft     → editable, botones "Guardar borrador" / "Enviar solicitud"
+//     submitted | reviewing | approved | rejected → pantalla read-only.
+// - Validación inline: nombre, apellido_paterno, email, telefono, RFC son
+//   obligatorios para CADA titular antes de permitir submit.
+// - Upload usa el endpoint existente `/api/intake/upload` que sube al bucket
+//   `tenant-docs` con service role; aquí no creamos buckets nuevos.
+
+import { useState, useCallback, useMemo } from 'react'
+import {
+  Loader2,
+  Upload,
+  CheckCircle2,
+  AlertCircle,
+  Plus,
+  Trash2,
+  FileText,
+  Send,
+  Save,
+} from 'lucide-react'
+import BawGrid from '@/components/BawGrid'
+import BawMark from '@/components/BawMark'
+import type {
+  TenantApplication,
+  Titular,
+  Aval,
+  ContractTypeCode,
+  DocType,
+} from '@/types'
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tipos y constantes locales
+// ──────────────────────────────────────────────────────────────────────────
+
+interface Empresa {
+  rfc: string
+  razon_social: string
+  representante_legal: string
+  domicilio_fiscal: string
+}
+
+interface TerceroPagador {
+  nombre: string
+  rfc: string
+  telefono: string
+  relacion: string
+}
+
+const EMPTY_TITULAR: Titular = {
+  nombre: '',
+  apellido_paterno: '',
+  apellido_materno: '',
+  curp: '',
+  rfc: '',
+  email: '',
+  telefono: '',
+  domicilio: '',
+  estado_civil: '',
+  nacionalidad: 'Mexicana',
+  fecha_nacimiento: '',
+  telefono_emergencia: '',
+}
+
+const EMPTY_AVAL: Aval = {
+  nombre: '',
+  rfc: '',
+  curp: '',
+  domicilio: '',
+  telefono: '',
+  relacion: '',
+}
+
+const EMPTY_EMPRESA: Empresa = {
+  rfc: '',
+  razon_social: '',
+  representante_legal: '',
+  domicilio_fiscal: '',
+}
+
+const EMPTY_TERCERO: TerceroPagador = {
+  nombre: '',
+  rfc: '',
+  telefono: '',
+  relacion: '',
+}
+
+const CONTRACT_TYPES: { code: ContractTypeCode; label: string; desc: string }[] = [
+  { code: 'A', label: 'A · Individual', desc: '1 titular con aval' },
+  { code: 'B', label: 'B · Coarrendatarios', desc: '2 a 4 titulares + aval' },
+  { code: 'C', label: 'C · Empresa', desc: 'Persona moral arrendataria' },
+  { code: 'D', label: 'D · Tercero pagador', desc: 'Titular + tercero que paga' },
+  { code: 'E', label: 'E · Institucional', desc: 'Empresa institucional' },
+]
+
+const DOC_BASE: { key: DocType; label: string; required: boolean }[] = [
+  { key: 'ine_front', label: 'INE — Frente', required: true },
+  { key: 'ine_back', label: 'INE — Reverso', required: true },
+  { key: 'income_proof', label: 'Comprobante de ingresos', required: false },
+  { key: 'domicilio_proof', label: 'Comprobante de domicilio', required: false },
+]
+
+const DOC_AVAL: { key: DocType; label: string; required: boolean }[] = [
+  { key: 'aval_ine', label: 'INE del aval', required: true },
+  { key: 'aval_domicilio_proof', label: 'Comprobante de domicilio del aval', required: false },
+]
+
+const READONLY_STATUSES: TenantApplication['status'][] = [
+  'submitted',
+  'reviewing',
+  'approved',
+  'rejected',
+]
+
+// ──────────────────────────────────────────────────────────────────────────
+// Componente principal
+// ──────────────────────────────────────────────────────────────────────────
+
+export default function ApplyForm({
+  initialData,
+}: {
+  initialData: TenantApplication
+}) {
+  const isReadonly = READONLY_STATUSES.includes(initialData.status)
+
+  const [contractType, setContractType] = useState<ContractTypeCode | null>(
+    initialData.contract_type
+  )
+  const [titulares, setTitulares] = useState<Titular[]>(
+    initialData.titulares?.length ? initialData.titulares : [{ ...EMPTY_TITULAR }]
+  )
+  const [avales, setAvales] = useState<Aval[]>(
+    initialData.avales?.length ? initialData.avales : [{ ...EMPTY_AVAL }]
+  )
+  const [empresa, setEmpresa] = useState<Empresa>(
+    (initialData.empresa as unknown as Empresa) ?? { ...EMPTY_EMPRESA }
+  )
+  const [tercero, setTercero] = useState<TerceroPagador>(
+    (initialData.tercero_pagador as unknown as TerceroPagador) ?? { ...EMPTY_TERCERO }
+  )
+  const [docs, setDocs] = useState<Partial<Record<DocType, string>>>(
+    initialData.docs ?? {}
+  )
+
+  const [saving, setSaving] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(initialData.status !== 'draft')
+  const [savedAt, setSavedAt] = useState<Date | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const showAvales = contractType === 'A' || contractType === 'B'
+  const showEmpresa = contractType === 'C' || contractType === 'E'
+  const showTercero = contractType === 'D'
+  const titulareLimit = contractType === 'B' ? 4 : 1
+
+  // ────────────────────────────────────────────────────────────────────
+  // Handlers de mutación
+  // ────────────────────────────────────────────────────────────────────
+
+  function updateTitular(idx: number, field: keyof Titular, value: string) {
+    setTitulares((prev) =>
+      prev.map((t, i) => (i === idx ? { ...t, [field]: value } : t))
+    )
+  }
+
+  function addTitular() {
+    if (titulares.length >= titulareLimit) return
+    setTitulares((prev) => [...prev, { ...EMPTY_TITULAR }])
+  }
+
+  function removeTitular(idx: number) {
+    if (titulares.length <= 1) return
+    setTitulares((prev) => prev.filter((_, i) => i !== idx))
+  }
+
+  function updateAval(idx: number, field: keyof Aval, value: string) {
+    setAvales((prev) =>
+      prev.map((a, i) => (i === idx ? { ...a, [field]: value } : a))
+    )
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // Validación
+  // ────────────────────────────────────────────────────────────────────
+
+  function validate(): boolean {
+    const next: Record<string, string> = {}
+
+    if (!contractType) {
+      next['contract_type'] = 'Selecciona el tipo de contrato'
+    }
+
+    titulares.forEach((t, i) => {
+      if (!t.nombre.trim()) next[`titular.${i}.nombre`] = 'Requerido'
+      if (!t.apellido_paterno.trim())
+        next[`titular.${i}.apellido_paterno`] = 'Requerido'
+      if (!t.email.trim()) next[`titular.${i}.email`] = 'Requerido'
+      if (!t.telefono.trim()) next[`titular.${i}.telefono`] = 'Requerido'
+      if (!t.rfc.trim()) next[`titular.${i}.rfc`] = 'Requerido'
+    })
+
+    if (showEmpresa) {
+      if (!empresa.rfc.trim()) next['empresa.rfc'] = 'Requerido'
+      if (!empresa.razon_social.trim()) next['empresa.razon_social'] = 'Requerido'
+    }
+
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // Persistencia (API /api/intake)
+  // ────────────────────────────────────────────────────────────────────
+
+  const buildPayload = useCallback(
+    (submit = false) => ({
+      titulares,
+      avales: showAvales ? avales : [],
+      contract_type: contractType,
+      contract_data: {},
+      docs,
+      ...(showEmpresa ? { empresa } : {}),
+      ...(showTercero ? { tercero_pagador: tercero } : {}),
+      submit,
+    }),
+    [titulares, avales, showAvales, contractType, docs, empresa, showEmpresa, tercero, showTercero]
+  )
+
+  async function handleSaveDraft() {
+    if (isReadonly) return
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch(
+        `/api/intake?token=${encodeURIComponent(initialData.token)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(buildPayload(false)),
+        }
+      )
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        setError(json.error || 'No se pudo guardar el borrador')
+        return
+      }
+      setSavedAt(new Date())
+    } catch {
+      setError('Error de conexión al guardar')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleSubmit() {
+    if (isReadonly) return
+    if (!validate()) {
+      setError('Completa los campos marcados antes de enviar')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch(
+        `/api/intake?token=${encodeURIComponent(initialData.token)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(buildPayload(true)),
+        }
+      )
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        setError(json.error || 'No se pudo enviar la solicitud')
+        return
+      }
+      setSubmitted(true)
+    } catch {
+      setError('Error de conexión al enviar')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleUpload(docType: DocType, file: File) {
+    if (isReadonly) return
+    const fd = new FormData()
+    fd.append('file', file)
+    fd.append('docType', docType)
+    fd.append('token', initialData.token)
+    try {
+      const res = await fetch('/api/intake/upload', { method: 'POST', body: fd })
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        setError(json.error || `No se pudo subir ${docType}`)
+        return
+      }
+      setDocs((prev) => ({ ...prev, [docType]: json.data.url }))
+    } catch {
+      setError('Error de conexión al subir el archivo')
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // Render
+  // ────────────────────────────────────────────────────────────────────
+
+  if (submitted) {
+    return <SubmittedScreen status={initialData.status} />
+  }
+
+  return (
+    <div
+      className="relative min-h-screen"
+      style={{ backgroundColor: 'var(--baw-bg)', color: 'var(--baw-text)' }}
+    >
+      <BawGrid position="fixed" />
+
+      <div className="relative max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+        {/* Header — mismo tratamiento que /login: BawMark A + wordmark + tagline */}
+        <header className="flex flex-col items-center text-center mb-10">
+          <div style={{ color: 'var(--baw-text)' }} className="mb-3">
+            <BawMark size={48} withWordmark wordmarkSize="lg" />
+          </div>
+          <p
+            style={{ fontFamily: 'var(--font-mono)', color: 'var(--baw-muted)' }}
+            className="text-[11px] uppercase tracking-[0.18em]"
+          >
+            Solicitud de Arrendamiento
+          </p>
+        </header>
+
+        {/* Sección: Tipo de contrato */}
+        <Section title="Tipo de contrato" subtitle="Selecciona el escenario que aplica a tu solicitud">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {CONTRACT_TYPES.map((opt) => {
+              const active = contractType === opt.code
+              return (
+                <button
+                  key={opt.code}
+                  type="button"
+                  disabled={isReadonly}
+                  onClick={() => setContractType(opt.code)}
+                  className="text-left rounded-md px-4 py-3 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                  style={{
+                    backgroundColor: active
+                      ? 'var(--baw-info-bg-soft)'
+                      : 'var(--baw-surface)',
+                    border: `1px solid ${
+                      active ? 'var(--baw-info-fg)' : 'var(--baw-border)'
+                    }`,
+                  }}
+                >
+                  <div
+                    className="text-sm font-semibold"
+                    style={{ color: 'var(--baw-text)' }}
+                  >
+                    {opt.label}
+                  </div>
+                  <div
+                    className="text-[12px] mt-0.5"
+                    style={{ color: 'var(--baw-muted)' }}
+                  >
+                    {opt.desc}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+          {errors['contract_type'] && (
+            <FieldError msg={errors['contract_type']} />
+          )}
+        </Section>
+
+        {/* Sección: Titulares */}
+        {contractType && (
+          <Section
+            title={contractType === 'B' ? 'Titulares (1 a 4)' : 'Titular'}
+            subtitle={
+              contractType === 'B'
+                ? 'Agrega cada coarrendatario que firmará el contrato'
+                : 'Datos personales de la persona que firmará el contrato'
+            }
+            action={
+              contractType === 'B' && titulares.length < titulareLimit && !isReadonly ? (
+                <button
+                  type="button"
+                  onClick={addTitular}
+                  className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-md transition-colors"
+                  style={{
+                    backgroundColor: 'var(--baw-surface)',
+                    color: 'var(--baw-text)',
+                    border: '1px solid var(--baw-border)',
+                  }}
+                >
+                  <Plus className="w-3.5 h-3.5" />
+                  Agregar titular
+                </button>
+              ) : undefined
+            }
+          >
+            <div className="space-y-6">
+              {titulares.map((t, idx) => (
+                <TitularBlock
+                  key={idx}
+                  idx={idx}
+                  titular={t}
+                  errors={errors}
+                  readonly={isReadonly}
+                  showRemove={titulares.length > 1 && !isReadonly}
+                  onChange={(field, value) => updateTitular(idx, field, value)}
+                  onRemove={() => removeTitular(idx)}
+                />
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {/* Sección: Empresa (Tipo C/E) */}
+        {contractType && showEmpresa && (
+          <Section
+            title="Datos de la empresa"
+            subtitle="Persona moral que figura como arrendataria"
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Field
+                label="RFC empresa"
+                required
+                value={empresa.rfc}
+                error={errors['empresa.rfc']}
+                readonly={isReadonly}
+                onChange={(v) => setEmpresa({ ...empresa, rfc: v })}
+              />
+              <Field
+                label="Razón social"
+                required
+                value={empresa.razon_social}
+                error={errors['empresa.razon_social']}
+                readonly={isReadonly}
+                onChange={(v) => setEmpresa({ ...empresa, razon_social: v })}
+              />
+              <Field
+                label="Representante legal"
+                value={empresa.representante_legal}
+                readonly={isReadonly}
+                onChange={(v) =>
+                  setEmpresa({ ...empresa, representante_legal: v })
+                }
+              />
+              <Field
+                label="Domicilio fiscal"
+                value={empresa.domicilio_fiscal}
+                readonly={isReadonly}
+                onChange={(v) => setEmpresa({ ...empresa, domicilio_fiscal: v })}
+                colSpan={2}
+              />
+            </div>
+          </Section>
+        )}
+
+        {/* Sección: Tercero pagador (Tipo D) */}
+        {contractType && showTercero && (
+          <Section
+            title="Tercero pagador"
+            subtitle="Persona o entidad que cubre las rentas en nombre del titular"
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Field
+                label="Nombre / razón social"
+                value={tercero.nombre}
+                readonly={isReadonly}
+                onChange={(v) => setTercero({ ...tercero, nombre: v })}
+              />
+              <Field
+                label="RFC"
+                value={tercero.rfc}
+                readonly={isReadonly}
+                onChange={(v) => setTercero({ ...tercero, rfc: v })}
+              />
+              <Field
+                label="Teléfono"
+                value={tercero.telefono}
+                readonly={isReadonly}
+                onChange={(v) => setTercero({ ...tercero, telefono: v })}
+              />
+              <Field
+                label="Relación con el titular"
+                value={tercero.relacion}
+                readonly={isReadonly}
+                onChange={(v) => setTercero({ ...tercero, relacion: v })}
+              />
+            </div>
+          </Section>
+        )}
+
+        {/* Sección: Avales (Tipo A/B) */}
+        {contractType && showAvales && (
+          <Section
+            title="Aval"
+            subtitle="Persona que respalda solidariamente el contrato"
+          >
+            {avales.map((a, idx) => (
+              <AvalBlock
+                key={idx}
+                aval={a}
+                readonly={isReadonly}
+                onChange={(field, value) => updateAval(idx, field, value)}
+              />
+            ))}
+          </Section>
+        )}
+
+        {/* Sección: Documentos */}
+        {contractType && (
+          <Section
+            title="Documentos"
+            subtitle="Sube fotografías o PDFs claros y legibles"
+          >
+            <div className="space-y-3">
+              {DOC_BASE.map((d) => (
+                <DocUploader
+                  key={d.key}
+                  docKey={d.key}
+                  label={d.label}
+                  required={d.required}
+                  uploaded={!!docs[d.key]}
+                  readonly={isReadonly}
+                  onUpload={(file) => handleUpload(d.key, file)}
+                />
+              ))}
+              {showAvales &&
+                DOC_AVAL.map((d) => (
+                  <DocUploader
+                    key={d.key}
+                    docKey={d.key}
+                    label={d.label}
+                    required={d.required}
+                    uploaded={!!docs[d.key]}
+                    readonly={isReadonly}
+                    onUpload={(file) => handleUpload(d.key, file)}
+                  />
+                ))}
+            </div>
+          </Section>
+        )}
+
+        {/* Banner de error global */}
+        {error && (
+          <div
+            className="mb-6 rounded-md px-4 py-3 text-sm flex items-start gap-2"
+            style={{
+              backgroundColor: 'var(--baw-danger-bg-soft)',
+              border: '1px solid var(--baw-danger-border)',
+              color: 'var(--baw-danger-fg)',
+            }}
+          >
+            <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Actions */}
+        {!isReadonly && (
+          <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-3 mt-2">
+            <div
+              className="text-[11px]"
+              style={{ color: 'var(--baw-faint)', fontFamily: 'var(--font-mono)' }}
+            >
+              {savedAt
+                ? `Borrador guardado · ${savedAt.toLocaleTimeString('es-MX')}`
+                : 'Tus cambios no se guardan automáticamente'}
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleSaveDraft}
+                disabled={saving || submitting}
+                className="inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-md text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{
+                  backgroundColor: 'var(--baw-surface)',
+                  color: 'var(--baw-text)',
+                  border: '1px solid var(--baw-border)',
+                }}
+              >
+                {saving ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Save className="w-4 h-4" />
+                )}
+                Guardar borrador
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={saving || submitting}
+                className="inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-md text-sm font-semibold transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{
+                  backgroundColor: 'var(--baw-text)',
+                  color: 'var(--baw-bg)',
+                }}
+              >
+                {submitting ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Send className="w-4 h-4" />
+                )}
+                Enviar solicitud
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Footer */}
+        <p
+          style={{ fontFamily: 'var(--font-mono)', color: 'var(--baw-faint)' }}
+          className="text-center text-[10px] uppercase tracking-[0.2em] mt-12"
+        >
+          BaW Design Lab · ZXY Ventures
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Subcomponentes presentacionales
+// ──────────────────────────────────────────────────────────────────────────
+
+function Section({
+  title,
+  subtitle,
+  action,
+  children,
+}: {
+  title: string
+  subtitle?: string
+  action?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <section
+      className="rounded-md mb-6 p-5 sm:p-6"
+      style={{
+        backgroundColor: 'var(--baw-surface)',
+        border: '1px solid var(--baw-border)',
+      }}
+    >
+      <div className="flex items-start justify-between gap-3 mb-5">
+        <div>
+          <h2
+            className="text-[15px] font-semibold tracking-tight"
+            style={{ color: 'var(--baw-text)' }}
+          >
+            {title}
+          </h2>
+          {subtitle && (
+            <p
+              className="text-[12px] mt-0.5"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              {subtitle}
+            </p>
+          )}
+        </div>
+        {action}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function TitularBlock({
+  idx,
+  titular,
+  errors,
+  readonly,
+  showRemove,
+  onChange,
+  onRemove,
+}: {
+  idx: number
+  titular: Titular
+  errors: Record<string, string>
+  readonly: boolean
+  showRemove: boolean
+  onChange: (field: keyof Titular, value: string) => void
+  onRemove: () => void
+}) {
+  const fields = useMemo<
+    { key: keyof Titular; label: string; required?: boolean; type?: string }[]
+  >(
+    () => [
+      { key: 'nombre', label: 'Nombre(s)', required: true },
+      { key: 'apellido_paterno', label: 'Apellido paterno', required: true },
+      { key: 'apellido_materno', label: 'Apellido materno' },
+      { key: 'email', label: 'Email', required: true, type: 'email' },
+      { key: 'telefono', label: 'Teléfono', required: true, type: 'tel' },
+      { key: 'rfc', label: 'RFC', required: true },
+      { key: 'curp', label: 'CURP' },
+      { key: 'fecha_nacimiento', label: 'Fecha de nacimiento', type: 'date' },
+      { key: 'estado_civil', label: 'Estado civil' },
+      { key: 'nacionalidad', label: 'Nacionalidad' },
+    ],
+    []
+  )
+
+  return (
+    <div
+      className="rounded-md p-4"
+      style={{
+        backgroundColor: 'var(--baw-elevated)',
+        border: '1px solid var(--baw-border)',
+      }}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            color: 'var(--baw-muted)',
+          }}
+          className="text-[11px] uppercase tracking-wider"
+        >
+          Titular {idx + 1}
+        </span>
+        {showRemove && (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded transition-colors"
+            style={{ color: 'var(--baw-danger-fg)' }}
+            title="Quitar titular"
+          >
+            <Trash2 className="w-3.5 h-3.5" /> Quitar
+          </button>
+        )}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {fields.map((f) => (
+          <Field
+            key={f.key}
+            label={f.label}
+            required={f.required}
+            type={f.type ?? 'text'}
+            value={titular[f.key] as string}
+            readonly={readonly}
+            error={errors[`titular.${idx}.${f.key}`]}
+            onChange={(v) => onChange(f.key, v)}
+          />
+        ))}
+        <Field
+          label="Domicilio actual"
+          value={titular.domicilio}
+          readonly={readonly}
+          onChange={(v) => onChange('domicilio', v)}
+          colSpan={2}
+        />
+      </div>
+    </div>
+  )
+}
+
+function AvalBlock({
+  aval,
+  readonly,
+  onChange,
+}: {
+  aval: Aval
+  readonly: boolean
+  onChange: (field: keyof Aval, value: string) => void
+}) {
+  const fields: { key: keyof Aval; label: string; required?: boolean }[] = [
+    { key: 'nombre', label: 'Nombre completo', required: true },
+    { key: 'rfc', label: 'RFC' },
+    { key: 'curp', label: 'CURP' },
+    { key: 'telefono', label: 'Teléfono', required: true },
+    { key: 'relacion', label: 'Relación con el titular' },
+  ]
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      {fields.map((f) => (
+        <Field
+          key={f.key}
+          label={f.label}
+          required={f.required}
+          value={aval[f.key]}
+          readonly={readonly}
+          onChange={(v) => onChange(f.key, v)}
+        />
+      ))}
+      <Field
+        label="Domicilio del aval"
+        value={aval.domicilio}
+        readonly={readonly}
+        onChange={(v) => onChange('domicilio', v)}
+        colSpan={2}
+      />
+    </div>
+  )
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  required,
+  type = 'text',
+  error,
+  readonly,
+  colSpan,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  required?: boolean
+  type?: string
+  error?: string
+  readonly?: boolean
+  colSpan?: 1 | 2
+}) {
+  return (
+    <div className={colSpan === 2 ? 'sm:col-span-2' : ''}>
+      <label
+        style={{ fontFamily: 'var(--font-mono)', color: 'var(--baw-muted)' }}
+        className="block text-[10px] uppercase tracking-wider mb-1.5"
+      >
+        {label}
+        {required && (
+          <span style={{ color: 'var(--baw-danger-fg)' }} className="ml-1">
+            *
+          </span>
+        )}
+      </label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={readonly}
+        className="w-full px-3 py-2 rounded-md text-sm transition-colors focus:outline-none focus:ring-2 disabled:opacity-70"
+        style={{
+          backgroundColor: 'var(--baw-bg)',
+          color: 'var(--baw-text)',
+          border: `1px solid ${
+            error ? 'var(--baw-danger-border)' : 'var(--baw-border)'
+          }`,
+        }}
+      />
+      {error && <FieldError msg={error} />}
+    </div>
+  )
+}
+
+function FieldError({ msg }: { msg: string }) {
+  return (
+    <p
+      className="mt-1 text-[11px]"
+      style={{ color: 'var(--baw-danger-fg)' }}
+    >
+      {msg}
+    </p>
+  )
+}
+
+function DocUploader({
+  docKey,
+  label,
+  required,
+  uploaded,
+  readonly,
+  onUpload,
+}: {
+  docKey: DocType
+  label: string
+  required: boolean
+  uploaded: boolean
+  readonly: boolean
+  onUpload: (file: File) => Promise<void> | void
+}) {
+  const [busy, setBusy] = useState(false)
+  return (
+    <label
+      className="flex items-center gap-3 px-4 py-3 rounded-md cursor-pointer transition-colors"
+      style={{
+        backgroundColor: uploaded
+          ? 'var(--baw-success-bg-soft)'
+          : 'var(--baw-elevated)',
+        border: `1px solid ${
+          uploaded ? 'var(--baw-success-border)' : 'var(--baw-border)'
+        }`,
+        opacity: readonly ? 0.7 : 1,
+        cursor: readonly ? 'not-allowed' : 'pointer',
+      }}
+    >
+      <div
+        className="w-9 h-9 rounded-md flex items-center justify-center shrink-0"
+        style={{
+          backgroundColor: uploaded ? 'var(--baw-success-bg)' : 'var(--baw-surface)',
+          color: uploaded ? 'var(--baw-success-fg)' : 'var(--baw-muted)',
+        }}
+      >
+        {busy ? (
+          <Loader2 className="w-4 h-4 animate-spin" />
+        ) : uploaded ? (
+          <CheckCircle2 className="w-4 h-4" />
+        ) : (
+          <Upload className="w-4 h-4" />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p
+          className="text-sm font-medium truncate"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          {label}
+          {required && (
+            <span style={{ color: 'var(--baw-danger-fg)' }} className="ml-1">
+              *
+            </span>
+          )}
+        </p>
+        <p
+          className="text-[11px]"
+          style={{ color: 'var(--baw-muted)' }}
+        >
+          {uploaded ? 'Archivo cargado' : 'PDF, JPG o PNG'}
+        </p>
+      </div>
+      <input
+        type="file"
+        className="hidden"
+        accept="image/*,.pdf"
+        disabled={readonly || busy}
+        data-doc-key={docKey}
+        onChange={async (e) => {
+          const file = e.target.files?.[0]
+          if (!file) return
+          setBusy(true)
+          try {
+            await onUpload(file)
+          } finally {
+            setBusy(false)
+          }
+        }}
+      />
+    </label>
+  )
+}
+
+function SubmittedScreen({
+  status,
+}: {
+  status: TenantApplication['status']
+}) {
+  const messages: Record<TenantApplication['status'], { title: string; body: string }> = {
+    draft: {
+      title: 'Solicitud guardada',
+      body: 'Tu borrador está guardado. Vuelve cuando estés listo para enviar.',
+    },
+    submitted: {
+      title: 'Recibimos tu solicitud',
+      body: 'Tus datos llegaron correctamente. Te contactaremos pronto para los siguientes pasos.',
+    },
+    reviewing: {
+      title: 'Tu solicitud está en revisión',
+      body: 'Estamos analizando los documentos. Te avisaremos en cuanto tengamos novedades.',
+    },
+    approved: {
+      title: 'Solicitud aprobada',
+      body: 'Tu solicitud fue aprobada. El property manager se pondrá en contacto contigo para firmar el contrato.',
+    },
+    rejected: {
+      title: 'Solicitud no aprobada',
+      body: 'Tu solicitud no procedió en esta ocasión. Si tienes dudas, contacta al property manager.',
+    },
+  }
+  const msg = messages[status] ?? messages.submitted
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ backgroundColor: 'var(--baw-bg)' }}
+    >
+      <BawGrid position="absolute" />
+      <div className="relative w-full max-w-md mx-auto px-6 text-center">
+        <div
+          className="flex justify-center mb-10"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          <BawMark size={48} withWordmark wordmarkSize="lg" />
+        </div>
+        <div
+          className="w-12 h-12 rounded-full mx-auto mb-5 flex items-center justify-center"
+          style={{
+            backgroundColor: 'var(--baw-success-bg)',
+            color: 'var(--baw-success-fg)',
+          }}
+        >
+          <FileText className="w-5 h-5" />
+        </div>
+        <h1
+          className="text-[20px] font-semibold mb-3 tracking-tight"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          {msg.title}
+        </h1>
+        <p
+          className="text-sm leading-relaxed mb-8"
+          style={{ color: 'var(--baw-muted)' }}
+        >
+          {msg.body}
+        </p>
+        <p
+          style={{ fontFamily: 'var(--font-mono)', color: 'var(--baw-faint)' }}
+          className="text-[10px] uppercase tracking-[0.2em]"
+        >
+          BaW OS · Property Management
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(public)/apply/[token]/layout.tsx
+++ b/src/app/(public)/apply/[token]/layout.tsx
@@ -1,0 +1,12 @@
+// BaW OS — Layout de la solicitud pública de arrendamiento.
+// Vive dentro del route group `(public)` (sin AppShell). Pasa-through:
+// el chrome (BawGrid + BawMark) lo dibuja cada page para mantener
+// consistencia con /login y not-found.tsx.
+
+export default function ApplyTokenLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <>{children}</>
+}

--- a/src/app/(public)/apply/[token]/not-found.tsx
+++ b/src/app/(public)/apply/[token]/not-found.tsx
@@ -1,0 +1,44 @@
+// BaW OS — Token de solicitud inválido o expirado
+import BawGrid from '@/components/BawGrid'
+import BawMark from '@/components/BawMark'
+
+export default function ApplyTokenNotFound() {
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ backgroundColor: 'var(--baw-bg)' }}
+    >
+      <BawGrid position="absolute" />
+      <div className="relative w-full max-w-md mx-auto px-6 text-center">
+        <div
+          className="flex justify-center mb-10"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          <BawMark size={48} withWordmark wordmarkSize="lg" />
+        </div>
+
+        <h1
+          className="text-[20px] font-semibold mb-3 tracking-tight"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Este link ya no es válido
+        </h1>
+
+        <p
+          className="text-sm leading-relaxed mb-8"
+          style={{ color: 'var(--baw-muted)' }}
+        >
+          El link de invitación que abriste expiró o ya no existe. Pídele a tu
+          arrendador o property manager que te genere uno nuevo.
+        </p>
+
+        <p
+          style={{ fontFamily: 'var(--font-mono)', color: 'var(--baw-faint)' }}
+          className="text-[10px] uppercase tracking-[0.2em]"
+        >
+          BaW OS · Property Management
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(public)/apply/[token]/page.tsx
+++ b/src/app/(public)/apply/[token]/page.tsx
@@ -1,497 +1,78 @@
-'use client'
+// BaW OS — Solicitud pública de arrendamiento (Server Component)
+//
+// Carga la aplicación por `token` con el cliente anon de Supabase (RLS permite
+// SELECT a anon, ver migration 20260404_tenant_intake.sql líneas 51-61).
+//
+// - Si el token no existe → notFound() (renderea not-found.tsx)
+// - Si la tabla no existe en este entorno → schemaMissing fallback (mismo
+//   patrón que /applications). Esto evita romper preview deploys donde la
+//   migración aún no fue aplicada.
+// - Si todo OK → pasa la row inicial al Client Component <ApplyForm/>.
 
-import { useEffect, useState, useCallback } from 'react'
-import { useParams } from 'next/navigation'
-import { Upload, CheckCircle2, Loader2, AlertCircle, User, FileText, Shield, Send } from 'lucide-react'
-import type { Titular, Aval, DocType } from '@/types'
+import { notFound } from 'next/navigation'
+import { createSupabaseServer } from '@/lib/supabase-server'
+import type { TenantApplication } from '@/types'
+import ApplyForm from './ApplyForm'
+import BawGrid from '@/components/BawGrid'
+import BawMark from '@/components/BawMark'
 
-// --------------- Tipos locales ---------------
-
-type Step = 1 | 2 | 3 | 4
-
-interface FormState {
-  titular: Titular
-  docs: Partial<Record<DocType, string>>
-  aval: Aval
+interface PageProps {
+  params: { token: string }
 }
 
-const EMPTY_TITULAR: Titular = {
-  nombre: '', apellido_paterno: '', apellido_materno: '',
-  curp: '', rfc: '', email: '', telefono: '',
-  domicilio: '', estado_civil: '', nacionalidad: 'Mexicana',
-  fecha_nacimiento: '', telefono_emergencia: '',
-}
+export const dynamic = 'force-dynamic'
 
-const EMPTY_AVAL: Aval = {
-  nombre: '', rfc: '', curp: '', domicilio: '', telefono: '', relacion: '',
-}
+export default async function ApplyPage({ params }: PageProps) {
+  const { token } = params
+  const supabase = createSupabaseServer()
 
-const STEPS: { num: Step; label: string; icon: typeof User }[] = [
-  { num: 1, label: 'Datos personales', icon: User },
-  { num: 2, label: 'Documentos', icon: FileText },
-  { num: 3, label: 'Datos del aval', icon: Shield },
-  { num: 4, label: 'Confirmación', icon: Send },
-]
-
-// --------------- Componente principal ---------------
-
-export default function ApplyPage() {
-  const { token } = useParams<{ token: string }>()
-  const [step, setStep] = useState<Step>(1)
-  const [loading, setLoading] = useState(true)
-  const [submitting, setSubmitting] = useState(false)
-  const [submitted, setSubmitted] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [appId, setAppId] = useState<string | null>(null)
-
-  const [form, setForm] = useState<FormState>({
-    titular: { ...EMPTY_TITULAR },
-    docs: {},
-    aval: { ...EMPTY_AVAL },
-  })
-
-  // Cargar datos existentes
-  const fetchApp = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/intake?token=${token}`)
-      const json = await res.json()
-      if (!json.success) {
-        setError(json.error || 'No se pudo cargar la aplicación')
-        setLoading(false)
-        return
-      }
-      setAppId(json.data.id)
-      // Pre-llenar si hay datos previos
-      if (json.data.titulares?.length > 0) {
-        setForm(prev => ({ ...prev, titular: json.data.titulares[0] }))
-      }
-      if (json.data.avales?.length > 0) {
-        setForm(prev => ({ ...prev, aval: json.data.avales[0] }))
-      }
-      if (json.data.docs) {
-        setForm(prev => ({ ...prev, docs: json.data.docs }))
-      }
-    } catch {
-      setError('Error de conexión')
-    } finally {
-      setLoading(false)
-    }
-  }, [token])
-
-  useEffect(() => { fetchApp() }, [fetchApp])
-
-  // --------------- Handlers ---------------
-
-  function updateTitular(field: keyof Titular, value: string) {
-    setForm(prev => ({ ...prev, titular: { ...prev.titular, [field]: value } }))
-  }
-
-  function updateAval(field: keyof Aval, value: string) {
-    setForm(prev => ({ ...prev, aval: { ...prev.aval, [field]: value } }))
-  }
-
-  async function handleUpload(docType: DocType, file: File) {
-    const fd = new FormData()
-    fd.append('file', file)
-    fd.append('docType', docType)
-    fd.append('token', token)
-
-    try {
-      const res = await fetch('/api/intake/upload', { method: 'POST', body: fd })
-      const json = await res.json()
-      if (json.success) {
-        setForm(prev => ({ ...prev, docs: { ...prev.docs, [docType]: json.data.url } }))
-      }
-    } catch {
-      // silently fail, user can retry
-    }
-  }
-
-  async function handleSubmit() {
-    setSubmitting(true)
-    try {
-      const res = await fetch(`/api/intake?token=${token}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          titulares: [form.titular],
-          avales: [form.aval],
-          contract_data: {},
-          docs: form.docs,
-          submit: true,
-        }),
-      })
-      const json = await res.json()
-      if (json.success) {
-        setSubmitted(true)
-      } else {
-        setError(json.error || 'Error al enviar')
-      }
-    } catch {
-      setError('Error de conexión')
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
-  function canAdvance(): boolean {
-    if (step === 1) {
-      const t = form.titular
-      return !!(t.nombre && t.apellido_paterno && t.curp && t.email && t.telefono)
-    }
-    if (step === 2) {
-      return !!(form.docs.ine_front && form.docs.ine_back)
-    }
-    if (step === 3) {
-      const a = form.aval
-      return !!(a.nombre && a.telefono)
-    }
-    return true
-  }
-
-  // --------------- Loading / Error / Submitted states ---------------
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-gray-400" />
-      </div>
+  const { data, error } = await supabase
+    .from('tenant_applications')
+    .select(
+      'id, org_id, unit_id, contract_type, status, token, titulares, avales, contract_data, empresa, tercero_pagador, docs, submitted_at, reviewed_by, reviewed_at, notes, created_at, updated_at'
     )
+    .eq('token', token)
+    .maybeSingle()
+
+  // Tabla no existe (preview deploy sin migración aplicada)
+  if (error && /tenant_applications/i.test(error.message)) {
+    return <SchemaMissingScreen />
   }
 
-  if (error && !appId) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 max-w-md w-full text-center">
-          <AlertCircle className="w-12 h-12 text-red-400 mx-auto mb-4" />
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">No se pudo cargar</h2>
-          <p className="text-sm text-gray-500">{error}</p>
+  if (!data) {
+    notFound()
+  }
+
+  return <ApplyForm initialData={data as TenantApplication} />
+}
+
+function SchemaMissingScreen() {
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ backgroundColor: 'var(--baw-bg)' }}
+    >
+      <BawGrid position="absolute" />
+      <div className="relative w-full max-w-md mx-auto px-6 text-center">
+        <div className="flex justify-center mb-8" style={{ color: 'var(--baw-text)' }}>
+          <BawMark size={48} withWordmark wordmarkSize="lg" />
         </div>
-      </div>
-    )
-  }
-
-  if (submitted) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 max-w-md w-full text-center">
-          <CheckCircle2 className="w-16 h-16 text-emerald-500 mx-auto mb-4" />
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">Solicitud enviada</h2>
-          <p className="text-sm text-gray-500">
-            Tus datos han sido recibidos. Nos pondremos en contacto contigo pronto.
+        <div
+          className="rounded-md p-6 text-left"
+          style={{
+            backgroundColor: 'var(--baw-danger-bg-soft)',
+            border: '1px solid var(--baw-danger-border)',
+            color: 'var(--baw-danger-fg)',
+          }}
+        >
+          <h2 className="text-sm font-semibold mb-2">Solicitudes no habilitadas</h2>
+          <p className="text-xs leading-relaxed">
+            La base de datos conectada todavía no tiene la tabla{' '}
+            <code className="font-mono">tenant_applications</code>. Falta aplicar la
+            migración de tenant intake en este entorno.
           </p>
         </div>
       </div>
-    )
-  }
-
-  // --------------- Render ---------------
-
-  return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 px-4 py-4">
-        <div className="max-w-2xl mx-auto flex items-center gap-3">
-          <div className="w-8 h-8 rounded-lg bg-gray-900 flex items-center justify-center font-bold text-sm text-white">B</div>
-          <div>
-            <h1 className="text-base font-semibold text-gray-900">Solicitud de Arrendamiento</h1>
-            <p className="text-xs text-gray-400">BaW Property Management</p>
-          </div>
-        </div>
-      </header>
-
-      {/* Stepper */}
-      <div className="bg-white border-b border-gray-200 px-4 py-3">
-        <div className="max-w-2xl mx-auto flex items-center justify-between">
-          {STEPS.map((s) => (
-            <button
-              key={s.num}
-              onClick={() => s.num < step && setStep(s.num)}
-              className={`flex items-center gap-2 text-xs font-medium transition-colors ${
-                s.num === step
-                  ? 'text-gray-900'
-                  : s.num < step
-                    ? 'text-emerald-600 cursor-pointer'
-                    : 'text-gray-300'
-              }`}
-            >
-              <span className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold border-2 ${
-                s.num === step
-                  ? 'border-gray-900 bg-gray-900 text-white'
-                  : s.num < step
-                    ? 'border-emerald-500 bg-emerald-500 text-white'
-                    : 'border-gray-200 text-gray-300'
-              }`}>
-                {s.num < step ? <CheckCircle2 className="w-4 h-4" /> : s.num}
-              </span>
-              <span className="hidden sm:inline">{s.label}</span>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Content */}
-      <div className="max-w-2xl mx-auto p-4 pt-6">
-        {step === 1 && <StepDatosPersonales titular={form.titular} onChange={updateTitular} />}
-        {step === 2 && <StepDocumentos docs={form.docs} onUpload={handleUpload} />}
-        {step === 3 && <StepAval aval={form.aval} onChange={updateAval} docs={form.docs} onUpload={handleUpload} />}
-        {step === 4 && <StepConfirmacion form={form} />}
-
-        {/* Error banner */}
-        {error && (
-          <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
-            {error}
-          </div>
-        )}
-
-        {/* Navigation */}
-        <div className="flex justify-between mt-6 pb-8">
-          {step > 1 ? (
-            <button
-              onClick={() => setStep((step - 1) as Step)}
-              className="px-5 py-2.5 text-sm font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50"
-            >
-              Anterior
-            </button>
-          ) : <div />}
-
-          {step < 4 ? (
-            <button
-              onClick={() => setStep((step + 1) as Step)}
-              disabled={!canAdvance()}
-              className="px-5 py-2.5 text-sm font-medium text-white bg-gray-900 rounded-lg hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              Siguiente
-            </button>
-          ) : (
-            <button
-              onClick={handleSubmit}
-              disabled={submitting}
-              className="px-6 py-2.5 text-sm font-medium text-white bg-gray-900 rounded-lg hover:bg-gray-800 disabled:opacity-40 flex items-center gap-2"
-            >
-              {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
-              Enviar solicitud
-            </button>
-          )}
-        </div>
-      </div>
     </div>
-  )
-}
-
-// --------------- Step 1: Datos personales ---------------
-
-function StepDatosPersonales({ titular, onChange }: { titular: Titular; onChange: (f: keyof Titular, v: string) => void }) {
-  const fields: { key: keyof Titular; label: string; type?: string; required?: boolean; placeholder?: string }[] = [
-    { key: 'nombre', label: 'Nombre(s)', required: true, placeholder: 'Juan Carlos' },
-    { key: 'apellido_paterno', label: 'Apellido paterno', required: true, placeholder: 'García' },
-    { key: 'apellido_materno', label: 'Apellido materno', placeholder: 'López' },
-    { key: 'curp', label: 'CURP', required: true, placeholder: 'XXXX000000XXXXXX00' },
-    { key: 'rfc', label: 'RFC', placeholder: 'XXXX000000XXX' },
-    { key: 'email', label: 'Correo electrónico', type: 'email', required: true, placeholder: 'correo@ejemplo.com' },
-    { key: 'telefono', label: 'Teléfono', type: 'tel', required: true, placeholder: '55 1234 5678' },
-    { key: 'domicilio', label: 'Domicilio actual', placeholder: 'Calle, número, colonia, CP, ciudad' },
-    { key: 'estado_civil', label: 'Estado civil', placeholder: 'Soltero/a, Casado/a, etc.' },
-    { key: 'nacionalidad', label: 'Nacionalidad', placeholder: 'Mexicana' },
-    { key: 'fecha_nacimiento', label: 'Fecha de nacimiento', type: 'date' },
-    { key: 'telefono_emergencia', label: 'Teléfono de emergencia', type: 'tel', placeholder: '55 9876 5432' },
-  ]
-
-  return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-6">
-      <h2 className="text-lg font-semibold text-gray-900 mb-1">Datos personales</h2>
-      <p className="text-sm text-gray-400 mb-6">Información del titular del contrato</p>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {fields.map(f => (
-          <div key={f.key} className={f.key === 'domicilio' ? 'sm:col-span-2' : ''}>
-            <label className="block text-xs font-medium text-gray-600 mb-1">
-              {f.label} {f.required && <span className="text-red-400">*</span>}
-            </label>
-            <input
-              type={f.type || 'text'}
-              value={titular[f.key]}
-              onChange={e => onChange(f.key, e.target.value)}
-              placeholder={f.placeholder}
-              className="w-full bg-gray-50 border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
-            />
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
-// --------------- Step 2: Documentos ---------------
-
-function StepDocumentos({ docs, onUpload }: { docs: Partial<Record<DocType, string>>; onUpload: (t: DocType, f: File) => void }) {
-  const docFields: { key: DocType; label: string; required?: boolean }[] = [
-    { key: 'ine_front', label: 'INE — Frente', required: true },
-    { key: 'ine_back', label: 'INE — Reverso', required: true },
-    { key: 'domicilio_proof', label: 'Comprobante de domicilio' },
-    { key: 'income_proof', label: 'Comprobante de ingresos (3 meses)' },
-  ]
-
-  return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-6">
-      <h2 className="text-lg font-semibold text-gray-900 mb-1">Documentos de identidad</h2>
-      <p className="text-sm text-gray-400 mb-6">Sube fotografías claras de tus documentos</p>
-
-      <div className="space-y-4">
-        {docFields.map(d => (
-          <FileUploadField
-            key={d.key}
-            label={d.label}
-            required={d.required}
-            uploaded={!!docs[d.key]}
-            onChange={file => onUpload(d.key, file)}
-          />
-        ))}
-      </div>
-    </div>
-  )
-}
-
-// --------------- Step 3: Aval ---------------
-
-function StepAval({ aval, onChange, docs, onUpload }: {
-  aval: Aval
-  onChange: (f: keyof Aval, v: string) => void
-  docs: Partial<Record<DocType, string>>
-  onUpload: (t: DocType, f: File) => void
-}) {
-  const fields: { key: keyof Aval; label: string; required?: boolean; placeholder?: string }[] = [
-    { key: 'nombre', label: 'Nombre completo', required: true, placeholder: 'Nombre del aval' },
-    { key: 'rfc', label: 'RFC', placeholder: 'XXXX000000XXX' },
-    { key: 'curp', label: 'CURP', placeholder: 'XXXX000000XXXXXX00' },
-    { key: 'domicilio', label: 'Domicilio', placeholder: 'Dirección completa' },
-    { key: 'telefono', label: 'Teléfono', required: true, placeholder: '55 1234 5678' },
-    { key: 'relacion', label: 'Relación con el titular', placeholder: 'Padre, hermano, amigo, etc.' },
-  ]
-
-  return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-6">
-      <h2 className="text-lg font-semibold text-gray-900 mb-1">Datos del aval</h2>
-      <p className="text-sm text-gray-400 mb-6">Persona que respalde tu solicitud</p>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
-        {fields.map(f => (
-          <div key={f.key} className={f.key === 'domicilio' ? 'sm:col-span-2' : ''}>
-            <label className="block text-xs font-medium text-gray-600 mb-1">
-              {f.label} {f.required && <span className="text-red-400">*</span>}
-            </label>
-            <input
-              type="text"
-              value={aval[f.key]}
-              onChange={e => onChange(f.key, e.target.value)}
-              placeholder={f.placeholder}
-              className="w-full bg-gray-50 border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
-            />
-          </div>
-        ))}
-      </div>
-
-      <h3 className="text-sm font-semibold text-gray-700 mb-3">Documentos del aval</h3>
-      <div className="space-y-4">
-        <FileUploadField label="INE del aval" uploaded={!!docs.aval_ine} onChange={file => onUpload('aval_ine', file)} />
-        <FileUploadField label="Comprobante de domicilio del aval" uploaded={!!docs.aval_domicilio_proof} onChange={file => onUpload('aval_domicilio_proof', file)} />
-      </div>
-    </div>
-  )
-}
-
-// --------------- Step 4: Confirmación ---------------
-
-function StepConfirmacion({ form }: { form: FormState }) {
-  const t = form.titular
-  const a = form.aval
-  const docCount = Object.keys(form.docs).length
-
-  return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-6">
-      <h2 className="text-lg font-semibold text-gray-900 mb-1">Confirmar y enviar</h2>
-      <p className="text-sm text-gray-400 mb-6">Revisa que tus datos sean correctos antes de enviar</p>
-
-      <div className="space-y-6">
-        {/* Titular */}
-        <div>
-          <h3 className="text-sm font-semibold text-gray-700 mb-2">Titular</h3>
-          <div className="bg-gray-50 rounded-lg p-4 text-sm text-gray-700 space-y-1">
-            <p><span className="text-gray-400">Nombre:</span> {t.nombre} {t.apellido_paterno} {t.apellido_materno}</p>
-            <p><span className="text-gray-400">CURP:</span> {t.curp}</p>
-            {t.rfc && <p><span className="text-gray-400">RFC:</span> {t.rfc}</p>}
-            <p><span className="text-gray-400">Email:</span> {t.email}</p>
-            <p><span className="text-gray-400">Tel:</span> {t.telefono}</p>
-            {t.domicilio && <p><span className="text-gray-400">Domicilio:</span> {t.domicilio}</p>}
-            {t.estado_civil && <p><span className="text-gray-400">Estado civil:</span> {t.estado_civil}</p>}
-            {t.fecha_nacimiento && <p><span className="text-gray-400">Nacimiento:</span> {t.fecha_nacimiento}</p>}
-          </div>
-        </div>
-
-        {/* Documentos */}
-        <div>
-          <h3 className="text-sm font-semibold text-gray-700 mb-2">Documentos</h3>
-          <div className="bg-gray-50 rounded-lg p-4 text-sm text-gray-700">
-            <p>{docCount} documento{docCount !== 1 ? 's' : ''} subido{docCount !== 1 ? 's' : ''}</p>
-          </div>
-        </div>
-
-        {/* Aval */}
-        <div>
-          <h3 className="text-sm font-semibold text-gray-700 mb-2">Aval</h3>
-          <div className="bg-gray-50 rounded-lg p-4 text-sm text-gray-700 space-y-1">
-            <p><span className="text-gray-400">Nombre:</span> {a.nombre || '—'}</p>
-            <p><span className="text-gray-400">Tel:</span> {a.telefono || '—'}</p>
-            {a.relacion && <p><span className="text-gray-400">Relación:</span> {a.relacion}</p>}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// --------------- FileUploadField ---------------
-
-function FileUploadField({ label, required, uploaded, onChange }: {
-  label: string
-  required?: boolean
-  uploaded: boolean
-  onChange: (file: File) => void
-}) {
-  const [uploading, setUploading] = useState(false)
-
-  async function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0]
-    if (!file) return
-    setUploading(true)
-    await onChange(file)
-    setUploading(false)
-  }
-
-  return (
-    <label className={`flex items-center gap-4 p-4 rounded-lg border-2 border-dashed cursor-pointer transition-colors ${
-      uploaded ? 'border-emerald-300 bg-emerald-50' : 'border-gray-200 bg-gray-50 hover:border-gray-300'
-    }`}>
-      <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
-        uploaded ? 'bg-emerald-100' : 'bg-gray-100'
-      }`}>
-        {uploading ? (
-          <Loader2 className="w-5 h-5 animate-spin text-gray-400" />
-        ) : uploaded ? (
-          <CheckCircle2 className="w-5 h-5 text-emerald-600" />
-        ) : (
-          <Upload className="w-5 h-5 text-gray-400" />
-        )}
-      </div>
-      <div className="flex-1">
-        <p className="text-sm font-medium text-gray-700">
-          {label} {required && <span className="text-red-400">*</span>}
-        </p>
-        <p className="text-xs text-gray-400">
-          {uploaded ? 'Archivo subido' : 'PDF, JPG o PNG'}
-        </p>
-      </div>
-      <input type="file" className="hidden" accept="image/*,.pdf" onChange={handleChange} />
-    </label>
   )
 }

--- a/src/app/(public)/apply/page.tsx
+++ b/src/app/(public)/apply/page.tsx
@@ -1,0 +1,53 @@
+// BaW OS — Landing genérico para /apply (sin token).
+// Sin un link de invitación válido (`/apply/<token>`) no hay nada que mostrar,
+// pero queremos que /apply NO devuelva 404 (cierra issue #21).
+import BawGrid from '@/components/BawGrid'
+import BawMark from '@/components/BawMark'
+
+export default function ApplyLandingPage() {
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ backgroundColor: 'var(--baw-bg)' }}
+    >
+      <BawGrid position="absolute" />
+      <div className="relative w-full max-w-md mx-auto px-6 text-center">
+        <div
+          className="flex justify-center mb-10"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          <BawMark size={48} withWordmark wordmarkSize="lg" />
+        </div>
+
+        <h1
+          className="text-[20px] font-semibold mb-3 tracking-tight"
+          style={{ color: 'var(--baw-text)' }}
+        >
+          Necesitas un link de invitación
+        </h1>
+
+        <p
+          className="text-sm leading-relaxed mb-8"
+          style={{ color: 'var(--baw-muted)' }}
+        >
+          Para llenar tu solicitud de arrendamiento, pídele a tu arrendador o
+          property manager que te comparta el link único que termina en
+          <span
+            className="mx-1"
+            style={{ fontFamily: 'var(--font-mono)', color: 'var(--baw-text)' }}
+          >
+            /apply/&lt;tu-código&gt;
+          </span>
+          .
+        </p>
+
+        <p
+          style={{ fontFamily: 'var(--font-mono)', color: 'var(--baw-faint)' }}
+          className="text-[10px] uppercase tracking-[0.2em]"
+        >
+          BaW OS · Property Management
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/intake/route.ts
+++ b/src/app/api/intake/route.ts
@@ -50,6 +50,10 @@ export async function POST(request: NextRequest) {
     if (body.avales !== undefined) updates.avales = body.avales
     if (body.contract_data !== undefined) updates.contract_data = body.contract_data
     if (body.docs !== undefined) updates.docs = body.docs
+    if (body.empresa !== undefined) updates.empresa = body.empresa
+    if (body.tercero_pagador !== undefined) updates.tercero_pagador = body.tercero_pagador
+    // Permitir setear contract_type desde el form público
+    if (body.contract_type !== undefined) updates.contract_type = body.contract_type
 
     // Si submit=true → marcar como enviada
     if (body.submit === true) {


### PR DESCRIPTION
## Summary

Cierra **#21** (`/apply listed como public_prefix pero ruta devuelve 404`).

`AppShell.PUBLIC_PREFIXES` y `AuthGuard.PUBLIC_PATHS` ya listaban `/apply` como ruta pública desde Sprint 4, pero la ruta jamás se implementó completa: `/apply` devolvía 404, y `/apply/<token>` existía como un client component monolítico que no respetaba el design system BaW (usaba clases `bg-gray-50`/`text-gray-900` directas en vez de `--baw-*` tokens), no soportaba todos los tipos de contrato A/B/C/D/E, no manejaba estados read-only post-submit, y no tenía pantalla "token inválido".

Era un feature gap real: los links que `/applications` genera con el botón "Nueva solicitud" (`${origin}/apply/${token}`) llevaban a una pantalla que rompía la voz visual de marca o, sin token, a un 404 directo.

## Cambios

### Archivos creados
- `src/app/(public)/apply/page.tsx` — landing genérico cuando se entra a `/apply` sin token. Mensaje "Necesitas un link de invitación de tu arrendador". Cierra el 404 raíz del issue #21.
- `src/app/(public)/apply/[token]/ApplyForm.tsx` — Client Component nuevo con todo el form (titulares, avales, empresa, tercero pagador, documentos, save/submit, validación inline).
- `src/app/(public)/apply/[token]/not-found.tsx` — pantalla "Este link ya no es válido" para tokens inexistentes.
- `src/app/(public)/apply/[token]/layout.tsx` — passthrough.

### Archivos modificados
- `src/app/(public)/apply/[token]/page.tsx` — convertido a **Server Component**: lee la row con el cliente anon de Supabase usando `.maybeSingle()` (RLS permite SELECT a anon, ver migración `20260404_tenant_intake.sql` líneas 51-61). Si no encuentra el token llama a `notFound()`. Si la tabla no existe en el entorno, muestra fallback `SchemaMissingScreen` (mismo patrón que `/applications` con `schemaMissing`).
- `src/app/api/intake/route.ts` — el POST ahora pasa también `empresa`, `tercero_pagador` y `contract_type` al UPDATE (antes los descartaba).

### Tipos de contrato soportados (A/B/C/D/E)
- **A · Individual** — 1 titular + aval
- **B · Coarrendatarios** — 2 a 4 titulares (`Plus`/`Trash2` para agregar/quitar) + aval
- **C · Empresa** — sección Empresa (RFC, razón social, representante legal, domicilio fiscal)
- **D · Tercero pagador** — titular + sección Tercero (nombre, RFC, teléfono, relación)
- **E · Institucional** — sección Empresa

### Estado del bucket `tenant-docs`
**No se toca infra de Storage en este PR.** El form usa el endpoint existente `/api/intake/upload` que ya escribe al bucket `tenant-docs` con service role; si el bucket no existe en algún entorno, ese endpoint regresa error visible en el form (banner rojo). No bloquea el resto del flujo: el usuario puede guardar borrador / enviar sin docs (los docs no son hard-required en validación, solo INE marcado con `*`).

### Estilo visual (regla canónica Sprint 6)
- `BawGrid position="fixed"` sobre toda la pantalla.
- `BawMark` (Mark A) + wordmark "BaW / OS" + tagline mono "Solicitud de Arrendamiento" en el header, mismo tratamiento que `/login`.
- 100% tokens `--baw-*` (incluyendo `--baw-success-bg-soft`, `--baw-info-bg-soft`, `--baw-danger-fg`, etc). **Cero HEX nuevos, cero rgba nuevos.**
- Tipografía Inter heredada de `layout.tsx` raíz, mono `var(--font-mono)` para labels/tags.
- Errores inline con badge rojo (`--baw-danger-fg` sobre `--baw-danger-bg-soft`), no `alert()` nativo.

### Estados read-only
- `status === 'draft'` → form editable.
- `status === 'submitted' | 'reviewing' | 'approved' | 'rejected'` → pantalla `SubmittedScreen` con mensaje específico por status (e.g. "Recibimos tu solicitud", "Tu solicitud está en revisión").

### Patrones de bug evitados (docs/PROJECT_STATE.md §5)
- §5.5: `.maybeSingle()` en vez de `.single()` para token posiblemente inexistente.
- §5.4: `try/finally` con `setSaving(false)` y `setSubmitting(false)`.
- No se usa el patrón problemático `useEffect(() => { if (orgId) load() })` — los datos llegan como prop desde el Server Component, sin loading eterno.

### NO se toca
- `src/components/AppShell.tsx`
- `src/components/AuthGuard.tsx`
- `src/middleware.ts`
- `src/lib/navigation.ts`
- `src/lib/platform-admin.ts`
- `src/lib/org-context.ts`
- `supabase/migrations/`
- `src/app/applications/page.tsx` (vista interna, fuera de scope)
- `design/baw-design/tokens/`

## Verification

- `npx tsc --noEmit` — limpio
- `npm run build` — verde, ambas rutas registradas:
  - `○ /apply` (static, 181 B)
  - `ƒ /apply/[token]` (dynamic, 6.61 kB)

## Test plan (QA humano)

- [ ] Visitar `/apply` sin token → muestra landing "Necesitas un link de invitación", no 404.
- [ ] Visitar `/apply/<token-inexistente>` → muestra `not-found.tsx` con mensaje "Este link ya no es válido".
- [ ] Crear aplicación desde `/applications` → copiar link → abrir en incógnito → debería pre-llenar campos vacíos.
- [ ] Seleccionar contrato A → ver sección Aval; seleccionar C → ver sección Empresa; seleccionar D → ver sección Tercero pagador.
- [ ] Tipo B → botón "Agregar titular" llega hasta 4, "Quitar" deja mínimo 1.
- [ ] "Guardar borrador" actualiza la row sin cambiar `status`; el internal `/applications` debe ver los cambios.
- [ ] "Enviar solicitud" cambia `status` a `submitted` y `submitted_at`; al recargar el link el inquilino ve la pantalla read-only "Recibimos tu solicitud".
- [ ] Validación: dejar nombre/email/RFC vacío y dar "Enviar" → muestra errores inline en rojo.
- [ ] Upload de INE frente → bucket `tenant-docs` recibe el archivo (verificar en Supabase Storage). Si el bucket no existe en prod, crearlo manualmente o crear migración aparte.
- [ ] Visual: BawGrid visible de fondo, BawMark A en header (3 placas con desfase X +6/-6), tipografía Inter, todo en `--baw-*` tokens.

## Pendientes (out of scope)

- El bucket `tenant-docs` se asume existente (creado en Supabase). No incluido aquí porque tocaría migraciones / infra. Si falta, abrir issue separado.
- Validación de formato (RFC mexicano, CURP, email regex) — solo presence check por ahora.
- i18n: textos en español MX hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)