### PR TITLE
feat(agents): platform foundation — docs, agent_credentials, view mode, agent console

### DIFF
--- a/docs/AGENTIC_PRINCIPLES.md
+++ b/docs/AGENTIC_PRINCIPLES.md
@@ -1,0 +1,188 @@
+# BaW OS — Agentic Design Principles (condensado)
+
+> Condensación operable del doc maestro de Notion ["Agentic Design Principles — BaW OS / ZXY Platforms"](https://www.notion.so/zxyventures/Agentic-Design-Principles-BaW-OS-ZXY-Platforms-355169373e72818dba04e653ecec8e58). Notion queda como bitácora viva; este doc es el contrato canónico para implementación.
+>
+> Última actualización: 2026-05-03
+
+---
+
+## 1. Cambio de paradigma — Operator → Supervisor
+
+**Antes (Operator):** humano ejecuta cada tarea, software es herramienta pasiva.
+**Ahora (Supervisor):** humano define intención, agentes ejecutan, humano supervisa excepciones.
+
+### Implicaciones de UX (Nielsen)
+
+- La UI deja de ser "menús + formularios" y se convierte en **dashboard de excepciones + timeline de actividad + cola de aprobaciones**.
+- Onboarding cambia: el humano aprende a **delegar y supervisar**, no a hacer click-by-click.
+- Estado por defecto: **silencio operativo**. El sistema solo notifica cuando algo requiere atención.
+
+### Implicación para BaW OS
+
+- Modo Agent (Fase 3) debe mostrar **excepciones primero**, actividad después, controles al final.
+- Modo Human (default) sigue existiendo para descubrimiento y onboarding.
+
+---
+
+## 2. Lifecycle agentic (Smashing) — 6 patrones
+
+Todo agente atraviesa estos 6 momentos. La UI y la API deben soportar cada uno explícitamente.
+
+| Fase | Pregunta del usuario | Soporte BaW |
+|---|---|---|
+| **1. Discovery** | ¿Qué puede hacer este agente? | Página `/agents` con catálogo + capabilities + autonomy actual |
+| **2. Onboarding** | ¿Cómo lo configuro? | UI `/admin/agents/{id}` para credentials + policies |
+| **3. Activation** | ¿Cómo lo arranco? | Botón "Run" + cron + webhook trigger |
+| **4. Active use** | ¿Qué está haciendo? | Timeline en vivo, runs page, exceptions bar |
+| **5. Recovery** | ¿Qué pasa cuando falla? | Approval queue + retry + escalation a humano |
+| **6. Deactivation** | ¿Cómo lo apago? | Status `paused` + revoke credentials, sin pérdida de audit |
+
+### 12 patrones HatchWorks (referenciados, no obligatorios)
+
+Resumen: progressive disclosure, transparent reasoning, controllable autonomy, graceful degradation, undo affordance, explicit boundaries, conversational + structured I/O, attention budget, multi-modal feedback, error recovery, trust calibration, identity persistence.
+
+### Framework ADEPTS
+
+**A**utonomy · **D**ecision visibility · **E**rror recovery · **P**ersonalization · **T**ransparency · **S**afety. Toda decisión de UI agente debe puntuar las 6.
+
+### Máquina de estados de un agente
+
+```
+idle → activated → running → (succeeded | failed | partial | awaiting_approval) → idle
+                              ↓
+                         approval_pending → (approved → running) | (denied → idle)
+```
+
+`agent_runs.status` ya implementa esto: `running | succeeded | failed | partial | canceled`. Falta solo `awaiting_approval` que en v1 puede vivir en `agent_actions.status='pending_approval'` y mantener `agent_runs.status='partial'` hasta resolver.
+
+---
+
+## 3. Niveles de autonomía
+
+Combinamos dos frameworks:
+
+### Knight Columbia L1–L5 (capabilities)
+
+- **L1** — Single-task assistant. Ejecuta una tarea específica, humano supervisa cada output.
+- **L2** — Multi-task within domain. Ejecuta secuencias dentro de un dominio (e.g. cobranza completa).
+- **L3** — Cross-domain orchestration. Coordina múltiples dominios o agentes.
+- **L4** — Autonomous goal pursuit. Persigue un objetivo abstracto sin pasos prescritos.
+- **L5** — Open-ended generative. Define sus propios objetivos. **No usar en producción BaW.**
+
+### CEI A0–A4 (control)
+
+- **A0** — Disabled.
+- **A1** — Suggest only. Agente propone, humano decide y ejecuta.
+- **A2** — Approve each. Agente propone + ejecuta tras approval por acción.
+- **A3** — Approve batch. Agente ejecuta lotes con approval del lote.
+- **A4** — Full auto. Agente ejecuta sin approval, humano revisa post-hoc vía audit.
+
+### Mapeo BaW
+
+Usamos **A0–A4** como `autonomy_level` en `agent_policies` (Fase 4). El nivel L de capability se infiere del scope: un agente con scopes cross-domain implícitamente está en L3+.
+
+> Default conservador siempre: nuevo agente arranca en A1 hasta validación.
+
+---
+
+## 4. Coordinación multi-agente
+
+### Patrón canónico — Supervisor / Worker
+
+Un agente supervisor (`hugo-cos`, `baw`) recibe la intención del humano y delega a workers. Workers no se hablan entre sí; el supervisor agrega outputs.
+
+```
+Humano
+  ↓ define objetivo
+Supervisor (Hugo-COS o BaW)
+  ↓ delega
+Worker A · Worker B · Worker C
+  ↓ ejecutan en paralelo o secuencia
+Supervisor agrega resultado
+  ↓ reporta
+Humano
+```
+
+### Anti-patrones a evitar
+
+- **Mesh sin coordinador.** Workers hablándose entre sí sin supervisor → caos, deadlocks, feedback loops.
+- **Supervisor mutante.** Agente cambia su rol durante una run → debugging imposible.
+- **Recursión sin tope.** Supervisor delega a sí mismo o crea ciclos → siempre poner `max_depth=3` en delegaciones.
+
+### Patrón alterno — Pipeline determinista
+
+Cuando la secuencia es fija (e.g. cierre mensual: Cobranza → Facturación → Reportes), usar cron con jobs encadenados, NO supervisor LLM. Más predecible, más barato.
+
+---
+
+## 5. Command center patterns
+
+### Densidad — Bloomberg-style en Modo Agent
+
+- Información crítica en encima del fold: excepciones, KPIs en deltas, runs en vivo.
+- Tipografía monoespaciada para datos numéricos.
+- Color con propósito (rojo = excepción, ámbar = pending approval, verde = ok), nunca decorativo.
+- Sin scroll innecesario en pantalla principal.
+
+### Exception-first
+
+- La UI **no muestra todo lo que está bien**; muestra **lo que requiere atención**.
+- Si no hay excepciones: pantalla casi vacía con mensaje "All systems normal" + último run resumido.
+
+### Activity timeline
+
+- Feed unificado de runs + actions + approvals.
+- Filtros por agente, por org, por severidad.
+- Eventos firmados con `correlation_id` para rastrear cadenas de delegación.
+
+### Approval queue
+
+- Cola lateral con items pending_approval ordenados por `expires_at` ascendente.
+- Cada item: agente, action_type, payload preview, botones Approve / Deny.
+- Bulk approve solo para acciones del mismo type del mismo agente.
+
+---
+
+## 6. Referentes de industria (no copiar, aprender)
+
+- **Microsoft Copilot Studio** — agent identity, scoped permissions, telemetría granular.
+- **Salesforce Agentforce** — autonomy por agente, org-level governance.
+- **Palantir Foundry** — operadores humanos como first-class citizens, auditoría como producto.
+- **Linear** — comando + atajos de teclado, densidad sin sacrificar legibilidad.
+- **Bloomberg Terminal** — densidad extrema, exception-first, monospace.
+- **Stripe Dashboard** — read-first con write-on-demand, audit trail nativo.
+
+---
+
+## 7. Voces de industria + cognición (síntesis)
+
+- **Sutton (2024):** "The bitter lesson aplica también al diseño: agentes con menos hand-coded rules y más feedback loops escalan mejor."
+- **Sutskever:** atención del usuario es el recurso más escaso; el sistema debe protegerla con default silencio operativo.
+- **Norman (cognición):** el costo cognitivo de aprobar > el de descartar. Approvals deben ser binarios y rápidos; los detalles, on-demand.
+- **Doctorow:** el riesgo de los agentes no es técnico sino de gobernanza. Audit trails inmutables y reversibilidad son **product features**, no nice-to-haves.
+
+---
+
+## Aplicación inmediata a BaW OS
+
+| Principio | Aplicación |
+|---|---|
+| Operator → Supervisor | Modo Agent (Fase 3) muestra excepciones primero. |
+| Lifecycle 6 fases | UI `/agents` cubre Discovery + Onboarding + Activation; runs page cubre Active use + Recovery; status `paused` cubre Deactivation. |
+| Niveles autonomía | `agent_policies.autonomy_level` (Fase 4) = A0–A4. |
+| Supervisor/worker | Hugo-COS y BaW son únicos supervisores; resto son workers. |
+| Command center | Layout 3-paneles tipo Bloomberg en Modo Agent (Fase 3). |
+| Exception-first | Exceptions bar pegada al top en Modo Agent. |
+| Audit como feature | `agent_runs` + `agent_actions` ya inmutables; UI debe exponerlos. |
+| Reversibilidad | Toda fase del roadmap apagable vía feature flag. |
+
+---
+
+## Referencias externas
+
+- Notion master doc: [Agentic Design Principles — BaW OS / ZXY Platforms](https://www.notion.so/zxyventures/Agentic-Design-Principles-BaW-OS-ZXY-Platforms-355169373e72818dba04e653ecec8e58)
+- Knight Columbia "Levels of Autonomy" (L1–L5)
+- HatchWorks "12 Patterns for Agentic UX"
+- Smashing Magazine "Designing for AI Agents Lifecycle"
+- Nielsen Norman Group "Operator vs Supervisor UX"
+- Bloomberg Terminal & Linear como referencias visuales de densidad

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -1,0 +1,243 @@
+# BaW OS — Agent Integration Guide
+
+> Cómo conectar un agente (interno o third-party) a BaW OS. Si vas a integrar a Hugo-COS, Alicia-Ops, Beto, Maribel, Luis, Andrés-CTO, Rafa-Research o cualquier nuevo agente externo, este es el contrato.
+>
+> Última actualización: 2026-05-03
+
+---
+
+## Modelo mental
+
+Un **agente** en BaW OS es un actor identificable que opera contra la API pública en nombre de **una org específica**, con **scopes acotados**, **rate-limit propio** y **clasificación per-action** de qué puede hacer solo, qué debe loggear, y qué requiere aprobación humana.
+
+Corolarios:
+
+- **Una identidad por agente, por org.** Hugo-COS de la org A ≠ Hugo-COS de la org B; cada uno tiene su API key.
+- **No hay master key.** `BAW_API_KEY` global se elimina en Fase 1; quien la siga usando rompe contrato.
+- **Scopes son explícitos.** Un agente sin scope `payments:write` no puede tocar pagos, aunque la lógica del runner lo permita.
+- **Clasificación AUTO/LOG/REQUIRE_APPROVAL es por action_type, no por agente.** El mismo agente puede tener acciones AUTO y otras REQUIRE_APPROVAL.
+
+---
+
+## Lifecycle de integración
+
+### 1. Registrar al agente en el catálogo (`agents` table)
+
+Si el agente es nuevo (no está en `supabase/migrations/20260502_agents_roster_v02.sql`), añadirlo via migración nueva. **No hacerlo via dashboard de Supabase** — todo el catálogo vive en migraciones para reproducibilidad.
+
+```sql
+INSERT INTO public.agents (
+  id, display_name, full_name, family, domain, description,
+  capability_level, feedback_level, status, is_shared_zxy
+) VALUES (
+  'andres-cto', 'Andrés-CTO', 'Agente Andrés-CTO',
+  'third-party', 'tech',
+  'CTO OpenClaw — coordinación técnica cross-platform',
+  0, 0, 'planned', true
+);
+```
+
+### 2. Generar API key (`agent_credentials`)
+
+UI: `/admin/agents/{id}/credentials → New credential`. Backend genera `sk_live_<32 chars>`, almacena `bcrypt(key)` en `api_key_hash`, devuelve la key plana **una sola vez**.
+
+CLI alterna (Fase 1):
+
+```bash
+pnpm baw-cli agents:keys:create \
+  --org=baw-operations \
+  --agent=andres-cto \
+  --label=prod \
+  --scopes=tasks:read,tasks:write,incidents:read,runs:read \
+  --expires-in=90d
+```
+
+### 3. Asignar scopes
+
+Scopes son strings `recurso:operación`. Tabla canónica:
+
+| Recurso | Operaciones | Notas |
+|---|---|---|
+| `units` | `read`, `write` | Inventario inmobiliario |
+| `reservations` | `read`, `write`, `cancel` | STR / MTR |
+| `payments` | `read`, `trigger` | `trigger` invoca cobro |
+| `contracts` | `read`, `write`, `terminate` | Documentos legales |
+| `incidents` | `read`, `write`, `resolve` | Mantenimiento |
+| `tasks` | `read`, `write`, `assign` | Workboard interno |
+| `agents` | `run`, `manage` | `manage` ≠ run, alto privilegio |
+| `runs` | `read` | Solo lectura de historial |
+| `insights` | `read` | KPIs sintetizados |
+| `messages` | `send`, `read` | Comunicación con tenants |
+| `policies` | `read`, `write` | Auto-modificación; restringir |
+
+Recomendación: **least privilege**. Un agente de Reportes solo necesita `*:read` + `insights:read`.
+
+### 4. Configurar policy (autonomy + per-action)
+
+UI: `/admin/agents/{id}/policies` (Fase 4). Determina:
+
+- **Autonomy level** (L0–L4). Default conservador: L1–L2.
+- **Per-action overrides** (`action_type → AUTO | LOG | REQUIRE_APPROVAL`).
+- **Rate caps** (`actions_per_hour`, `approvals_pending_max`).
+
+Ejemplo:
+
+```json
+{
+  "autonomy_level": 2,
+  "per_action": {
+    "email.send_to_tenant": "REQUIRE_APPROVAL",
+    "incident.update_status": "AUTO",
+    "task.create": "AUTO",
+    "payment.charge": "REQUIRE_APPROVAL"
+  },
+  "rate_caps": {
+    "actions_per_hour": 100,
+    "approvals_pending_max": 25
+  }
+}
+```
+
+### 5. Implementar el agente externo (lado cliente)
+
+El agente externo (proceso, servicio, MCP server, cron) hace requests autenticadas:
+
+```http
+POST https://baw-os.vercel.app/api/v1/incidents
+Authorization: Bearer sk_live_<token>
+Content-Type: application/json
+Idempotency-Key: <uuid>
+
+{
+  "unit_id": "u_123",
+  "title": "AC failure unit 304",
+  "severity": "high",
+  "source_agent": "andres-cto"
+}
+```
+
+Reglas:
+
+- `Authorization: Bearer` o header `x-api-key` (ambos funcionan en v1).
+- `Idempotency-Key` obligatorio en POST/PATCH. UUIDv4 generado por el agente.
+- Request fallido por scope insuficiente → `403 forbidden_scope`.
+- Action clasificada `REQUIRE_APPROVAL` → `202 pending_approval` con `{approval_id}`. Agente debe poll `/v1/approvals/:id` o suscribirse a webhook.
+- Rate-limit excedido → `429` con `Retry-After` header.
+
+### 6. Suscribirse a webhooks (opcional)
+
+Si el agente necesita reaccionar a eventos del sistema (no solo polling):
+
+```http
+POST https://baw-os.vercel.app/api/v1/webhooks
+Authorization: Bearer sk_live_<token>
+
+{
+  "url": "https://andres-agent.openclaw.com/baw-events",
+  "events": ["incident.created", "approval.granted", "approval.denied"],
+  "signing_secret": "auto-generated"
+}
+```
+
+Eventos firmados con HMAC-SHA256. Verificación obligatoria del lado del agente.
+
+---
+
+## Clasificación AUTO / LOG / REQUIRE_APPROVAL
+
+Cada `action_type` debe tener una clasificación por defecto. La policy del agente puede sobrescribirla. Esta tabla es la **fuente de verdad inicial**:
+
+| action_type | Default | Justificación |
+|---|---|---|
+| `unit.read` | LOG | Lectura, sin riesgo. |
+| `unit.create` | REQUIRE_APPROVAL | Inventario es estado pesado. |
+| `unit.update_metadata` | AUTO | Cambios cosméticos. |
+| `reservation.create` | REQUIRE_APPROVAL | Compromiso económico. |
+| `reservation.cancel` | REQUIRE_APPROVAL | Refund implícito. |
+| `payment.charge` | REQUIRE_APPROVAL | Dinero. Siempre. |
+| `payment.refund` | REQUIRE_APPROVAL | Idem. |
+| `incident.create` | AUTO | Crear ticket es bajo riesgo. |
+| `incident.assign` | AUTO | Routing operativo. |
+| `incident.resolve` | LOG | Cierre con auditoría. |
+| `task.create` | AUTO | Trabajo interno. |
+| `task.assign` | AUTO | Idem. |
+| `email.send_to_tenant` | REQUIRE_APPROVAL | Contacto externo. |
+| `email.send_internal` | LOG | Equipo interno. |
+| `contract.draft` | AUTO | Generar borrador, no firmar. |
+| `contract.sign` | REQUIRE_APPROVAL | Compromiso legal. |
+| `cfdi.emit` | REQUIRE_APPROVAL | SAT, cero margen. |
+| `policy.modify` | REQUIRE_APPROVAL | Auto-modificación restringida. |
+
+> **Regla de oro:** si la acción tiene efecto irreversible **fuera de BaW OS** (email enviado, dinero movido, CFDI emitido, contrato firmado), default es `REQUIRE_APPROVAL`.
+
+---
+
+## Patrones recomendados
+
+### Supervisor / worker
+
+Cuando un agente coordina a otros, usar **supervisor pattern**, no mesh.
+
+```
+Hugo-COS (supervisor)
+  ├─ delega a → Alicia-Ops
+  ├─ delega a → Beto-Conta
+  ├─ delega a → Maribel-Law
+  └─ delega a → Luis-Growth
+```
+
+Cada delegación = `POST /v1/agents/:id/run`. Hugo agrega resultados, no los workers entre sí.
+
+### Idempotencia
+
+Toda acción mutante debe ser idempotente vía `Idempotency-Key`. Reintentos del agente NO duplican efectos. Backend mantiene cache `idempotency_keys` con TTL 24h.
+
+### Approval flow
+
+```
+1. Agente: POST /v1/payments/charge { ... }
+2. Backend: 202 { approval_id: "ap_123", expires_at: "..." }
+3. Humano: aprueba en /approvals (UI Human o Agent mode)
+4. Backend: webhook approval.granted → agente
+5. Agente (opcional): POST /v1/approvals/ap_123/execute
+   ó
+   Backend ejecuta directo cuando aprueba (recomendado).
+```
+
+Approval expirado (default 24h) → cancelado automáticamente.
+
+### Audit trail
+
+Todo run + toda action queda en `agent_runs` y `agent_actions`. RLS garantiza que un tenant no ve runs de otro. Auditoría tiene `runs:read` y opera transversal.
+
+---
+
+## Errores típicos a evitar
+
+1. **Hardcodear scope checks en runner.** El middleware `requireAgentAuth(req, scopes[])` ya lo hace; runner debe asumir que llegó autorizado.
+2. **Compartir API key entre agentes.** Rompe el modelo. Una key = una identidad.
+3. **Saltar idempotency en POST.** Reintentos de webhook causan duplicados.
+4. **Asumir AUTO en acciones nuevas.** Default seguro es REQUIRE_APPROVAL hasta que se valide.
+5. **Modificar `agents.config` desde el runner.** `config` es read-only para el agente; solo platform admin lo edita.
+6. **Bypass de RLS via service role en endpoints públicos.** Service role solo en server-side admin paths, nunca tras `requireAgentAuth`.
+
+---
+
+## Onboarding rápido para Andrés (CTO OpenClaw)
+
+1. Lee este doc + [`AGENT_ROSTER.md`](./AGENT_ROSTER.md) + [`AGENTIC_PRINCIPLES.md`](./AGENTIC_PRINCIPLES.md).
+2. Pide a Fran que ejecute la migración para sembrar `andres-cto` en `agents`.
+3. Pide credencial vía `/admin/agents/andres-cto/credentials` → label `prod`, scopes mínimos.
+4. Implementa lado OpenClaw consumiendo `/api/v1/*`.
+5. Suscríbete a webhooks `incident.created`, `approval.granted` para coordinar con BaW.
+6. Issue tracking en [`docs/COLAB_ANDRES.md`](./COLAB_ANDRES.md).
+
+---
+
+## Versionado del contrato
+
+Este doc es **v1** del contrato de integración. Breaking changes requieren bump a v2 con migración asistida; non-breaking changes se documentan en changelog al final del doc.
+
+### Changelog
+
+- **2026-05-03 — v1.0** — Documento inicial. Define lifecycle, scopes, clasificación, patrones.

--- a/docs/AGENT_PLATFORM_ROADMAP.md
+++ b/docs/AGENT_PLATFORM_ROADMAP.md
@@ -1,0 +1,277 @@
+# BaW OS — Agent Platform Roadmap
+
+> Plan canónico para convertir BaW OS en una plataforma operada por humanos **y** agentes (internos + third-party). Basado en los principios condensados en [`docs/AGENTIC_PRINCIPLES.md`](./AGENTIC_PRINCIPLES.md), el roster definido en [`docs/AGENT_ROSTER.md`](./AGENT_ROSTER.md), y el protocolo de integración de [`docs/AGENT_INTEGRATION.md`](./AGENT_INTEGRATION.md).
+>
+> Última actualización: 2026-05-03
+
+---
+
+## TL;DR
+
+BaW OS evoluciona de **app multi-tenant para humanos** → **plataforma multi-actor** donde los actores son tanto **personas** como **agentes** (10 internos + 6 ZXY third-party). El roadmap tiene **5 fases** que se implementan en este orden, cada una con criterios de éxito y reversibilidad explícitos.
+
+| Fase | Objetivo | Duración | Bloquea | Reversible |
+|---|---|---|---|---|
+| **0** | Documentos canónicos en repo | 1 sesión | — | Sí (solo docs) |
+| **1** | Identidad por agente (API keys, scopes) | 1 sprint | Fases 2–4 | Sí (feature flag) |
+| **2** | API pública v1 (REST → MCP adapter) | 2 sprints | Fase 4 | Parcial (versionada) |
+| **3** | Modo Human/Agent en UI | 1 sprint | — | Sí (toggle por user) |
+| **4** | Autonomy slider + policies engine | 1 sprint | — | Sí (defaults conservadores) |
+
+---
+
+## Principios rectores
+
+1. **Mismos datos, dos lenguajes.** UI Human y UI Agent comparten data layer; difieren en densidad, velocidad y forma de interacción.
+2. **Una identidad por agente, por org.** No hay `BAW_API_KEY` global. Cada agente tiene su credencial, sus scopes y su rate-limit.
+3. **Clasificación obligatoria de cada acción**: `AUTO` (agente la hace y notifica) / `LOG` (agente la hace y loggea) / `REQUIRE_APPROVAL` (humano debe aprobar). Default conservador.
+4. **REST primero, MCP encima.** Construimos REST v1 estable y MCP es un adapter encima. No al revés.
+5. **Supervisor/worker por defecto.** Hugo-COS orquesta a los demás ZXY; BaW Coordinador orquesta los 10 internos. Nada de mesh sin razón clara.
+6. **Reversibilidad obligatoria.** Toda fase debe poder apagarse vía feature flag o reset de policy sin pérdida de datos.
+
+---
+
+## Fase 0 — Documentos canónicos
+
+**Objetivo:** que el repo contenga la verdad canónica del sistema agentic, no Notion. Notion queda como bitácora viva, repo como contrato.
+
+### Entregables
+
+- [`docs/AGENT_PLATFORM_ROADMAP.md`](./AGENT_PLATFORM_ROADMAP.md) (este doc)
+- [`docs/AGENT_INTEGRATION.md`](./AGENT_INTEGRATION.md) — cómo conectar agentes externos
+- [`docs/AGENT_ROSTER.md`](./AGENT_ROSTER.md) — quién es quién, autonomía default, scopes default
+- [`docs/AGENTIC_PRINCIPLES.md`](./AGENTIC_PRINCIPLES.md) — condensación operable del Notion doc maestro
+
+### Criterios de éxito
+
+- Cualquier persona técnica que clone el repo puede entender el modelo de agentes sin abrir Notion.
+- Andrés (CTO OpenClaw) puede leer estos 4 docs y empezar a integrar sin reuniones.
+- Claude Code / Codex / Cursor pueden tomar tareas sobre agentes con contexto suficiente.
+
+---
+
+## Fase 1 — Identidad por agente
+
+**Objetivo:** que cada agente tenga su propia API key, sus scopes y su rate-limit. Eliminar `BAW_API_KEY` global como concepto.
+
+### Schema (nueva migración)
+
+```sql
+CREATE TABLE public.agent_credentials (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL REFERENCES public.agents(id) ON DELETE RESTRICT,
+  label TEXT NOT NULL,                          -- 'prod', 'staging', 'dev-local'
+  api_key_hash TEXT NOT NULL,                   -- bcrypt(sk_live_xxx)
+  api_key_prefix TEXT NOT NULL,                 -- 'sk_live_abc...' (primeros 12 chars para UI)
+  scopes TEXT[] NOT NULL DEFAULT '{}',          -- ['units:read','reservations:write',...]
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active','revoked','expired')),
+  rate_limit_tier TEXT NOT NULL DEFAULT 'standard'
+    CHECK (rate_limit_tier IN ('standard','elevated','unlimited')),
+  expires_at TIMESTAMPTZ,                       -- NULL = no expira
+  last_used_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  revoked_at TIMESTAMPTZ,
+  revoked_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  UNIQUE (org_id, agent_id, label)
+);
+
+CREATE INDEX idx_agent_credentials_lookup
+  ON public.agent_credentials (api_key_prefix)
+  WHERE status = 'active';
+```
+
+RLS: solo platform admins y admins del tenant ven las credenciales del tenant. Nunca se devuelve `api_key_hash` ni la key completa después de creación.
+
+### UI
+
+- `/admin/agents/[id]/credentials` — listar, crear (solo aparece la key completa una vez), revocar.
+- Banner explícito: "Esta es la única vez que verás la key completa. Guárdala ahora."
+
+### API auth refactor
+
+- Middleware `requireAgentAuth(req, requiredScopes)` reemplaza el patrón actual `req.headers['x-api-key'] === BAW_API_KEY`.
+- Resuelve agente por hash, valida scopes, registra en `agent_credentials.last_used_at`.
+- Endpoints actuales (`/api/mora`) mantienen compat por feature flag durante 1 sprint.
+
+### Criterios de éxito
+
+- 17 credenciales generables (10 BaW + 6 ZXY + BaW Coordinador) por org sin colisiones.
+- `/api/mora` rechaza requests con `x-api-key` que no resuelva a credencial activa con scope `mora:trigger`.
+- Rotación de key revoca anterior atómicamente.
+
+---
+
+## Fase 2 — API pública v1
+
+**Objetivo:** superficie estable y versionada bajo `/api/v1/*` que los agentes (internos y ZXY) usan para leer y escribir el estado del sistema.
+
+### Endpoints (mínimo viable)
+
+| Endpoint | Métodos | Scopes | Clasificación default |
+|---|---|---|---|
+| `/v1/units` | GET, POST, PATCH | `units:read`, `units:write` | LOG (read) / REQUIRE_APPROVAL (write nuevo) / AUTO (patch propio) |
+| `/v1/reservations` | GET, POST, PATCH | `reservations:*` | LOG / REQUIRE_APPROVAL / AUTO |
+| `/v1/payments` | GET, POST | `payments:*` | LOG / REQUIRE_APPROVAL |
+| `/v1/contracts` | GET, POST, PATCH | `contracts:*` | LOG / REQUIRE_APPROVAL |
+| `/v1/incidents` | GET, POST, PATCH | `incidents:*` | LOG / AUTO / AUTO |
+| `/v1/tasks` | GET, POST, PATCH | `tasks:*` | LOG / AUTO / AUTO |
+| `/v1/agents/:id/run` | POST | `agents:run` | LOG (cobertura por policy) |
+| `/v1/runs` | GET | `runs:read` | LOG |
+| `/v1/insights/:topic` | GET | `insights:read` | LOG |
+| `/v1/messages` | POST | `messages:send` | REQUIRE_APPROVAL (default) |
+
+### Convenciones
+
+- Versionado en path (`/v1/`), no en header.
+- Errores como JSON-API style: `{ error: { code, message, details? } }`.
+- Pagination cursor-based (`?cursor=...&limit=...`).
+- Idempotency-Key header en todos los POST/PATCH.
+- Webhooks bidireccionales: `POST /v1/webhooks` para que agentes externos reciban eventos.
+
+### MCP adapter
+
+Después de v1 estable, exponer las mismas operaciones vía MCP server. El adapter mapea tools MCP → endpoints REST internos. Agentes que prefieran MCP (Claude Desktop nativo, etc.) lo consumen sin que dupliquemos lógica.
+
+### Criterios de éxito
+
+- Agente externo (ZXY o tercero) puede operar BaW OS solo con docs públicos + API key.
+- Hugo-COS puede invocar a Alicia-Ops vía REST sin hardcoding.
+- Cobertura de tests >80% en endpoints v1.
+
+---
+
+## Fase 3 — Modo Human/Agent en UI
+
+**Objetivo:** que la UI tenga dos lenguajes visuales según el contexto del usuario, sin duplicar páginas.
+
+### Mecanismo
+
+- Switch en navbar: `Human ↔ Agent`.
+- Persistido en `org_members.preferred_view_mode` (`'human' | 'agent'`).
+- Layout shell condicional: rutas como `/dashboard`, `/agents`, `/units` renderizan layouts distintos según el modo.
+- **Mismos datos, diferente densidad y velocidad.**
+
+### Modo Human (default)
+
+- Lo que ya existe hoy.
+- Cards generosas, jerarquías visuales claras, onboarding tooltips.
+- Optimizado para descubrimiento y comprensión.
+
+### Modo Agent (Bloomberg/Linear-style)
+
+Layout 3-paneles típico:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Exceptions Bar (top)                                │
+│ 3 reservations awaiting approval · 1 mora critical  │
+├──────────┬──────────────────────┬───────────────────┤
+│          │                      │                   │
+│ Roster   │  Activity Timeline   │  Approval Queue   │
+│ sidebar  │  (live feed)         │  (action items)   │
+│          │                      │                   │
+│ Hugo-COS │  10:23 Cobranza      │  ☐ Approve email  │
+│ Alicia   │  ran (87 invoices)   │     to T. Garcia  │
+│ Beto     │  10:24 Mora notif    │  ☐ Approve refund │
+│ Maribel  │  sent to 3 tenants   │     $1,200 MXN    │
+│ Luis     │  ...                 │                   │
+│          │                      │                   │
+└──────────┴──────────────────────┴───────────────────┘
+                              ┌───────────────────────┐
+                              │  Upcoming (7 days)    │
+                              └───────────────────────┘
+```
+
+### Criterios de éxito
+
+- Switch persiste entre sesiones.
+- Modo Agent carga `<150ms` (densidad alta no debe sacrificar perf).
+- Exceptions-first: si hay excepción crítica, salta encima del feed normal.
+- Retícula del fondo (distintivo BaW) presente en ambos modos.
+
+---
+
+## Fase 4 — Autonomy slider + policies engine
+
+**Objetivo:** que el dueño del tenant pueda regular **cuánto** decide cada agente sin tocar código, y que policies se respeten transversalmente.
+
+### Schema
+
+```sql
+CREATE TABLE public.agent_policies (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL REFERENCES public.agents(id) ON DELETE RESTRICT,
+  autonomy_level INT NOT NULL CHECK (autonomy_level BETWEEN 0 AND 4),
+  -- L0=disabled · L1=suggest only · L2=approve each · L3=approve batch · L4=full auto
+  per_action JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- override por action_type, p.ej. {"email.send":"REQUIRE_APPROVAL", "incident.update":"AUTO"}
+  rate_caps JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- {"actions_per_hour":50, "approvals_pending_max":20}
+  active BOOLEAN NOT NULL DEFAULT true,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  UNIQUE (org_id, agent_id)
+);
+```
+
+### Defaults conservadores propuestos
+
+| Agente | Autonomy default | Razón |
+|---|---|---|
+| Hugo-COS | L2 | Orquestador, decisiones de routing, bajo riesgo. |
+| Alicia-Ops | L3 | Volumen alto, acciones bien definidas. |
+| Beto-Conta | L1 | Dinero involucrado, riesgo regulatorio. |
+| Maribel-Law | L1 | Decisiones legales irreversibles. |
+| Luis-Growth | L2 | Outbound, riesgo de spam si L4. |
+| Andrés-CTO | L2 | Acciones técnicas con impacto productivo. |
+| Rafa-Research | L4 | Solo lee + sintetiza, sin write afuera. |
+| Cobranza | L2 | Manda emails a clientes. |
+| Mantenimiento | L3 | Crea tasks, asigna técnicos. |
+| Reservas/Atención | L2 | CX directo. |
+| Tarifas | L1 | Cambios de pricing impactan ingresos. |
+| Renovaciones | L2 | Outreach a residentes. |
+| Facturación | L1 | CFDI = SAT, cero margen de error. |
+| Reportes | L4 | Read-only + síntesis. |
+| Auditoría | L4 | Read-only governance. |
+| Fiscal | L1 | Compliance, cero margen. |
+
+### UI
+
+- Página `/admin/agents/[id]/policies` con slider 0–4 + toggles por action_type.
+- Audit log: quién cambió la policy, cuándo, valor anterior y nuevo.
+
+### Criterios de éxito
+
+- Cambiar autonomía de un agente toma <30s sin SQL.
+- Agente respeta su policy en runtime (test: subir Beto a L4 y ver que requiere approval no se gatilla).
+- Audit trail completo de cambios de policy.
+
+---
+
+## Cómo ejecutar este roadmap
+
+**Opciones equivalentes** (cualquiera funciona, cualquiera es interrumpible):
+
+1. **Claude Code (VS Code o Desktop)** con [`CLAUDE.md`](../CLAUDE.md) + estos docs. Mejor para flujo continuo y diseño visual.
+2. **Codex / Cursor** con [`AGENTS.md`](../AGENTS.md) + estos docs. Mejor para refactors grandes con review humano agresivo.
+3. **Computer (Perplexity)** con sesión activa. Mejor para handoff cross-session y multi-tooling.
+4. **Andrés (CTO OpenClaw)** vía Discord, siguiendo [`docs/COLAB_ANDRES.md`](./COLAB_ANDRES.md).
+
+Convención cross-tool: una rama por fase, PR a `main` con review humano explícito (no auto-merge), single-line commits.
+
+---
+
+## Referencias internas
+
+- [`CLAUDE.md`](../CLAUDE.md) — briefing canónico Claude Code
+- [`AGENTS.md`](../AGENTS.md) — briefing canónico Codex/Cursor
+- [`docs/PROJECT_STATE.md`](./PROJECT_STATE.md) — estado vivo del sprint
+- [`docs/MIGRATION_GUIDE.md`](./MIGRATION_GUIDE.md) — cómo arrancar en cada herramienta
+- [`docs/COLAB_ANDRES.md`](./COLAB_ANDRES.md) — protocolo Andrés/Discord
+- [`docs/AGENT_ROSTER.md`](./AGENT_ROSTER.md) — quién es quién
+- [`docs/AGENT_INTEGRATION.md`](./AGENT_INTEGRATION.md) — cómo conectar
+- [`docs/AGENTIC_PRINCIPLES.md`](./AGENTIC_PRINCIPLES.md) — principios condensados

--- a/docs/AGENT_ROSTER.md
+++ b/docs/AGENT_ROSTER.md
@@ -1,0 +1,222 @@
+# BaW OS — Agent Roster
+
+> Quiénes son los agentes que operan BaW OS. Agrupa los **10 internos BaW** (`pm-ops`, `experiencia`, `inteligencia`), el **BaW Coordinador** y los **6 ZXY third-party**. Define autonomía default, scopes default y rol esperado.
+>
+> Última actualización: 2026-05-03
+
+---
+
+## Estructura
+
+| Family | Cantidad | Quiénes | Identidad |
+|---|---|---|---|
+| `baw-coord` | 1 | BaW (coordinador raíz) | Único, orquesta agentes BaW internos |
+| `ops-core` | 3 | Cobranza, Mantenimiento, Facturación | BaW internos |
+| `experiencia` | 3 | Reservas, Atención, Tarifas, Renovaciones | BaW internos (Atención y Renovaciones cuentan como experiencia) |
+| `inteligencia` | 3 | Reportes, Auditoría, Fiscal | BaW internos |
+| `third-party` | 7 | Hugo-COS, Alicia-Ops, Beto-Conta, Maribel-Law, Luis-Growth, Andrés-CTO, Rafa-Research | ZXY shared, conectables |
+
+> Total: 10 internos + 1 coordinador + 7 third-party = **18 agentes** (16 + Andrés + Rafa nuevos en este doc).
+
+---
+
+## ZXY Third-party
+
+Agentes externos que **operan en nombre de la org BaW** vía API pública con identidad propia.
+
+### Hugo Sánchez — Chief of Staff
+
+- `id`: `hugo-cos`
+- **Rol:** orquestador. Recibe instrucciones del humano CEO/CoS y delega a Alicia, Beto, Maribel, Luis, Andrés, Rafa. Sintetiza outputs y rinde cuentas.
+- **Autonomy default:** L2 (approve each delegation)
+- **Scopes default:** `agents:run`, `runs:read`, `tasks:read`, `tasks:write`, `messages:send`, `insights:read`
+- **Patrón:** supervisor. Nunca actúa directo en payments/contracts/CFDI; siempre delega.
+- **Acción típica:** "Coordina cierre mensual: ejecuta Beto-Conta, espera resultado, dispara Reportes."
+
+### Alicia Cervantes — COO / Operadora Virtual BaW Mateos 809P
+
+- `id`: `alicia-ops`
+- **Rol:** operaciones diarias del producto BaW. Tiene acceso amplio a unidades, reservas, incidencias.
+- **Autonomy default:** L3 (approve batch)
+- **Scopes default:** `units:read`, `units:write`, `reservations:read`, `reservations:write`, `incidents:*`, `tasks:*`, `messages:send`
+- **Patrón:** worker bajo Hugo, también puede recibir órdenes directas del humano.
+- **Acción típica:** "Procesa todas las check-ins de hoy y reporta excepciones."
+
+### Beto — CFO / Contador
+
+- `id`: `conta-beto`
+- **Rol:** contabilidad, conciliación bancaria, soporte a Facturación interno.
+- **Autonomy default:** L1 (suggest only)
+- **Scopes default:** `payments:read`, `payments:trigger` (con REQUIRE_APPROVAL en `payment.charge`), `insights:read`, `messages:send`
+- **Patrón:** worker. Riesgo regulatorio alto, autonomía baja por diseño.
+- **Acción típica:** "Concilia cuenta BBVA con pagos del mes."
+
+### Maribel — CLO / Abogada Virtual
+
+- `id`: `maribel-law`
+- **Rol:** contratos, NDA, cumplimiento legal LATAM.
+- **Autonomy default:** L1 (suggest only)
+- **Scopes default:** `contracts:read`, `contracts:write` (con REQUIRE_APPROVAL en `contract.sign`), `insights:read`, `messages:send`
+- **Patrón:** worker. Decisiones legales irreversibles → autonomía baja.
+- **Acción típica:** "Revisa contrato de proveedor X y marca cláusulas de riesgo."
+
+### Luis — CGO / Growth & GTM
+
+- `id`: `luis-growth`
+- **Rol:** outbound, marketing, captación de tenants y propietarios.
+- **Autonomy default:** L2 (approve each)
+- **Scopes default:** `messages:send`, `insights:read`, `tasks:read`, `tasks:write`
+- **Patrón:** worker. Riesgo de spam si L4; mantener L2 hasta validar.
+- **Acción típica:** "Manda secuencia de outreach a 50 propietarios potenciales."
+
+### Andrés — CTO OpenClaw
+
+- `id`: `andres-cto` (NUEVO — pendiente migración)
+- **Rol:** coordinación técnica cross-platform. Ejecuta tasks técnicas que cruzan BaW ↔ OpenClaw ↔ otras plataformas ZXY.
+- **Autonomy default:** L2
+- **Scopes default:** `tasks:read`, `tasks:write`, `incidents:read`, `incidents:write`, `runs:read`
+- **Patrón:** worker técnico. Coordinación con humano Andrés vía Discord (ver [`COLAB_ANDRES.md`](./COLAB_ANDRES.md)).
+- **Acción típica:** "Crea incidente cross-platform cuando OpenClaw detecta anomalía en sync con BaW."
+
+### Rafa — Research / Customer Development
+
+- `id`: `rafa-research` (NUEVO — pendiente migración)
+- **Rol:** investigación de mercado, customer dev, síntesis competitiva. Read-only respecto al sistema operativo.
+- **Autonomy default:** L4 (full auto)
+- **Scopes default:** `insights:read`, `runs:read`, `units:read` (solo si necesita data agregada)
+- **Patrón:** worker independiente. Read-only afuera del producto, autonomía alta porque no hay efectos irreversibles.
+- **Acción típica:** "Sintetiza tendencias del mercado MTR en Querétaro Q2 2026."
+
+---
+
+## BaW Coordinador
+
+### BaW (raíz)
+
+- `id`: `baw` (raíz de family `baw-coord`)
+- **Rol:** orquestador supremo de los 10 agentes internos. No es ZXY; es producto.
+- **Autonomy default:** L2
+- **Scopes default:** `agents:run`, `agents:manage`, `runs:read`, `policies:read`, `tasks:*`, `insights:read`
+- **Patrón:** supervisor de Cobranza, Mantenimiento, Facturación, Reservas, Atención, Tarifas, Renovaciones, Reportes, Auditoría, Fiscal.
+- **Acción típica:** "Cron diario 02:00 — ejecuta Cobranza, espera, dispara Reportes."
+
+---
+
+## BaW Internos
+
+### Operaciones Core (`ops-core`)
+
+#### Cobranza
+
+- `id`: `cobranza`
+- Outreach automatizado mora preventiva/reactiva, escalonado.
+- **Autonomy default:** L2
+- **Scopes:** `payments:read`, `messages:send` (REQUIRE_APPROVAL si monto > umbral), `tasks:write`
+- Estado actual: **único agente con runner implementado** (`src/lib/agents/registry.ts`).
+
+#### Mantenimiento
+
+- `id`: `mantenimiento`
+- Triage de incidencias, asignación de técnicos, follow-up.
+- **Autonomy default:** L3
+- **Scopes:** `incidents:*`, `tasks:*`, `messages:send_internal`, `units:read`
+
+#### Facturación
+
+- `id`: `facturacion`
+- CFDI 4.0 vía PAC, conciliación, recibos electrónicos.
+- **Autonomy default:** L1 (SAT = cero margen)
+- **Scopes:** `payments:read`, `cfdi:emit` (siempre REQUIRE_APPROVAL), `contracts:read`
+
+### Experiencia (`experiencia`)
+
+#### Reservas
+
+- `id`: `reservas`
+- STR/MTR booking management, channel sync.
+- **Autonomy default:** L2
+- **Scopes:** `reservations:*`, `units:read`, `messages:send`
+
+#### Atención
+
+- `id`: `atencion`
+- 24/7 con residentes/huéspedes. FAQs, anuncios, surveys, quejas no críticas.
+- **Autonomy default:** L2
+- **Scopes:** `messages:*`, `incidents:read`, `incidents:write` (escalation), `tasks:read`
+
+#### Tarifas
+
+- `id`: `tarifas`
+- Dynamic pricing por temporada, eventos, ocupación, FX.
+- **Autonomy default:** L1 (cambios de pricing impactan ingresos)
+- **Scopes:** `units:read`, `units:write` (solo `pricing` field), `insights:read`
+
+#### Renovaciones
+
+- `id`: `renovaciones`
+- Outreach 60/30/15 días pre-vencimiento.
+- **Autonomy default:** L2
+- **Scopes:** `contracts:read`, `messages:send`, `tasks:write`, `insights:read`
+
+### Inteligencia (`inteligencia`)
+
+#### Reportes
+
+- `id`: `reportes`
+- Dashboards de propietario, narrativa LLM, briefings.
+- **Autonomy default:** L4 (read-only + síntesis)
+- **Scopes:** `*:read` (todos los recursos, solo lectura), `insights:read`, `messages:send_internal`
+
+#### Auditoría
+
+- `id`: `auditoria`
+- Audit trail inmutable, anomaly detection.
+- **Autonomy default:** L4 (read-only governance)
+- **Scopes:** `runs:read`, `*:read` (transversal vía RLS de auditoría)
+
+#### Fiscal
+
+- `id`: `fiscal`
+- Validación CFDI/SAT, monitoreo regulatorio.
+- **Autonomy default:** L1 (compliance, cero margen)
+- **Scopes:** `payments:read`, `cfdi:read`, `contracts:read`, `insights:read`
+
+---
+
+## Tabla resumen autonomía / scopes
+
+| Agente | Family | Autonomía default | Scopes count | Riesgo principal |
+|---|---|---:|---:|---|
+| Hugo-COS | third-party | L2 | 6 | Mala delegación |
+| Alicia-Ops | third-party | L3 | 8+ | Volumen alto |
+| Beto-Conta | third-party | L1 | 4 | Dinero |
+| Maribel-Law | third-party | L1 | 4 | Legal |
+| Luis-Growth | third-party | L2 | 4 | Spam |
+| Andrés-CTO | third-party | L2 | 5 | Cross-platform |
+| Rafa-Research | third-party | L4 | 3 | Bajo (read-only) |
+| BaW (coord) | baw-coord | L2 | 6+ | Orquestación |
+| Cobranza | ops-core | L2 | 3 | Customer-facing |
+| Mantenimiento | ops-core | L3 | 4 | Volumen |
+| Facturación | ops-core | L1 | 3 | SAT |
+| Reservas | experiencia | L2 | 3 | Compromiso económico |
+| Atención | experiencia | L2 | 4 | CX |
+| Tarifas | experiencia | L1 | 3 | Ingresos |
+| Renovaciones | experiencia | L2 | 4 | Customer churn |
+| Reportes | inteligencia | L4 | many (read) | Bajo (read-only) |
+| Auditoría | inteligencia | L4 | many (read) | Bajo (read-only) |
+| Fiscal | inteligencia | L1 | 4 | Compliance |
+
+---
+
+## Migraciones pendientes
+
+- [ ] Agregar `andres-cto` a `agents` table (third-party, status='planned').
+- [ ] Agregar `rafa-research` a `agents` table (third-party, status='planned').
+- [ ] Verificar que los 5 ZXY originales estén en `family='third-party'` (ya hecho por `20260502_agents_third_party_family.sql`).
+
+---
+
+## Cambios respecto a Notion canónico
+
+- **Andrés-CTO** y **Rafa-Research** son nuevos en este roster. Notion los menciona en el doc "Agentic Design Principles" como parte del ZXY Agent OS 1.0 pero no estaban sembrados en `agents`. Se sembrarán en próxima migración.
+- El "BaW Coordinador" se mantiene como entidad de family `baw-coord` separada de los 10 internos. Es producto, no ZXY.

--- a/src/app/agents/AgentModeView.tsx
+++ b/src/app/agents/AgentModeView.tsx
@@ -1,0 +1,364 @@
+// BaW OS — Modo Agent · Layout 3-paneles (Bloomberg/Linear-style)
+// Densidad alta · exception-first · misma data que Modo Human, distinto lenguaje visual.
+// Server component. El switch en sí es client-side (ViewModeSwitch).
+
+import Link from 'next/link'
+import ViewModeSwitch from '@/components/ViewModeSwitch'
+
+interface AgentRow {
+  id: string
+  display_name: string
+  full_name: string
+  family: string
+  domain: string
+  description: string | null
+  capability_level: number
+  feedback_level: number
+  status: string
+  is_shared_zxy: boolean
+}
+
+interface AgentRunRow {
+  id: string
+  agent_id: string
+  triggered_by: string
+  status: string
+  started_at: string
+  finished_at: string | null
+  duration_ms: number | null
+  metrics: {
+    actions_total?: number
+    actions_ok?: number
+    actions_failed?: number
+    actions_skipped?: number
+  } | null
+  error: string | null
+}
+
+interface Props {
+  agents: AgentRow[]
+  runs: AgentRunRow[]
+  orgId: string | null
+  viewMode: 'human' | 'agent'
+}
+
+const FAMILY_LABEL: Record<string, string> = {
+  'baw-coord': 'BaW',
+  'ops-core': 'Ops',
+  experiencia: 'Exp',
+  inteligencia: 'Int',
+  'third-party': '3P',
+  'pm-ops': 'Ops',
+  'zxy-shared': '3P',
+}
+
+function fmtTime(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleTimeString('es-MX', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  })
+}
+
+function fmtRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const min = Math.floor(diff / 60_000)
+  if (min < 1) return 'just now'
+  if (min < 60) return `${min}m ago`
+  const h = Math.floor(min / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  return `${d}d ago`
+}
+
+export default function AgentModeView({ agents, runs, orgId, viewMode }: Props) {
+  // Exceptions = runs failed o partial recientes
+  const exceptions = runs.filter(
+    (r) => r.status === 'failed' || r.status === 'partial'
+  )
+
+  // Activity timeline = runs ordenados (ya viene desc)
+  const timeline = runs.slice(0, 30)
+
+  // Roster ordenado: third-party primero (ZXY), luego baw-coord, luego escuadrones
+  const rosterOrder = ['third-party', 'baw-coord', 'ops-core', 'experiencia', 'inteligencia']
+  const rosterSorted = [...agents].sort((a, b) => {
+    const ai = rosterOrder.indexOf(a.family)
+    const bi = rosterOrder.indexOf(b.family)
+    if (ai !== bi) return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi)
+    return a.display_name.localeCompare(b.display_name)
+  })
+
+  // Stats agregados
+  const totalAgents = agents.length
+  const live = agents.filter((a) => a.status === 'live').length
+  const planned = agents.filter((a) => a.status === 'planned').length
+  const last24h = runs.filter(
+    (r) => Date.now() - new Date(r.started_at).getTime() < 24 * 3600_000
+  )
+  const succeededLast24 = last24h.filter((r) => r.status === 'succeeded').length
+  const failedLast24 = last24h.filter((r) => r.status === 'failed').length
+
+  return (
+    <div
+      className="space-y-3"
+      style={{ fontFamily: 'var(--font-mono, ui-monospace)' }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1
+            className="text-[18px] tracking-tight"
+            style={{ color: 'var(--baw-text)' }}
+          >
+            AGENT CONSOLE
+          </h1>
+          <p className="text-[10px]" style={{ color: 'var(--baw-muted)' }}>
+            {totalAgents} agents · {live} live · {planned} planned · last 24h:{' '}
+            <span style={{ color: 'var(--baw-success-fg)' }}>{succeededLast24}✓</span> ·{' '}
+            <span style={{ color: 'var(--baw-danger-fg)' }}>{failedLast24}✗</span>
+          </p>
+        </div>
+        <ViewModeSwitch initialMode={viewMode} size="sm" />
+      </div>
+
+      {/* Exceptions bar */}
+      {exceptions.length > 0 ? (
+        <div
+          className="rounded-md border-l-2 p-2 text-[11px]"
+          style={{
+            borderLeftColor: 'var(--baw-danger-fg)',
+            backgroundColor: 'var(--baw-danger-bg-soft)',
+          }}
+        >
+          <div
+            className="text-[10px] uppercase tracking-wider mb-1"
+            style={{ color: 'var(--baw-danger-fg)' }}
+          >
+            EXCEPTIONS · {exceptions.length}
+          </div>
+          {exceptions.slice(0, 3).map((r) => (
+            <div key={r.id} className="flex justify-between gap-3 py-0.5">
+              <span style={{ color: 'var(--baw-text)' }}>
+                <span className="font-semibold">{r.agent_id}</span>{' '}
+                <span style={{ color: 'var(--baw-muted)' }}>· {r.status}</span>
+              </span>
+              <span
+                className="truncate"
+                style={{ color: 'var(--baw-muted)', maxWidth: '60%' }}
+              >
+                {r.error || '—'}
+              </span>
+              <span
+                className="tabular-nums"
+                style={{ color: 'var(--baw-muted)' }}
+              >
+                {fmtRelative(r.started_at)}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div
+          className="rounded-md p-2 text-[11px]"
+          style={{
+            backgroundColor: 'var(--baw-success-bg-soft)',
+            color: 'var(--baw-success-fg)',
+          }}
+        >
+          <span className="uppercase tracking-wider">All systems normal</span>
+        </div>
+      )}
+
+      {/* 3-panel grid */}
+      <div className="grid grid-cols-12 gap-3">
+        {/* Roster sidebar */}
+        <aside
+          className="col-span-12 md:col-span-3 rounded-md p-2"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          <div
+            className="text-[10px] uppercase tracking-wider mb-2 pb-1"
+            style={{
+              color: 'var(--baw-muted)',
+              borderBottom: '1px solid var(--baw-border)',
+            }}
+          >
+            ROSTER
+          </div>
+          <div className="space-y-0.5">
+            {rosterSorted.map((a) => (
+              <Link
+                key={a.id}
+                href={`/agents/${a.id}/credentials`}
+                className="flex items-center justify-between gap-2 px-1.5 py-1 rounded text-[11px] hover:bg-black/5"
+                style={{ color: 'var(--baw-text)' }}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span
+                    className="text-[9px] px-1 py-0.5 rounded shrink-0"
+                    style={{
+                      backgroundColor: 'var(--baw-neutral-bg-soft)',
+                      color: 'var(--baw-neutral-fg)',
+                    }}
+                  >
+                    {FAMILY_LABEL[a.family] || '?'}
+                  </span>
+                  <span className="truncate">{a.display_name}</span>
+                </div>
+                <span
+                  className="text-[9px] tabular-nums shrink-0"
+                  style={{
+                    color:
+                      a.status === 'live'
+                        ? 'var(--baw-success-fg)'
+                        : a.status === 'beta'
+                          ? 'var(--baw-agent-fg)'
+                          : 'var(--baw-muted)',
+                  }}
+                >
+                  {a.status}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </aside>
+
+        {/* Activity timeline */}
+        <main
+          className="col-span-12 md:col-span-6 rounded-md p-2"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          <div
+            className="text-[10px] uppercase tracking-wider mb-2 pb-1 flex justify-between"
+            style={{
+              color: 'var(--baw-muted)',
+              borderBottom: '1px solid var(--baw-border)',
+            }}
+          >
+            <span>ACTIVITY · {timeline.length}</span>
+            {orgId && (
+              <span className="tabular-nums" style={{ color: 'var(--baw-faint)' }}>
+                org {orgId.slice(0, 8)}
+              </span>
+            )}
+          </div>
+          {timeline.length === 0 ? (
+            <div
+              className="text-[11px] py-8 text-center"
+              style={{ color: 'var(--baw-muted)' }}
+            >
+              {orgId ? 'No runs yet. Trigger one from Human mode.' : 'Login required.'}
+            </div>
+          ) : (
+            <div className="space-y-0.5 text-[11px]">
+              {timeline.map((r) => {
+                const m = r.metrics || {}
+                const statusColor =
+                  r.status === 'succeeded'
+                    ? 'var(--baw-success-fg)'
+                    : r.status === 'failed'
+                      ? 'var(--baw-danger-fg)'
+                      : r.status === 'partial'
+                        ? 'var(--baw-warning-fg)'
+                        : r.status === 'running'
+                          ? 'var(--baw-info-fg)'
+                          : 'var(--baw-muted)'
+                return (
+                  <div
+                    key={r.id}
+                    className="flex items-center gap-2 py-0.5 tabular-nums"
+                  >
+                    <span
+                      className="shrink-0 w-[60px]"
+                      style={{ color: 'var(--baw-muted)' }}
+                    >
+                      {fmtTime(r.started_at)}
+                    </span>
+                    <span
+                      className="shrink-0 w-[100px] truncate"
+                      style={{ color: 'var(--baw-text)' }}
+                    >
+                      {r.agent_id}
+                    </span>
+                    <span
+                      className="shrink-0 w-[60px]"
+                      style={{ color: 'var(--baw-muted)' }}
+                    >
+                      {r.triggered_by}
+                    </span>
+                    <span
+                      className="shrink-0 w-[70px] uppercase text-[10px]"
+                      style={{ color: statusColor }}
+                    >
+                      {r.status}
+                    </span>
+                    <span
+                      className="shrink-0"
+                      style={{ color: 'var(--baw-muted)' }}
+                    >
+                      {(m.actions_ok || 0)}✓·{(m.actions_failed || 0)}✗
+                    </span>
+                    <span
+                      className="ml-auto shrink-0"
+                      style={{ color: 'var(--baw-faint)' }}
+                    >
+                      {r.duration_ms != null ? `${r.duration_ms}ms` : '—'}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </main>
+
+        {/* Approval queue (placeholder Fase 4) */}
+        <aside
+          className="col-span-12 md:col-span-3 rounded-md p-2"
+          style={{
+            backgroundColor: 'var(--baw-surface)',
+            border: '1px solid var(--baw-border)',
+          }}
+        >
+          <div
+            className="text-[10px] uppercase tracking-wider mb-2 pb-1"
+            style={{
+              color: 'var(--baw-muted)',
+              borderBottom: '1px solid var(--baw-border)',
+            }}
+          >
+            APPROVAL QUEUE
+          </div>
+          <div
+            className="text-[11px] py-6 text-center"
+            style={{ color: 'var(--baw-muted)' }}
+          >
+            <p>Sin items pendientes.</p>
+            <p
+              className="mt-2 text-[10px]"
+              style={{ color: 'var(--baw-faint)' }}
+            >
+              Disponible cuando Fase 4 (autonomy slider) entre.
+            </p>
+          </div>
+        </aside>
+      </div>
+
+      <div className="text-[10px]" style={{ color: 'var(--baw-faint)' }}>
+        Modo Agent · densidad alta · exception-first · ver{' '}
+        <Link href="/docs" className="underline">
+          AGENTIC_PRINCIPLES.md
+        </Link>{' '}
+        para principios.
+      </div>
+    </div>
+  )
+}

--- a/src/app/agents/[id]/credentials/CredentialsManager.tsx
+++ b/src/app/agents/[id]/credentials/CredentialsManager.tsx
@@ -1,0 +1,357 @@
+'use client'
+
+// BaW OS — Cliente para gestionar credenciales de un agente
+// Maneja: listar, crear (mostrar key plana 1 vez), revocar.
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface CredentialRow {
+  id: string
+  agent_id: string
+  agent_name?: string
+  label: string
+  api_key_prefix: string
+  scopes: string[]
+  status: string
+  rate_limit_tier: string
+  expires_at: string | null
+  last_used_at: string | null
+  created_at: string
+  revoked_at: string | null
+}
+
+interface Props {
+  agentId: string
+  agentName: string
+  initialCredentials: CredentialRow[]
+}
+
+const COMMON_SCOPES = [
+  'units:read',
+  'units:write',
+  'reservations:read',
+  'reservations:write',
+  'payments:read',
+  'payments:trigger',
+  'contracts:read',
+  'contracts:write',
+  'incidents:read',
+  'incidents:write',
+  'tasks:read',
+  'tasks:write',
+  'agents:run',
+  'runs:read',
+  'insights:read',
+  'messages:send',
+  'messages:read',
+]
+
+export default function CredentialsManager({
+  agentId,
+  agentName,
+  initialCredentials,
+}: Props) {
+  const router = useRouter()
+  const [credentials, setCredentials] = useState<CredentialRow[]>(initialCredentials)
+  const [showForm, setShowForm] = useState(false)
+  const [label, setLabel] = useState('prod')
+  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set())
+  const [rateLimitTier, setRateLimitTier] = useState<'standard' | 'elevated' | 'unlimited'>(
+    'standard'
+  )
+  const [expiresInDays, setExpiresInDays] = useState<number | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [revealedKey, setRevealedKey] = useState<{
+    plain: string
+    label: string
+  } | null>(null)
+
+  const toggleScope = (scope: string) => {
+    setSelectedScopes((prev) => {
+      const next = new Set(prev)
+      if (next.has(scope)) next.delete(scope)
+      else next.add(scope)
+      return next
+    })
+  }
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setCreating(true)
+    try {
+      const res = await fetch(`/api/admin/agents/${agentId}/credentials`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          label: label.trim(),
+          scopes: Array.from(selectedScopes),
+          rate_limit_tier: rateLimitTier,
+          expires_in_days: expiresInDays,
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        setError(json.error || `HTTP ${res.status}`)
+        return
+      }
+      setRevealedKey({ plain: json.data.api_key, label: json.data.label })
+      setCredentials((prev) => [
+        {
+          id: json.data.id,
+          agent_id: agentId,
+          agent_name: agentName,
+          label: json.data.label,
+          api_key_prefix: json.data.api_key_prefix,
+          scopes: json.data.scopes,
+          status: json.data.status,
+          rate_limit_tier: json.data.rate_limit_tier,
+          expires_at: json.data.expires_at,
+          last_used_at: null,
+          created_at: json.data.created_at,
+          revoked_at: null,
+        },
+        ...prev,
+      ])
+      setShowForm(false)
+      setLabel('prod')
+      setSelectedScopes(new Set())
+      setRateLimitTier('standard')
+      setExpiresInDays(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Network error')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleRevoke = async (credentialId: string) => {
+    if (!confirm('¿Revocar esta credencial? Esta acción no se puede deshacer.')) return
+    try {
+      const res = await fetch(
+        `/api/admin/agents/${agentId}/credentials?credential_id=${credentialId}`,
+        { method: 'DELETE' }
+      )
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        alert(json.error || `HTTP ${res.status}`)
+        return
+      }
+      router.refresh()
+      setCredentials((prev) =>
+        prev.map((c) =>
+          c.id === credentialId
+            ? { ...c, status: 'revoked', revoked_at: new Date().toISOString() }
+            : c
+        )
+      )
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Network error')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {revealedKey && (
+        <div className="rounded-lg border-2 border-amber-400 bg-amber-50 p-4">
+          <p className="font-medium text-amber-900">Credencial creada: {revealedKey.label}</p>
+          <p className="mt-2 text-sm text-amber-800">
+            Esta es la única vez que verás la key completa. Cópiala ahora — no se puede recuperar
+            después.
+          </p>
+          <pre className="mt-3 overflow-x-auto rounded border border-amber-300 bg-white p-3 font-mono text-sm">
+            {revealedKey.plain}
+          </pre>
+          <button
+            onClick={() => navigator.clipboard.writeText(revealedKey.plain)}
+            className="mt-2 rounded bg-amber-900 px-3 py-1 text-sm text-white hover:bg-amber-950"
+          >
+            Copiar al portapapeles
+          </button>
+          <button
+            onClick={() => setRevealedKey(null)}
+            className="ml-2 rounded border border-amber-300 px-3 py-1 text-sm text-amber-900 hover:bg-amber-100"
+          >
+            Ya la guardé
+          </button>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-medium">Credenciales activas</h2>
+        {!showForm && (
+          <button
+            onClick={() => setShowForm(true)}
+            className="rounded bg-neutral-900 px-4 py-2 text-sm text-white hover:bg-neutral-800"
+          >
+            + Nueva credencial
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <form onSubmit={handleCreate} className="space-y-4 rounded-lg border bg-white p-4">
+          <div>
+            <label className="mb-1 block text-sm font-medium">Label</label>
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              maxLength={32}
+              required
+              className="w-full rounded border px-3 py-2 text-sm"
+              placeholder="prod, staging, dev-local"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium">Scopes</label>
+            <div className="grid grid-cols-2 gap-1 text-sm md:grid-cols-3">
+              {COMMON_SCOPES.map((scope) => (
+                <label key={scope} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={selectedScopes.has(scope)}
+                    onChange={() => toggleScope(scope)}
+                  />
+                  <span className="font-mono text-xs">{scope}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium">Rate limit tier</label>
+              <select
+                value={rateLimitTier}
+                onChange={(e) =>
+                  setRateLimitTier(e.target.value as 'standard' | 'elevated' | 'unlimited')
+                }
+                className="w-full rounded border px-3 py-2 text-sm"
+              >
+                <option value="standard">standard</option>
+                <option value="elevated">elevated</option>
+                <option value="unlimited">unlimited</option>
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Expira en (días)</label>
+              <input
+                type="number"
+                min={1}
+                max={3650}
+                value={expiresInDays ?? ''}
+                onChange={(e) =>
+                  setExpiresInDays(e.target.value ? parseInt(e.target.value, 10) : null)
+                }
+                placeholder="vacío = no expira"
+                className="w-full rounded border px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={creating}
+              className="rounded bg-neutral-900 px-4 py-2 text-sm text-white hover:bg-neutral-800 disabled:opacity-50"
+            >
+              {creating ? 'Creando…' : 'Crear credencial'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowForm(false)
+                setError(null)
+              }}
+              className="rounded border px-4 py-2 text-sm hover:bg-neutral-100"
+            >
+              Cancelar
+            </button>
+          </div>
+        </form>
+      )}
+
+      <div className="overflow-x-auto rounded-lg border bg-white">
+        <table className="w-full text-sm">
+          <thead className="bg-neutral-50 text-left">
+            <tr>
+              <th className="px-3 py-2">Label</th>
+              <th className="px-3 py-2">Prefix</th>
+              <th className="px-3 py-2">Status</th>
+              <th className="px-3 py-2">Scopes</th>
+              <th className="px-3 py-2">Tier</th>
+              <th className="px-3 py-2">Last used</th>
+              <th className="px-3 py-2">Expires</th>
+              <th className="px-3 py-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {credentials.length === 0 && (
+              <tr>
+                <td colSpan={8} className="px-3 py-6 text-center text-neutral-500">
+                  Sin credenciales todavía.
+                </td>
+              </tr>
+            )}
+            {credentials.map((c) => (
+              <tr key={c.id} className="border-t">
+                <td className="px-3 py-2 font-medium">{c.label}</td>
+                <td className="px-3 py-2 font-mono text-xs">{c.api_key_prefix}…</td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`rounded px-2 py-0.5 text-xs ${
+                      c.status === 'active'
+                        ? 'bg-green-100 text-green-900'
+                        : c.status === 'revoked'
+                          ? 'bg-red-100 text-red-900'
+                          : 'bg-neutral-100 text-neutral-700'
+                    }`}
+                  >
+                    {c.status}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-xs">
+                  {c.scopes.length === 0 ? (
+                    <span className="text-neutral-500">—</span>
+                  ) : (
+                    <span className="font-mono">
+                      {c.scopes.slice(0, 2).join(', ')}
+                      {c.scopes.length > 2 && ` +${c.scopes.length - 2}`}
+                    </span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-xs">{c.rate_limit_tier}</td>
+                <td className="px-3 py-2 text-xs">
+                  {c.last_used_at
+                    ? new Date(c.last_used_at).toLocaleString()
+                    : <span className="text-neutral-500">never</span>}
+                </td>
+                <td className="px-3 py-2 text-xs">
+                  {c.expires_at
+                    ? new Date(c.expires_at).toLocaleDateString()
+                    : <span className="text-neutral-500">no expira</span>}
+                </td>
+                <td className="px-3 py-2">
+                  {c.status === 'active' && (
+                    <button
+                      onClick={() => handleRevoke(c.id)}
+                      className="text-xs text-red-700 hover:underline"
+                    >
+                      Revocar
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/agents/[id]/credentials/page.tsx
+++ b/src/app/agents/[id]/credentials/page.tsx
@@ -1,0 +1,160 @@
+// BaW OS — /agents/[id]/credentials · Gestión de API keys por agente
+// Owners/admins del tenant generan, listan y revocan credenciales aquí.
+
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { createServiceClient } from '@/lib/supabase'
+import { resolveOrgId, OrgContextError } from '@/lib/org-context'
+import { createSupabaseServer } from '@/lib/supabase-server'
+import CredentialsManager from './CredentialsManager'
+
+export const dynamic = 'force-dynamic'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+interface AgentRow {
+  id: string
+  display_name: string
+  full_name: string
+  family: string
+  domain: string
+  description: string | null
+  is_shared_zxy: boolean
+}
+
+interface CredentialRow {
+  id: string
+  agent_id: string
+  agent_name: string
+  label: string
+  api_key_prefix: string
+  scopes: string[]
+  status: string
+  rate_limit_tier: string
+  expires_at: string | null
+  last_used_at: string | null
+  created_at: string
+  revoked_at: string | null
+}
+
+async function requireAdminOfActiveOrg(): Promise<{
+  ok: true
+  orgId: string
+  isPlatformAdmin: boolean
+} | null> {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return null
+
+  const service = createServiceClient()
+
+  const { data: pa } = await service
+    .from('platform_admins')
+    .select('user_id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  const isPlatformAdmin = !!pa
+
+  let orgId: string
+  try {
+    orgId = await resolveOrgId()
+  } catch (e) {
+    if (e instanceof OrgContextError) return null
+    throw e
+  }
+
+  if (!isPlatformAdmin) {
+    const { data: membership } = await service
+      .from('org_members')
+      .select('role')
+      .eq('user_id', user.id)
+      .eq('org_id', orgId)
+      .maybeSingle()
+    if (!membership || !['owner', 'admin'].includes(membership.role as string)) {
+      return null
+    }
+  }
+
+  return { ok: true, orgId, isPlatformAdmin }
+}
+
+async function loadAgent(id: string): Promise<AgentRow | null> {
+  const service = createServiceClient()
+  const { data } = await service
+    .from('agents')
+    .select('id, display_name, full_name, family, domain, description, is_shared_zxy')
+    .eq('id', id)
+    .maybeSingle()
+  return (data as AgentRow) || null
+}
+
+async function loadCredentials(agentId: string, orgId: string): Promise<CredentialRow[]> {
+  const service = createServiceClient()
+  const { data } = await service
+    .from('v_agent_credentials_audit')
+    .select('*')
+    .eq('agent_id', agentId)
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false })
+  return (data as CredentialRow[]) || []
+}
+
+export default async function AgentCredentialsPage({ params }: PageProps) {
+  const resolvedParams = await params
+  const agentId = resolvedParams.id
+
+  const ctx = await requireAdminOfActiveOrg()
+  if (!ctx) {
+    redirect(`/login?next=/agents/${agentId}/credentials`)
+  }
+
+  const agent = await loadAgent(agentId)
+  if (!agent) {
+    return (
+      <div className="container mx-auto max-w-4xl px-4 py-8">
+        <p className="text-sm text-neutral-500">
+          Agente no encontrado.{' '}
+          <Link href="/agents" className="underline">
+            Volver al catálogo
+          </Link>
+        </p>
+      </div>
+    )
+  }
+
+  const credentials = await loadCredentials(agentId, ctx.orgId)
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4 py-8">
+      <nav className="mb-6 text-sm">
+        <Link href="/agents" className="text-neutral-500 hover:text-neutral-900">
+          ← Agentes
+        </Link>
+      </nav>
+
+      <header className="mb-8">
+        <h1 className="text-3xl font-semibold">{agent.full_name} · Credenciales</h1>
+        <p className="mt-2 text-sm text-neutral-600">{agent.description}</p>
+        <div className="mt-2 flex gap-2 text-xs">
+          <span className="rounded bg-neutral-100 px-2 py-0.5">
+            family: {agent.family}
+          </span>
+          <span className="rounded bg-neutral-100 px-2 py-0.5">domain: {agent.domain}</span>
+          {agent.is_shared_zxy && (
+            <span className="rounded bg-amber-100 px-2 py-0.5 text-amber-900">ZXY shared</span>
+          )}
+        </div>
+      </header>
+
+      <CredentialsManager
+        agentId={agentId}
+        agentName={agent.full_name}
+        initialCredentials={credentials}
+      />
+    </div>
+  )
+}

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -4,7 +4,10 @@ import Link from 'next/link'
 import { createServiceClient } from '@/lib/api-auth'
 import { resolveOrgId } from '@/lib/org-context'
 import { listImplementedAgents } from '@/lib/agents/registry'
+import { getViewMode } from '@/lib/agents/view-mode'
 import AgentRunButton from './AgentRunButton'
+import ViewModeSwitch from '@/components/ViewModeSwitch'
+import AgentModeView from './AgentModeView'
 
 export const dynamic = 'force-dynamic'
 
@@ -132,6 +135,18 @@ function RunStatusBadge({ status }: { status: string }) {
 export default async function AgentsPage() {
   const { agents, runs, orgId } = await loadData()
   const implemented = new Set<string>(listImplementedAgents())
+  const viewMode = await getViewMode()
+
+  if (viewMode === 'agent') {
+    return (
+      <AgentModeView
+        agents={agents}
+        runs={runs}
+        orgId={orgId}
+        viewMode={viewMode}
+      />
+    )
+  }
 
   const grouped = agents.reduce<Record<string, AgentRow[]>>((acc, a) => {
     acc[a.family] = acc[a.family] || []
@@ -154,6 +169,9 @@ export default async function AgentsPage() {
         >
           BaW + 10 especialistas en 3 escuadrones · Operaciones Core · Experiencia · Inteligencia · Third Party · Roster v0.2 · v1: Cobranza dunning
         </p>
+        <div className="mt-3">
+          <ViewModeSwitch initialMode={viewMode} />
+        </div>
       </div>
 
       {Object.entries(grouped)

--- a/src/app/api/admin/agents/[id]/credentials/route.ts
+++ b/src/app/api/admin/agents/[id]/credentials/route.ts
@@ -1,0 +1,235 @@
+// BaW OS — Admin: gestión de credenciales por agente
+// GET   /api/admin/agents/[id]/credentials              — listar (sin hash)
+// POST  /api/admin/agents/[id]/credentials              — crear nueva (devuelve key plana 1 vez)
+// DELETE /api/admin/agents/[id]/credentials?credential_id=... — revocar
+//
+// RLS protege a nivel DB; aquí además validamos que el caller sea owner/admin
+// de la org activa o platform_admin.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { resolveOrgId, OrgContextError } from '@/lib/org-context'
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { generateApiKey, hashApiKey } from '@/lib/agents/auth'
+import type { AgentId } from '@/lib/agents/types'
+
+interface RouteContext {
+  params: Promise<{ id: string }>
+}
+
+async function requireAdminCaller(): Promise<
+  | { ok: true; userId: string; orgId: string; isPlatformAdmin: boolean }
+  | { ok: false; status: number; message: string }
+> {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+    error: userErr,
+  } = await supabase.auth.getUser()
+  if (userErr || !user) {
+    return { ok: false, status: 401, message: 'No authenticated user' }
+  }
+
+  const service = createServiceClient()
+  const { data: pa } = await service
+    .from('platform_admins')
+    .select('user_id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  const isPlatformAdmin = !!pa
+
+  let orgId: string
+  try {
+    orgId = await resolveOrgId()
+  } catch (e) {
+    if (e instanceof OrgContextError) {
+      return { ok: false, status: 401, message: e.message }
+    }
+    throw e
+  }
+
+  if (!isPlatformAdmin) {
+    const { data: membership } = await service
+      .from('org_members')
+      .select('role')
+      .eq('user_id', user.id)
+      .eq('org_id', orgId)
+      .maybeSingle()
+    if (!membership || !['owner', 'admin'].includes(membership.role as string)) {
+      return { ok: false, status: 403, message: 'Owner or admin role required' }
+    }
+  }
+
+  return { ok: true, userId: user.id, orgId, isPlatformAdmin }
+}
+
+export async function GET(_req: NextRequest, ctx: RouteContext) {
+  const params = await ctx.params
+  const agentId = params.id
+
+  const auth = await requireAdminCaller()
+  if (!auth.ok) {
+    return NextResponse.json(
+      { success: false, error: auth.message },
+      { status: auth.status }
+    )
+  }
+
+  const service = createServiceClient()
+  const { data, error } = await service
+    .from('v_agent_credentials_audit')
+    .select('*')
+    .eq('org_id', auth.orgId)
+    .eq('agent_id', agentId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ success: true, data: data || [] })
+}
+
+export async function POST(req: NextRequest, ctx: RouteContext) {
+  const params = await ctx.params
+  const agentId = params.id as AgentId
+
+  const auth = await requireAdminCaller()
+  if (!auth.ok) {
+    return NextResponse.json(
+      { success: false, error: auth.message },
+      { status: auth.status }
+    )
+  }
+
+  let body: {
+    label?: string
+    scopes?: string[]
+    rate_limit_tier?: 'standard' | 'elevated' | 'unlimited'
+    expires_in_days?: number | null
+  }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Invalid JSON body' },
+      { status: 400 }
+    )
+  }
+
+  const label = (body.label || '').trim()
+  if (!label || label.length > 32) {
+    return NextResponse.json(
+      { success: false, error: 'label is required (1-32 chars)' },
+      { status: 400 }
+    )
+  }
+  const scopes = Array.isArray(body.scopes) ? body.scopes.filter((s) => typeof s === 'string') : []
+  const rateLimitTier = body.rate_limit_tier || 'standard'
+  if (!['standard', 'elevated', 'unlimited'].includes(rateLimitTier)) {
+    return NextResponse.json(
+      { success: false, error: 'invalid rate_limit_tier' },
+      { status: 400 }
+    )
+  }
+
+  // Validar que el agente existe
+  const service = createServiceClient()
+  const { data: agent, error: agentErr } = await service
+    .from('agents')
+    .select('id')
+    .eq('id', agentId)
+    .maybeSingle()
+  if (agentErr || !agent) {
+    return NextResponse.json(
+      { success: false, error: 'Agent not found' },
+      { status: 404 }
+    )
+  }
+
+  // Generar key + hash
+  const { plainKey, prefix } = generateApiKey('live')
+  const apiKeyHash = await hashApiKey(plainKey)
+
+  const expiresAt = body.expires_in_days
+    ? new Date(Date.now() + body.expires_in_days * 24 * 60 * 60 * 1000).toISOString()
+    : null
+
+  const { data: credential, error: insertErr } = await service
+    .from('agent_credentials')
+    .insert({
+      org_id: auth.orgId,
+      agent_id: agentId,
+      label,
+      api_key_hash: apiKeyHash,
+      api_key_prefix: prefix,
+      scopes,
+      rate_limit_tier: rateLimitTier,
+      expires_at: expiresAt,
+      created_by: auth.userId,
+    })
+    .select('id, label, api_key_prefix, scopes, status, rate_limit_tier, expires_at, created_at')
+    .single()
+
+  if (insertErr || !credential) {
+    const msg = insertErr?.message || 'Failed to create credential'
+    const isDup = msg.includes('duplicate') || msg.includes('unique')
+    return NextResponse.json(
+      { success: false, error: isDup ? `Label "${label}" already exists for this agent` : msg },
+      { status: isDup ? 409 : 500 }
+    )
+  }
+
+  // Devolver la key plana UNA SOLA VEZ
+  return NextResponse.json({
+    success: true,
+    data: {
+      ...credential,
+      api_key: plainKey,
+      warning:
+        'Esta es la única vez que verás la key completa. Guárdala ahora — no se puede recuperar después.',
+    },
+  })
+}
+
+export async function DELETE(req: NextRequest, _ctx: RouteContext) {
+  const credentialId = req.nextUrl.searchParams.get('credential_id')
+  if (!credentialId) {
+    return NextResponse.json(
+      { success: false, error: 'credential_id query param required' },
+      { status: 400 }
+    )
+  }
+
+  const auth = await requireAdminCaller()
+  if (!auth.ok) {
+    return NextResponse.json(
+      { success: false, error: auth.message },
+      { status: auth.status }
+    )
+  }
+
+  const service = createServiceClient()
+  const { error } = await service
+    .from('agent_credentials')
+    .update({
+      status: 'revoked',
+      revoked_at: new Date().toISOString(),
+      revoked_by: auth.userId,
+    })
+    .eq('id', credentialId)
+    .eq('org_id', auth.orgId)
+    .eq('status', 'active')
+
+  if (error) {
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/me/view-mode/route.ts
+++ b/src/app/api/me/view-mode/route.ts
@@ -1,0 +1,37 @@
+// BaW OS — GET/POST /api/me/view-mode
+// Lee y persiste la preferencia Human/Agent del usuario activo en su org activa.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getViewMode, setViewMode, type ViewMode } from '@/lib/agents/view-mode'
+
+export async function GET() {
+  const mode = await getViewMode()
+  return NextResponse.json({ success: true, data: { mode } })
+}
+
+export async function POST(req: NextRequest) {
+  let body: { mode?: ViewMode }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Invalid JSON body' },
+      { status: 400 }
+    )
+  }
+  const mode = body.mode
+  if (mode !== 'human' && mode !== 'agent') {
+    return NextResponse.json(
+      { success: false, error: 'mode must be "human" or "agent"' },
+      { status: 400 }
+    )
+  }
+  const result = await setViewMode(mode)
+  if (!result.ok) {
+    return NextResponse.json(
+      { success: false, error: result.error || 'Failed to set view mode' },
+      { status: 500 }
+    )
+  }
+  return NextResponse.json({ success: true, data: { mode } })
+}

--- a/src/app/api/mora/route.ts
+++ b/src/app/api/mora/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { getMoraLevel, type MoraStatus } from '@/lib/mora-engine'
+import {
+  authenticateAgentRequest,
+  agentAuthErrorResponse,
+  validateLegacyApiKey,
+} from '@/lib/agents/auth'
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ||
@@ -13,10 +18,15 @@ function createMoraClient() {
 }
 
 export async function GET(request: NextRequest) {
-  const apiKey = request.headers.get('x-api-key')
-  const expected = process.env.BAWOS_API_KEY
-  if (!expected || apiKey !== expected) {
-    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
+  // Fase 1 transition: aceptamos credenciales sk_live_/sk_test_ (nueva) o
+  // BAWOS_API_KEY global (legacy). El legacy se elimina en Fase 2.
+  const auth = await authenticateAgentRequest(request, ['mora:read'])
+  if (!auth.ok) {
+    if (validateLegacyApiKey(request)) {
+      // Legacy path: aceptado pero sin identidad de agente.
+    } else {
+      return agentAuthErrorResponse(auth)
+    }
   }
 
   try {

--- a/src/components/ViewModeSwitch.tsx
+++ b/src/components/ViewModeSwitch.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+// BaW OS — Switch Human ↔ Agent
+// Drop-in: monta donde quieras (sidebar, navbar, header).
+// Persiste vía POST /api/me/view-mode → org_members.preferred_view_mode.
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { User2, Bot } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export type ViewMode = 'human' | 'agent'
+
+interface Props {
+  initialMode?: ViewMode
+  className?: string
+  size?: 'sm' | 'md'
+}
+
+export default function ViewModeSwitch({
+  initialMode,
+  className,
+  size = 'md',
+}: Props) {
+  const router = useRouter()
+  const [mode, setMode] = useState<ViewMode>(initialMode || 'human')
+  const [saving, setSaving] = useState(false)
+
+  // Si no llegó initialMode, lo cargamos client-side
+  useEffect(() => {
+    if (initialMode) return
+    fetch('/api/me/view-mode')
+      .then((r) => r.json())
+      .then((j) => {
+        if (j?.success && j.data?.mode) setMode(j.data.mode as ViewMode)
+      })
+      .catch(() => {})
+  }, [initialMode])
+
+  const apply = async (next: ViewMode) => {
+    if (next === mode) return
+    setSaving(true)
+    setMode(next)
+    try {
+      await fetch('/api/me/view-mode', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mode: next }),
+      })
+      router.refresh()
+    } catch {
+      // revert si falla
+      setMode(mode)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const padding = size === 'sm' ? 'px-2 py-1 text-xs' : 'px-3 py-1.5 text-sm'
+  const iconSize = size === 'sm' ? 12 : 14
+
+  return (
+    <div
+      role="group"
+      aria-label="View mode"
+      className={cn(
+        'inline-flex rounded-md border border-neutral-200 bg-white p-0.5',
+        saving && 'opacity-70',
+        className
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => apply('human')}
+        aria-pressed={mode === 'human'}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded transition-colors',
+          padding,
+          mode === 'human'
+            ? 'bg-neutral-900 text-white'
+            : 'text-neutral-600 hover:bg-neutral-100'
+        )}
+      >
+        <User2 size={iconSize} />
+        Human
+      </button>
+      <button
+        type="button"
+        onClick={() => apply('agent')}
+        aria-pressed={mode === 'agent'}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded transition-colors',
+          padding,
+          mode === 'agent'
+            ? 'bg-neutral-900 text-white'
+            : 'text-neutral-600 hover:bg-neutral-100'
+        )}
+      >
+        <Bot size={iconSize} />
+        Agent
+      </button>
+    </div>
+  )
+}

--- a/src/lib/agents/auth.ts
+++ b/src/lib/agents/auth.ts
@@ -1,0 +1,229 @@
+// BaW OS — Agent Authentication (Fase 1 del Agent Platform Roadmap)
+// Una identidad por agente, por org. Reemplaza el patrón BAWOS_API_KEY global.
+// Contrato: ver docs/AGENT_INTEGRATION.md
+//
+// Nota de seguridad: usamos SHA-256 (Web Crypto, sin deps nuevas) con timing-safe
+// compare. Suficiente para API keys de agente (no son passwords humanos, y se
+// almacenan + transmiten siempre por canales TLS). Para Fase 2 evaluaremos bcrypt
+// si las claves se filtran por logs accidentalmente.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import type { AgentId } from './types'
+
+const KEY_PREFIX_LIVE = 'sk_live_'
+const KEY_PREFIX_TEST = 'sk_test_'
+const PREFIX_LOOKUP_LEN = 12
+
+export interface AgentAuthResult {
+  ok: true
+  credentialId: string
+  orgId: string
+  agentId: AgentId
+  scopes: string[]
+  rateLimitTier: 'standard' | 'elevated' | 'unlimited'
+}
+
+export interface AgentAuthFailure {
+  ok: false
+  status: number
+  code: string
+  message: string
+}
+
+/**
+ * Hashea una API key para almacenamiento. Determinístico (sin salt) porque
+ * necesitamos lookup-by-hash para validación. La protección viene de:
+ *  1. La key plana solo se devuelve una vez al crear.
+ *  2. SHA-256 sin colisiones prácticas.
+ *  3. RLS: solo admins ven el hash.
+ */
+export async function hashApiKey(plainKey: string): Promise<string> {
+  const enc = new TextEncoder().encode(plainKey)
+  const buf = await crypto.subtle.digest('SHA-256', enc)
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Genera una nueva API key con prefix visible.
+ * Formato: sk_live_<32 hex chars random>
+ */
+export function generateApiKey(env: 'live' | 'test' = 'live'): {
+  plainKey: string
+  prefix: string
+} {
+  const bytes = new Uint8Array(24)
+  crypto.getRandomValues(bytes)
+  const random = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+  const fullPrefix = env === 'live' ? KEY_PREFIX_LIVE : KEY_PREFIX_TEST
+  const plainKey = `${fullPrefix}${random}`
+  return { plainKey, prefix: plainKey.slice(0, PREFIX_LOOKUP_LEN) }
+}
+
+/**
+ * Timing-safe string compare para hashes. Evita ataques por tiempo.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}
+
+/**
+ * Extrae la API key del request. Acepta:
+ *  - Authorization: Bearer sk_live_...
+ *  - x-api-key: sk_live_...
+ */
+function extractApiKey(req: NextRequest): string | null {
+  const auth = req.headers.get('authorization')
+  if (auth && auth.startsWith('Bearer ')) {
+    return auth.slice('Bearer '.length).trim()
+  }
+  const xApi = req.headers.get('x-api-key')
+  if (xApi) return xApi.trim()
+  return null
+}
+
+/**
+ * Valida un request contra la tabla agent_credentials.
+ * Devuelve identidad del agente o failure con status code apropiado.
+ *
+ * Uso:
+ *   const auth = await authenticateAgentRequest(req, ['units:read'])
+ *   if (!auth.ok) return NextResponse.json({ error: auth.code }, { status: auth.status })
+ */
+export async function authenticateAgentRequest(
+  req: NextRequest,
+  requiredScopes: string[] = []
+): Promise<AgentAuthResult | AgentAuthFailure> {
+  const plainKey = extractApiKey(req)
+  if (!plainKey) {
+    return {
+      ok: false,
+      status: 401,
+      code: 'missing_credentials',
+      message: 'Missing Authorization or x-api-key header',
+    }
+  }
+
+  if (!plainKey.startsWith(KEY_PREFIX_LIVE) && !plainKey.startsWith(KEY_PREFIX_TEST)) {
+    return {
+      ok: false,
+      status: 401,
+      code: 'invalid_credential_format',
+      message: 'API key must start with sk_live_ or sk_test_',
+    }
+  }
+
+  const prefix = plainKey.slice(0, PREFIX_LOOKUP_LEN)
+  const hash = await hashApiKey(plainKey)
+
+  const supabase = createServiceClient()
+
+  // Lookup por prefix activo, luego validar hash en memoria con timing-safe.
+  const { data: rows, error } = await supabase
+    .from('agent_credentials')
+    .select('id, org_id, agent_id, api_key_hash, scopes, status, expires_at, rate_limit_tier')
+    .eq('api_key_prefix', prefix)
+    .eq('status', 'active')
+
+  if (error) {
+    return {
+      ok: false,
+      status: 500,
+      code: 'auth_lookup_failed',
+      message: error.message,
+    }
+  }
+
+  const candidates = rows || []
+  const matched = candidates.find((row) =>
+    timingSafeEqual(row.api_key_hash as string, hash)
+  )
+
+  if (!matched) {
+    return {
+      ok: false,
+      status: 401,
+      code: 'invalid_credential',
+      message: 'API key not recognized or revoked',
+    }
+  }
+
+  // Expiry check
+  if (matched.expires_at) {
+    const expiresAt = new Date(matched.expires_at as string).getTime()
+    if (Date.now() > expiresAt) {
+      // Soft-mark expired (best-effort; no bloqueante)
+      void supabase
+        .from('agent_credentials')
+        .update({ status: 'expired' })
+        .eq('id', matched.id as string)
+      return {
+        ok: false,
+        status: 401,
+        code: 'credential_expired',
+        message: 'API key expired',
+      }
+    }
+  }
+
+  // Scope check
+  const grantedScopes = (matched.scopes as string[]) || []
+  const missing = requiredScopes.filter(
+    (s) => !grantedScopes.includes(s) && !grantedScopes.includes('*')
+  )
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      status: 403,
+      code: 'forbidden_scope',
+      message: `Missing required scopes: ${missing.join(', ')}`,
+    }
+  }
+
+  // Touch last_used_at (fire-and-forget)
+  void supabase.rpc('touch_agent_credential', { p_credential_id: matched.id as string })
+
+  return {
+    ok: true,
+    credentialId: matched.id as string,
+    orgId: matched.org_id as string,
+    agentId: matched.agent_id as AgentId,
+    scopes: grantedScopes,
+    rateLimitTier: (matched.rate_limit_tier as 'standard' | 'elevated' | 'unlimited') ||
+      'standard',
+  }
+}
+
+/**
+ * Helper para responder con error de auth en formato consistente.
+ */
+export function agentAuthErrorResponse(failure: AgentAuthFailure): NextResponse {
+  return NextResponse.json(
+    {
+      success: false,
+      error: { code: failure.code, message: failure.message },
+    },
+    { status: failure.status }
+  )
+}
+
+/**
+ * BACKWARDS-COMPAT (Fase 1 transition): valida con BAWOS_API_KEY global como
+ * fallback si no hay header de agente. Se elimina en Fase 2 cuando todos los
+ * callers migraron.
+ */
+export function validateLegacyApiKey(req: NextRequest): boolean {
+  const apiKey = req.headers.get('x-api-key')
+  const expected = process.env.BAWOS_API_KEY
+  if (!expected) return false
+  return apiKey === expected
+}

--- a/src/lib/agents/view-mode.ts
+++ b/src/lib/agents/view-mode.ts
@@ -1,0 +1,58 @@
+// BaW OS — View Mode helper (Human ↔ Agent)
+// Persiste preferencia en org_members.preferred_view_mode.
+// Lectura cliente: useViewMode hook (en componente .tsx aparte).
+// Lectura servidor: getViewMode() para SSR.
+
+import { createServiceClient } from '@/lib/supabase'
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { resolveOrgId } from '@/lib/org-context'
+
+export type ViewMode = 'human' | 'agent'
+export const DEFAULT_VIEW_MODE: ViewMode = 'human'
+
+export async function getViewMode(): Promise<ViewMode> {
+  try {
+    const supabase = createSupabaseServer()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return DEFAULT_VIEW_MODE
+
+    const orgId = await resolveOrgId()
+    const service = createServiceClient()
+    const { data } = await service
+      .from('org_members')
+      .select('preferred_view_mode')
+      .eq('user_id', user.id)
+      .eq('org_id', orgId)
+      .maybeSingle()
+
+    const mode = (data?.preferred_view_mode as ViewMode) || DEFAULT_VIEW_MODE
+    return mode === 'agent' ? 'agent' : 'human'
+  } catch {
+    return DEFAULT_VIEW_MODE
+  }
+}
+
+export async function setViewMode(mode: ViewMode): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const supabase = createSupabaseServer()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return { ok: false, error: 'No authenticated user' }
+
+    const orgId = await resolveOrgId()
+    const service = createServiceClient()
+    const { error } = await service
+      .from('org_members')
+      .update({ preferred_view_mode: mode })
+      .eq('user_id', user.id)
+      .eq('org_id', orgId)
+
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'unknown' }
+  }
+}

--- a/supabase/migrations/20260503_agent_credentials.sql
+++ b/supabase/migrations/20260503_agent_credentials.sql
@@ -1,0 +1,125 @@
+-- BaW OS — Agent Credentials (Fase 1 del Agent Platform Roadmap)
+-- Una identidad por agente, por org. Reemplaza BAWOS_API_KEY global.
+-- Contrato: ver docs/AGENT_INTEGRATION.md
+
+BEGIN;
+
+-- 1. Tabla de credenciales
+CREATE TABLE IF NOT EXISTS public.agent_credentials (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL REFERENCES public.agents(id) ON DELETE RESTRICT,
+  label TEXT NOT NULL,                          -- 'prod', 'staging', 'dev-local'
+  api_key_hash TEXT NOT NULL,                   -- bcrypt(sk_live_xxx)
+  api_key_prefix TEXT NOT NULL,                 -- primeros 12 chars para UI ('sk_live_abc1')
+  scopes TEXT[] NOT NULL DEFAULT '{}',          -- ['units:read','reservations:write',...]
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active','revoked','expired')),
+  rate_limit_tier TEXT NOT NULL DEFAULT 'standard'
+    CHECK (rate_limit_tier IN ('standard','elevated','unlimited')),
+  expires_at TIMESTAMPTZ,
+  last_used_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  revoked_at TIMESTAMPTZ,
+  revoked_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  UNIQUE (org_id, agent_id, label)
+);
+
+-- 2. Índices
+CREATE INDEX IF NOT EXISTS idx_agent_credentials_prefix_active
+  ON public.agent_credentials (api_key_prefix)
+  WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_agent_credentials_org_agent
+  ON public.agent_credentials (org_id, agent_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_credentials_status
+  ON public.agent_credentials (status, expires_at);
+
+-- 3. RLS — solo admins del tenant ven credenciales del tenant; platform_admin ve todo.
+ALTER TABLE public.agent_credentials ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS agent_credentials_select ON public.agent_credentials;
+CREATE POLICY agent_credentials_select ON public.agent_credentials FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = agent_credentials.org_id
+      AND om.user_id = auth.uid()
+      AND om.role IN ('owner','admin')
+  )
+  OR EXISTS (SELECT 1 FROM public.platform_admins pa WHERE pa.user_id = auth.uid())
+);
+
+DROP POLICY IF EXISTS agent_credentials_insert ON public.agent_credentials;
+CREATE POLICY agent_credentials_insert ON public.agent_credentials FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = agent_credentials.org_id
+      AND om.user_id = auth.uid()
+      AND om.role IN ('owner','admin')
+  )
+  OR EXISTS (SELECT 1 FROM public.platform_admins pa WHERE pa.user_id = auth.uid())
+);
+
+DROP POLICY IF EXISTS agent_credentials_update ON public.agent_credentials;
+CREATE POLICY agent_credentials_update ON public.agent_credentials FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = agent_credentials.org_id
+      AND om.user_id = auth.uid()
+      AND om.role IN ('owner','admin')
+  )
+  OR EXISTS (SELECT 1 FROM public.platform_admins pa WHERE pa.user_id = auth.uid())
+);
+
+-- No DELETE policy: las credenciales se revocan (status='revoked'), no se borran. Audit trail.
+
+-- 4. Función helper: validar y resolver agente por hash
+-- NOTA: bcrypt comparison lo hace el server-side con la lib. Esta función solo expone
+--       lookup por prefix (rápido) + última actualización de last_used_at.
+CREATE OR REPLACE FUNCTION public.touch_agent_credential(p_credential_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.agent_credentials
+  SET last_used_at = now()
+  WHERE id = p_credential_id AND status = 'active';
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.touch_agent_credential(UUID) TO authenticated;
+-- service_role siempre tiene acceso
+
+-- 5. View para auditoría (no expone hash)
+CREATE OR REPLACE VIEW public.v_agent_credentials_audit AS
+SELECT
+  c.id,
+  c.org_id,
+  c.agent_id,
+  a.full_name AS agent_name,
+  c.label,
+  c.api_key_prefix,
+  c.scopes,
+  c.status,
+  c.rate_limit_tier,
+  c.expires_at,
+  c.last_used_at,
+  c.created_at,
+  c.created_by,
+  c.revoked_at,
+  c.revoked_by
+FROM public.agent_credentials c
+JOIN public.agents a ON a.id = c.agent_id;
+
+COMMIT;
+
+-- Rollback:
+-- BEGIN;
+--   DROP VIEW IF EXISTS public.v_agent_credentials_audit;
+--   DROP FUNCTION IF EXISTS public.touch_agent_credential(UUID);
+--   DROP TABLE IF EXISTS public.agent_credentials;
+-- COMMIT;

--- a/supabase/migrations/20260503_agents_andres_rafa.sql
+++ b/supabase/migrations/20260503_agents_andres_rafa.sql
@@ -1,0 +1,30 @@
+-- BaW OS — Sembrar agentes ZXY faltantes: Andrés-CTO y Rafa-Research
+-- Definidos en docs/AGENT_ROSTER.md, mencionados en Notion master doc.
+
+BEGIN;
+
+INSERT INTO public.agents (
+  id, display_name, full_name, family, domain, description,
+  capability_level, feedback_level, status, is_shared_zxy
+) VALUES
+  (
+    'andres-cto', 'Andrés-CTO', 'Agente Andrés-CTO',
+    'third-party', 'tech',
+    'CTO OpenClaw — coordinación técnica cross-platform BaW ↔ OpenClaw ↔ ZXY',
+    0, 0, 'planned', true
+  ),
+  (
+    'rafa-research', 'Rafa-Research', 'Agente Rafa-Research',
+    'third-party', 'research',
+    'Customer development y síntesis competitiva. Read-only respecto al sistema operativo.',
+    0, 0, 'planned', true
+  )
+ON CONFLICT (id) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  full_name = EXCLUDED.full_name,
+  family = EXCLUDED.family,
+  domain = EXCLUDED.domain,
+  description = EXCLUDED.description,
+  is_shared_zxy = EXCLUDED.is_shared_zxy;
+
+COMMIT;

--- a/supabase/migrations/20260503_view_mode_preference.sql
+++ b/supabase/migrations/20260503_view_mode_preference.sql
@@ -1,0 +1,18 @@
+-- BaW OS — Preferencia Human/Agent view mode (Fase 3 light)
+-- Persiste el modo de visualización elegido por el miembro en cada org.
+
+BEGIN;
+
+ALTER TABLE public.org_members
+  ADD COLUMN IF NOT EXISTS preferred_view_mode TEXT NOT NULL DEFAULT 'human'
+    CHECK (preferred_view_mode IN ('human','agent'));
+
+COMMENT ON COLUMN public.org_members.preferred_view_mode IS
+  'UI view mode preference per (user, org). human = layouts generosos descubrimiento; agent = densidad Bloomberg/Linear, exception-first.';
+
+COMMIT;
+
+-- Rollback:
+-- BEGIN;
+--   ALTER TABLE public.org_members DROP COLUMN IF EXISTS preferred_view_mode;
+-- COMMIT;


### PR DESCRIPTION
## Resumen

Foundation del **Agent Platform Roadmap** (5 fases). Este PR cubre Fase 0 (docs), Fase 1 (identidad), Fase 3 light (modo Agent + switch). Fase 2 (API v1) y Fase 4 (autonomy slider) quedan para PRs siguientes.

## Qué incluye

### Fase 0 — Docs canónicos (4 archivos)

- `docs/AGENT_PLATFORM_ROADMAP.md` — 5 fases detalladas con criterios de éxito
- `docs/AGENT_INTEGRATION.md` — contrato de integración: scopes, AUTO/LOG/REQUIRE_APPROVAL, lifecycle
- `docs/AGENT_ROSTER.md` — los 18 agentes (10 BaW + 1 coord + 7 ZXY incluyendo nuevos Andrés-CTO y Rafa-Research)
- `docs/AGENTIC_PRINCIPLES.md` — condensación operable del Notion master doc

### Fase 1 — Identidad por agente

- Migración `agent_credentials` con hash SHA-256, scopes[], rate_limit_tier, status, expires_at
- Función `touch_agent_credential` para `last_used_at`
- View `v_agent_credentials_audit` (sin hash)
- Migración `agents_andres_rafa.sql` siembra los 2 agentes faltantes
- `src/lib/agents/auth.ts` con `authenticateAgentRequest(req, scopes[])` + `generateApiKey` + `hashApiKey` + timing-safe compare
- API `/api/admin/agents/[id]/credentials` (GET/POST/DELETE)
- UI `/agents/[id]/credentials` con flujo "key visible 1 vez" + scopes checklist + revocar
- `/api/mora` migrado a auth dual (legacy `BAWOS_API_KEY` + nuevo) durante transición

### Fase 3 light — Modo Human / Agent

- Migración `view_mode_preference.sql` (col `org_members.preferred_view_mode`)
- `src/lib/agents/view-mode.ts` (getViewMode/setViewMode SSR)
- `/api/me/view-mode` (GET/POST)
- `<ViewModeSwitch />` componente client persistente
- `/agents` ahora renderiza `AgentModeView` (Bloomberg-style 3-paneles: Exceptions + Roster + Activity Timeline + Approval Queue placeholder) cuando el modo es agent

## Criterios de éxito

- [x] `tsc --noEmit` limpio
- [x] `next build` verde
- [x] 17+ rutas en build incluyendo nuevas
- [ ] Migraciones aplicadas en Supabase (manual antes de merge)
- [ ] Vercel preview verde

## Migraciones a aplicar

1. `20260503_agent_credentials.sql`
2. `20260503_agents_andres_rafa.sql`
3. `20260503_view_mode_preference.sql`

## Reversibilidad

Cada migración tiene su rollback documentado al final del archivo. La auth dual del endpoint `/api/mora` permite revertir Fase 1 sin downtime.

## Referencias

- Notion: [Agentic Design Principles — BaW OS / ZXY Platforms](https://www.notion.so/zxyventures/Agentic-Design-Principles-BaW-OS-ZXY-Platforms-355169373e72818dba04e653ecec8e58)
- Roadmap completo: `docs/AGENT_PLATFORM_ROADMAP.md`
