### PR TITLE
feat(sprint5b/ws1) public booking backend — migration + 7 endpoints + utils

### DIFF
--- a/docs/sprints/SPRINT_5B_ENV.md
+++ b/docs/sprints/SPRINT_5B_ENV.md
@@ -1,0 +1,110 @@
+# Sprint 5B — Environment Variables
+
+All variables required by the public booking engine (WS-1). **Do not commit actual secret values.**
+Add these to Vercel → Project Settings → Environment Variables (and to `.env.local` for local dev).
+
+---
+
+## Feature Flag
+
+| Variable | Example | Description |
+|---|---|---|
+| `PUBLIC_BOOKING_ENABLED` | `false` | Master flag. Set to `"true"` only when ready for public traffic. Server-side only. |
+| `NEXT_PUBLIC_PUBLIC_BOOKING_ENABLED` | `false` | Client-side version of the flag. Controls whether frontend renders booking UI. |
+
+> **Default:** both are `false`. All 7 public endpoints return 404 while disabled.
+
+---
+
+## CORS
+
+| Variable | Example | Description |
+|---|---|---|
+| `PUBLIC_BOOKING_ALLOWED_ORIGINS` | `https://809.mx,https://baw-os.vercel.app` | Comma-separated list of allowed origins. No trailing slashes. Exact match only. |
+
+> In `development` (NODE_ENV=development), `localhost`, `127.0.0.1` and `*.vercel.app` are automatically allowed regardless of this list.
+
+---
+
+## Stripe (public booking)
+
+| Variable | Example | Description |
+|---|---|---|
+| `STRIPE_SECRET_KEY` | `sk_test_...` | Stripe secret key. **Never expose to the browser.** Shared with internal billing (Sprint 4). Use `sk_test_...` in dev/staging, `sk_live_...` in production. |
+| `STRIPE_WEBHOOK_SECRET_PUBLIC` | `whsec_...` | Webhook signing secret for `/api/public/v1/webhooks/stripe`. **Different from the internal** `STRIPE_WEBHOOK_SECRET` — do not mix them. Obtain from Stripe Dashboard → Webhooks → your endpoint → Signing secret. |
+
+> `STRIPE_PUBLISHABLE_KEY` is not needed in v1 (Stripe Checkout hosted). Required only if migrating to Elements in v2.
+
+---
+
+## Checkout URLs
+
+| Variable | Example | Description |
+|---|---|---|
+| `PUBLIC_BOOKING_SUCCESS_URL` | `https://809.mx/confirmacion/{HOLD_ID}` | Stripe redirects here on successful payment. Use `{HOLD_ID}` as a literal placeholder — the server substitutes the hold ID at session creation time. |
+| `PUBLIC_BOOKING_CANCEL_URL` | `https://809.mx/reservar` | Stripe redirects here if the user cancels or the session expires. |
+
+---
+
+## Supabase (already in project)
+
+These are already configured from Sprint 1–4 but are required for the public booking engine too:
+
+| Variable | Description |
+|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon (public) key — used for reading public views. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key — used server-side for writes (holds, reservations). **Never expose to the browser.** |
+
+---
+
+## Local `.env.local` template
+
+Copy this to `.env.local` and fill in real values for local development:
+
+```bash
+# ── Feature flags ────────────────────────────────────────────
+PUBLIC_BOOKING_ENABLED=true
+NEXT_PUBLIC_PUBLIC_BOOKING_ENABLED=true
+
+# ── CORS ────────────────────────────────────────────────────
+PUBLIC_BOOKING_ALLOWED_ORIGINS=https://809.mx,https://baw-os.vercel.app
+
+# ── Stripe (test mode) ───────────────────────────────────────
+STRIPE_SECRET_KEY=sk_test_REPLACE_ME
+STRIPE_WEBHOOK_SECRET_PUBLIC=whsec_REPLACE_ME
+
+# ── Checkout URLs ────────────────────────────────────────────
+PUBLIC_BOOKING_SUCCESS_URL=https://809.mx/confirmacion/{HOLD_ID}
+PUBLIC_BOOKING_CANCEL_URL=https://809.mx/reservar
+
+# ── Supabase (already set, listed for completeness) ──────────
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
+SUPABASE_SERVICE_ROLE_KEY=eyJ...
+```
+
+---
+
+## Vercel production checklist
+
+Before enabling `PUBLIC_BOOKING_ENABLED=true` in production:
+
+- [ ] Stripe webhook endpoint registered: `https://baw-os.vercel.app/api/public/v1/webhooks/stripe`
+- [ ] Stripe webhook events enabled: `checkout.session.completed`, `checkout.session.expired`
+- [ ] `STRIPE_WEBHOOK_SECRET_PUBLIC` updated with the production signing secret
+- [ ] `PUBLIC_BOOKING_SUCCESS_URL` and `PUBLIC_BOOKING_CANCEL_URL` point to production URLs
+- [ ] Smoke test completed with card `4242 4242 4242 4242` in Stripe test mode
+- [ ] E2E test passing (WS-5)
+- [ ] Reconciliation cron configured (WS-4)
+- [ ] Email confirmation working (WS-4)
+
+---
+
+## Notes
+
+- The public booking endpoints use **two Supabase clients**:
+  - **Anon client** (`createAnonClient`): for reading `v_public_buildings` and `v_public_units` views.
+  - **Service role client** (`createServiceClient`): for all writes (holds, reservations, idempotency tables) and calling `fn_unit_is_available`.
+- The service role key is only used server-side (in Next.js API route handlers, never in `'use client'` components).
+- Rate limits are in-memory per Vercel instance (v1). For multi-instance production, replace with Upstash Ratelimit.

--- a/src/app/api/public/v1/bookings/checkout/route.ts
+++ b/src/app/api/public/v1/bookings/checkout/route.ts
@@ -1,0 +1,202 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createAnonClient, createServiceClient } from '@/lib/public-booking/supabase-public'
+import { createCheckoutSession } from '@/lib/public-booking/stripe-public'
+import {
+  featureDisabled,
+  handlePreflight,
+  withCors,
+  rateLimitExceeded,
+  errorResponse,
+} from '@/lib/public-booking/cors'
+import { rateLimitByIp } from '@/lib/public-booking/rate-limit'
+import { CheckoutRequest, CheckoutResponse } from '@/lib/public-booking/schemas'
+import { computeQuote } from '@/lib/public-booking/pricing'
+
+export const runtime = 'nodejs'
+
+export async function OPTIONS(request: NextRequest) {
+  return handlePreflight(request.headers.get('origin'))
+}
+
+export async function POST(request: NextRequest) {
+  if (process.env.PUBLIC_BOOKING_ENABLED !== 'true') return featureDisabled()
+
+  const origin = request.headers.get('origin')
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+
+  const rl = rateLimitByIp('bookings-checkout', ip, 10)
+  if (!rl.allowed) return withCors(rateLimitExceeded(), origin)
+
+  // Idempotency key is mandatory
+  const idempotencyKey = request.headers.get('Idempotency-Key')?.trim()
+  if (!idempotencyKey) {
+    return withCors(
+      errorResponse('MISSING_IDEMPOTENCY_KEY', 'Header "Idempotency-Key" is required'),
+      origin,
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return withCors(errorResponse('INVALID_JSON', 'Request body must be JSON'), origin)
+  }
+
+  const parsed = CheckoutRequest.safeParse(body)
+  if (!parsed.success) {
+    return withCors(
+      errorResponse('INVALID_PARAMS', parsed.error.errors[0]?.message ?? 'Invalid params'),
+      origin,
+    )
+  }
+
+  const { unit_slug, from, to, guests, guest } = parsed.data
+  const svc = createServiceClient()
+
+  console.log(
+    `action=checkout_start unit=${unit_slug} from=${from} to=${to} guests=${guests} idem=${idempotencyKey} ip=${ip}`,
+  )
+
+  // ── Capa 1: check idempotency cache ──────────────────────────────────────
+  const { data: cached } = await svc
+    .from('checkout_idempotency')
+    .select('response, expires_at')
+    .eq('key', idempotencyKey)
+    .single()
+
+  if (cached && new Date(cached.expires_at) > new Date()) {
+    console.log(`action=checkout_start idem=${idempotencyKey} status=cache_hit`)
+    return withCors(NextResponse.json({ data: cached.response }), origin)
+  }
+
+  // ── Resolve unit ──────────────────────────────────────────────────────────
+  const anon = createAnonClient()
+  const { data: unit, error: unitErr } = await anon
+    .from('v_public_units')
+    .select('id, slug, name, base_rate_mxn, cleaning_fee_mxn, max_guests, min_nights')
+    .eq('slug', unit_slug)
+    .single()
+
+  if (unitErr || !unit) {
+    return withCors(
+      errorResponse('UNIT_NOT_FOUND', `Unit "${unit_slug}" not found`, 404),
+      origin,
+    )
+  }
+
+  // ── Availability check ────────────────────────────────────────────────────
+  const { data: isAvailable } = await svc.rpc('fn_unit_is_available', {
+    p_unit_id: unit.id,
+    p_from: from,
+    p_to: to,
+  })
+
+  if (!isAvailable) {
+    return withCors(
+      errorResponse('UNIT_UNAVAILABLE', 'Unit is not available for the requested dates', 409),
+      origin,
+    )
+  }
+
+  // ── Compute quote ─────────────────────────────────────────────────────────
+  let quote
+  try {
+    quote = computeQuote(unit, from, to, guests)
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Quote computation failed'
+    return withCors(errorResponse('QUOTE_ERROR', msg), origin)
+  }
+
+  // ── Create hold (15 min) ──────────────────────────────────────────────────
+  const { data: hold, error: holdErr } = await svc
+    .from('reservation_holds')
+    .insert({
+      unit_id: unit.id,
+      from_date: from,
+      to_date: to,
+      guests_count: guests,
+      guest_email: guest.email,
+      idempotency_key: idempotencyKey,
+    })
+    .select('id, expires_at')
+    .single()
+
+  if (holdErr || !hold) {
+    // Could be a GIST conflict (dates already held) or duplicate idempotency key
+    const msg =
+      holdErr?.code === '23P01'
+        ? 'Unit dates were just taken by another booking. Please choose different dates.'
+        : holdErr?.message ?? 'Failed to create hold'
+    console.log(`action=checkout_hold unit=${unit_slug} error=${holdErr?.code} msg=${msg}`)
+    return withCors(
+      errorResponse('HOLD_FAILED', msg, holdErr?.code === '23P01' ? 409 : 500),
+      origin,
+    )
+  }
+
+  console.log(
+    `action=checkout_hold unit=${unit_slug} hold_id=${hold.id} expires=${hold.expires_at}`,
+  )
+
+  // ── Create Stripe Checkout Session ────────────────────────────────────────
+  let session
+  try {
+    session = await createCheckoutSession({
+      unitName: unit.name ?? unit_slug,
+      nights: quote.nights,
+      from,
+      to,
+      guests,
+      totalMxn: quote.total_mxn,
+      metadata: {
+        hold_id: hold.id,
+        unit_id: unit.id,
+        unit_slug,
+        from,
+        to,
+        guests: String(guests),
+        guest_name: guest.name,
+        guest_email: guest.email,
+        guest_phone: guest.phone ?? '',
+      },
+      idempotencyKey,
+    })
+  } catch (err: unknown) {
+    // Cleanup hold on Stripe failure
+    await svc.from('reservation_holds').delete().eq('id', hold.id)
+    const msg = err instanceof Error ? err.message : 'Stripe session creation failed'
+    console.log(`action=checkout_stripe_fail unit=${unit_slug} hold_id=${hold.id} error=${msg}`)
+    return withCors(errorResponse('STRIPE_ERROR', msg, 502), origin)
+  }
+
+  // ── Update hold with stripe_session_id ───────────────────────────────────
+  await svc
+    .from('reservation_holds')
+    .update({ stripe_session_id: session.id })
+    .eq('id', hold.id)
+
+  console.log(
+    `action=checkout_session_created unit=${unit_slug} hold_id=${hold.id} session_id=${session.id}`,
+  )
+
+  // ── Build response ────────────────────────────────────────────────────────
+  const responseBody: CheckoutResponse = {
+    checkout_url: session.url!,
+    session_id: session.id,
+    hold_id: hold.id,
+    expires_at: hold.expires_at,
+  }
+
+  // ── Save to idempotency cache ─────────────────────────────────────────────
+  await svc.from('checkout_idempotency').upsert(
+    {
+      key: idempotencyKey,
+      response: responseBody as unknown as Record<string, unknown>,
+    },
+    { onConflict: 'key' },
+  )
+
+  return withCors(NextResponse.json({ data: responseBody }), origin)
+}

--- a/src/app/api/public/v1/buildings/[slug]/route.ts
+++ b/src/app/api/public/v1/buildings/[slug]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createAnonClient } from '@/lib/public-booking/supabase-public'
+import {
+  featureDisabled,
+  handlePreflight,
+  withCors,
+  rateLimitExceeded,
+  errorResponse,
+} from '@/lib/public-booking/cors'
+import { rateLimitByIp } from '@/lib/public-booking/rate-limit'
+
+export const runtime = 'nodejs'
+
+export async function OPTIONS(request: NextRequest) {
+  return handlePreflight(request.headers.get('origin'))
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { slug: string } },
+) {
+  if (process.env.PUBLIC_BOOKING_ENABLED !== 'true') return featureDisabled()
+
+  const origin = request.headers.get('origin')
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+
+  const rl = rateLimitByIp('buildings-slug', ip, 60)
+  if (!rl.allowed) return withCors(rateLimitExceeded(), origin)
+
+  const slug = params.slug
+  console.log(`action=buildings_get slug=${slug} ip=${ip}`)
+
+  const supabase = createAnonClient()
+  const { data, error } = await supabase
+    .from('v_public_buildings')
+    .select('*')
+    .eq('slug', slug)
+    .single()
+
+  if (error || !data) {
+    console.log(`action=buildings_get slug=${slug} status=not_found`)
+    return withCors(
+      errorResponse('BUILDING_NOT_FOUND', `Building "${slug}" not found`, 404),
+      origin,
+    )
+  }
+
+  console.log(`action=buildings_get slug=${slug} status=ok`)
+  return withCors(NextResponse.json({ data }), origin)
+}

--- a/src/app/api/public/v1/buildings/[slug]/units/route.ts
+++ b/src/app/api/public/v1/buildings/[slug]/units/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createAnonClient, createServiceClient } from '@/lib/public-booking/supabase-public'
+import {
+  featureDisabled,
+  handlePreflight,
+  withCors,
+  rateLimitExceeded,
+  errorResponse,
+} from '@/lib/public-booking/cors'
+import { rateLimitByIp } from '@/lib/public-booking/rate-limit'
+import { UnitsListQuery } from '@/lib/public-booking/schemas'
+
+export const runtime = 'nodejs'
+
+export async function OPTIONS(request: NextRequest) {
+  return handlePreflight(request.headers.get('origin'))
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { slug: string } },
+) {
+  if (process.env.PUBLIC_BOOKING_ENABLED !== 'true') return featureDisabled()
+
+  const origin = request.headers.get('origin')
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+
+  const rl = rateLimitByIp('buildings-slug-units', ip, 60)
+  if (!rl.allowed) return withCors(rateLimitExceeded(), origin)
+
+  const buildingSlug = params.slug
+  const searchParams = request.nextUrl.searchParams
+
+  // Validate query params
+  const parsed = UnitsListQuery.safeParse({
+    from: searchParams.get('from') ?? undefined,
+    to: searchParams.get('to') ?? undefined,
+    guests: searchParams.get('guests') ?? undefined,
+  })
+  if (!parsed.success) {
+    return withCors(
+      errorResponse('INVALID_PARAMS', parsed.error.errors[0]?.message ?? 'Invalid params'),
+      origin,
+    )
+  }
+
+  const { from, to, guests } = parsed.data
+  console.log(`action=buildings_units_list building=${buildingSlug} from=${from} to=${to} guests=${guests} ip=${ip}`)
+
+  const supabase = createAnonClient()
+
+  // Fetch units for this building slug
+  let query = supabase
+    .from('v_public_units')
+    .select('*')
+    .eq('building_slug', buildingSlug)
+
+  if (guests) {
+    query = query.gte('max_guests', guests)
+  }
+
+  const { data: units, error } = await query
+
+  if (error) {
+    console.log(`action=buildings_units_list building=${buildingSlug} status=error err=${error.message}`)
+    return withCors(errorResponse('DB_ERROR', 'Failed to fetch units', 500), origin)
+  }
+
+  if (!units || units.length === 0) {
+    return withCors(NextResponse.json({ data: [] }), origin)
+  }
+
+  // If date range provided, filter by availability
+  if (from && to) {
+    const svc = createServiceClient()
+    const availabilityChecks = await Promise.all(
+      units.map(async (unit) => {
+        const { data: available } = await svc.rpc('fn_unit_is_available', {
+          p_unit_id: unit.id,
+          p_from: from,
+          p_to: to,
+        })
+        return { unit, available: Boolean(available) }
+      }),
+    )
+    const filtered = availabilityChecks
+      .filter((r) => r.available)
+      .map((r) => r.unit)
+
+    console.log(`action=buildings_units_list building=${buildingSlug} total=${units.length} available=${filtered.length} status=ok`)
+    return withCors(NextResponse.json({ data: filtered }), origin)
+  }
+
+  console.log(`action=buildings_units_list building=${buildingSlug} total=${units.length} status=ok`)
+  return withCors(NextResponse.json({ data: units }), origin)
+}

--- a/src/app/api/public/v1/quotes/route.ts
+++ b/src/app/api/public/v1/quotes/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createAnonClient } from '@/lib/public-booking/supabase-public'
+import { createServiceClient } from '@/lib/public-booking/supabase-public'
+import {
+  featureDisabled,
+  handlePreflight,
+  withCors,
+  rateLimitExceeded,
+  errorResponse,
+} from '@/lib/public-booking/cors'
+import { rateLimitByIp } from '@/lib/public-booking/rate-limit'
+import { QuoteRequest } from '@/lib/public-booking/schemas'
+import { computeQuote } from '@/lib/public-booking/pricing'
+
+export const runtime = 'nodejs'
+
+export async function OPTIONS(request: NextRequest) {
+  return handlePreflight(request.headers.get('origin'))
+}
+
+export async function POST(request: NextRequest) {
+  if (process.env.PUBLIC_BOOKING_ENABLED !== 'true') return featureDisabled()
+
+  const origin = request.headers.get('origin')
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+
+  const rl = rateLimitByIp('quotes', ip, 10)
+  if (!rl.allowed) return withCors(rateLimitExceeded(), origin)
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return withCors(errorResponse('INVALID_JSON', 'Request body must be JSON'), origin)
+  }
+
+  const parsed = QuoteRequest.safeParse(body)
+  if (!parsed.success) {
+    return withCors(
+      errorResponse('INVALID_PARAMS', parsed.error.errors[0]?.message ?? 'Invalid params'),
+      origin,
+    )
+  }
+
+  const { unit_slug, from, to, guests } = parsed.data
+  console.log(`action=quote unit=${unit_slug} from=${from} to=${to} guests=${guests} ip=${ip}`)
+
+  // Fetch unit data (public view — no auth needed)
+  const anon = createAnonClient()
+  const { data: unit, error: unitErr } = await anon
+    .from('v_public_units')
+    .select('id, slug, base_rate_mxn, cleaning_fee_mxn, max_guests, min_nights')
+    .eq('slug', unit_slug)
+    .single()
+
+  if (unitErr || !unit) {
+    return withCors(
+      errorResponse('UNIT_NOT_FOUND', `Unit "${unit_slug}" not found`, 404),
+      origin,
+    )
+  }
+
+  // Check availability — quotes do NOT hold dates but we warn if unavailable
+  const svc = createServiceClient()
+  const { data: isAvailable } = await svc.rpc('fn_unit_is_available', {
+    p_unit_id: unit.id,
+    p_from: from,
+    p_to: to,
+  })
+
+  if (!isAvailable) {
+    return withCors(
+      errorResponse('UNIT_UNAVAILABLE', 'Unit is not available for the requested dates', 409),
+      origin,
+    )
+  }
+
+  // Compute quote
+  let quote
+  try {
+    quote = computeQuote(unit, from, to, guests)
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Quote computation failed'
+    return withCors(errorResponse('QUOTE_ERROR', msg), origin)
+  }
+
+  console.log(`action=quote unit=${unit_slug} total=${quote.total_mxn} nights=${quote.nights} status=ok`)
+  return withCors(NextResponse.json({ data: quote }), origin)
+}

--- a/src/app/api/public/v1/units/[slug]/availability/route.ts
+++ b/src/app/api/public/v1/units/[slug]/availability/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createAnonClient, createServiceClient } from '@/lib/public-booking/supabase-public'
+import {
+  featureDisabled,
+  handlePreflight,
+  withCors,
+  rateLimitExceeded,
+  errorResponse,
+} from '@/lib/public-booking/cors'
+import { rateLimitByIp } from '@/lib/public-booking/rate-limit'
+import { AvailabilityQuery } from '@/lib/public-booking/schemas'
+
+export const runtime = 'nodejs'
+
+const MAX_RANGE_DAYS = 90
+
+export async function OPTIONS(request: NextRequest) {
+  return handlePreflight(request.headers.get('origin'))
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { slug: string } },
+) {
+  if (process.env.PUBLIC_BOOKING_ENABLED !== 'true') return featureDisabled()
+
+  const origin = request.headers.get('origin')
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+
+  const rl = rateLimitByIp('units-availability', ip, 60)
+  if (!rl.allowed) return withCors(rateLimitExceeded(), origin)
+
+  const slug = params.slug
+  const sp = request.nextUrl.searchParams
+
+  const parsed = AvailabilityQuery.safeParse({
+    from: sp.get('from'),
+    to: sp.get('to'),
+  })
+  if (!parsed.success) {
+    return withCors(
+      errorResponse('INVALID_PARAMS', parsed.error.errors[0]?.message ?? 'from and to are required'),
+      origin,
+    )
+  }
+
+  const { from, to } = parsed.data
+
+  // Enforce 90-day max range
+  const fromMs = new Date(from).getTime()
+  const toMs = new Date(to).getTime()
+  const rangeDays = (toMs - fromMs) / 86_400_000
+  if (rangeDays > MAX_RANGE_DAYS) {
+    return withCors(
+      errorResponse('RANGE_TOO_LARGE', `Max range is ${MAX_RANGE_DAYS} days`),
+      origin,
+    )
+  }
+  if (rangeDays <= 0) {
+    return withCors(
+      errorResponse('INVALID_RANGE', '"to" must be after "from"'),
+      origin,
+    )
+  }
+
+  console.log(`action=unit_availability slug=${slug} from=${from} to=${to} ip=${ip}`)
+
+  // Resolve unit id from slug using anon client (public view)
+  const anon = createAnonClient()
+  const { data: unit, error: unitErr } = await anon
+    .from('v_public_units')
+    .select('id')
+    .eq('slug', slug)
+    .single()
+
+  if (unitErr || !unit) {
+    return withCors(
+      errorResponse('UNIT_NOT_FOUND', `Unit "${slug}" not found`, 404),
+      origin,
+    )
+  }
+
+  const svc = createServiceClient()
+
+  // Overall availability boolean
+  const { data: isAvailable } = await svc.rpc('fn_unit_is_available', {
+    p_unit_id: unit.id,
+    p_from: from,
+    p_to: to,
+  })
+
+  // Blocked date ranges (confirmed/checked_in reservations + active holds)
+  const [{ data: reservations }, { data: holds }] = await Promise.all([
+    svc
+      .from('reservations')
+      .select('check_in, check_out')
+      .eq('unit_id', unit.id)
+      .in('status', ['confirmed', 'checked_in', 'tentative'])
+      .gte('check_out', from)
+      .lte('check_in', to),
+
+    svc
+      .from('reservation_holds')
+      .select('from_date, to_date')
+      .eq('unit_id', unit.id)
+      .gt('expires_at', new Date().toISOString())
+      .gte('to_date', from)
+      .lte('from_date', to),
+  ])
+
+  // Build a set of blocked day strings in range (ISO YYYY-MM-DD)
+  const blockedDays = new Set<string>()
+
+  function addBlockedDays(start: string, end: string) {
+    const cursor = new Date(start)
+    const endDate = new Date(end)
+    while (cursor < endDate) {
+      blockedDays.add(cursor.toISOString().slice(0, 10))
+      cursor.setUTCDate(cursor.getUTCDate() + 1)
+    }
+  }
+
+  for (const r of reservations ?? []) {
+    addBlockedDays(r.check_in, r.check_out)
+  }
+  for (const h of holds ?? []) {
+    addBlockedDays(h.from_date, h.to_date)
+  }
+
+  console.log(`action=unit_availability slug=${slug} available=${isAvailable} blocked_days=${blockedDays.size} status=ok`)
+
+  return withCors(
+    NextResponse.json({
+      data: {
+        unit_slug: slug,
+        from,
+        to,
+        is_available: Boolean(isAvailable),
+        blocked_days: Array.from(blockedDays).sort(),
+      },
+    }),
+    origin,
+  )
+}

--- a/src/app/api/public/v1/units/[slug]/route.ts
+++ b/src/app/api/public/v1/units/[slug]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createAnonClient } from '@/lib/public-booking/supabase-public'
+import {
+  featureDisabled,
+  handlePreflight,
+  withCors,
+  rateLimitExceeded,
+  errorResponse,
+} from '@/lib/public-booking/cors'
+import { rateLimitByIp } from '@/lib/public-booking/rate-limit'
+
+export const runtime = 'nodejs'
+
+export async function OPTIONS(request: NextRequest) {
+  return handlePreflight(request.headers.get('origin'))
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { slug: string } },
+) {
+  if (process.env.PUBLIC_BOOKING_ENABLED !== 'true') return featureDisabled()
+
+  const origin = request.headers.get('origin')
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+
+  const rl = rateLimitByIp('units-slug', ip, 60)
+  if (!rl.allowed) return withCors(rateLimitExceeded(), origin)
+
+  const slug = params.slug
+  console.log(`action=unit_detail slug=${slug} ip=${ip}`)
+
+  const supabase = createAnonClient()
+  const { data, error } = await supabase
+    .from('v_public_units')
+    .select('*')
+    .eq('slug', slug)
+    .single()
+
+  if (error || !data) {
+    console.log(`action=unit_detail slug=${slug} status=not_found`)
+    return withCors(
+      errorResponse('UNIT_NOT_FOUND', `Unit "${slug}" not found`, 404),
+      origin,
+    )
+  }
+
+  console.log(`action=unit_detail slug=${slug} status=ok`)
+  return withCors(NextResponse.json({ data }), origin)
+}

--- a/src/app/api/public/v1/webhooks/stripe/route.ts
+++ b/src/app/api/public/v1/webhooks/stripe/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/public-booking/supabase-public'
+import { getStripePublic } from '@/lib/public-booking/stripe-public'
+
+export const runtime = 'nodejs'
+
+// Disable Next.js body parser — Stripe requires the raw body for signature verification
+export const dynamic = 'force-dynamic'
+
+// ACK shape
+const ack = (message = 'ok') => NextResponse.json({ received: true, message })
+
+export async function POST(request: NextRequest) {
+  // Raw body is mandatory for Stripe signature verification
+  const rawBody = await request.text()
+  const signature = request.headers.get('stripe-signature')
+
+  if (!signature) {
+    console.log('action=stripe_webhook error=missing_signature')
+    return NextResponse.json({ error: 'Missing stripe-signature header' }, { status: 400 })
+  }
+
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET_PUBLIC
+  if (!webhookSecret) {
+    console.log('action=stripe_webhook error=missing_webhook_secret')
+    return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 500 })
+  }
+
+  let event
+  try {
+    const stripe = getStripePublic()
+    event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret)
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Signature verification failed'
+    console.log(`action=stripe_webhook error=invalid_signature msg=${msg}`)
+    return NextResponse.json({ error: `Webhook signature invalid: ${msg}` }, { status: 400 })
+  }
+
+  const svc = createServiceClient()
+  const eventId = event.id
+  const eventType = event.type
+
+  console.log(`action=stripe_webhook event_id=${eventId} event_type=${eventType}`)
+
+  // ── Idempotency: skip if already processed ──────────────────────────────
+  const { error: insertErr } = await svc.from('stripe_processed_events').insert(
+    {
+      event_id: eventId,
+      event_type: eventType,
+      payload: JSON.parse(JSON.stringify(event)) as Record<string, unknown>,
+    },
+  ).select()
+
+  // Primary key conflict = already processed
+  if (insertErr && insertErr.code === '23505') {
+    console.log(`action=stripe_webhook event_id=${eventId} status=already_processed`)
+    return ack('already processed')
+  }
+  if (insertErr) {
+    console.log(`action=stripe_webhook event_id=${eventId} error=insert_fail msg=${insertErr.message}`)
+    // Non-idempotency error — still try to process but log
+  }
+
+  // ── Route events ──────────────────────────────────────────────────────────
+  switch (eventType) {
+    case 'checkout.session.completed': {
+      await handleSessionCompleted(JSON.parse(JSON.stringify(event.data.object)) as Record<string, unknown>, svc)
+      break
+    }
+    case 'checkout.session.expired': {
+      await handleSessionExpired(JSON.parse(JSON.stringify(event.data.object)) as Record<string, unknown>, svc)
+      break
+    }
+    default: {
+      console.log(`action=stripe_webhook event_id=${eventId} event_type=${eventType} status=ignored`)
+    }
+  }
+
+  return ack()
+}
+
+// ── checkout.session.completed → promote hold to confirmed reservation ────────
+async function handleSessionCompleted(
+  session: Record<string, unknown>,
+  svc: ReturnType<typeof createServiceClient>,
+) {
+  const sessionId = session.id as string
+  const metadata = (session.metadata ?? {}) as Record<string, string>
+  const holdId = metadata.hold_id
+  const unitId = metadata.unit_id
+  const from = metadata.from
+  const to = metadata.to
+  const guestName = metadata.guest_name ?? ''
+  const guestEmail = metadata.guest_email ?? ''
+  const guestPhone = metadata.guest_phone ?? ''
+  const amountTotal = typeof session.amount_total === 'number' ? session.amount_total : 0
+
+  console.log(
+    `action=session_completed session_id=${sessionId} hold_id=${holdId} unit_id=${unitId}`,
+  )
+
+  if (!holdId || !unitId || !from || !to) {
+    console.log(`action=session_completed session_id=${sessionId} error=missing_metadata`)
+    return
+  }
+
+  // Fetch hold to get guests_count
+  const { data: hold } = await svc
+    .from('reservation_holds')
+    .select('guests_count')
+    .eq('id', holdId)
+    .single()
+
+  const guestsCount = hold?.guests_count ?? 1
+  const totalMxn = amountTotal / 100 // Stripe stores in centavos
+
+  // Insert reservation (confirmed)
+  const { error: resErr } = await svc.from('reservations').insert({
+    unit_id: unitId,
+    check_in: from,
+    check_out: to,
+    guest_name: guestName,
+    guest_email: guestEmail,
+    guest_phone: guestPhone,
+    mode: 'direct',
+    total_price: totalMxn,
+    amount_paid: totalMxn,
+    status: 'confirmed',
+    payment_status: 'paid',
+    notes: `Stripe session: ${sessionId} | Hold: ${holdId} | Guests: ${guestsCount}`,
+  })
+
+  if (resErr) {
+    // Could be GIST conflict (double-booking attempt) — log and alert
+    console.log(
+      `action=session_completed session_id=${sessionId} hold_id=${holdId} error=reservation_insert err=${resErr.code} msg=${resErr.message}`,
+    )
+    // Do NOT delete hold — leave for manual reconciliation
+    return
+  }
+
+  // Delete hold
+  await svc.from('reservation_holds').delete().eq('id', holdId)
+
+  console.log(
+    `action=session_completed session_id=${sessionId} hold_id=${holdId} unit_id=${unitId} status=promoted`,
+  )
+}
+
+// ── checkout.session.expired → delete hold ────────────────────────────────────
+async function handleSessionExpired(
+  session: Record<string, unknown>,
+  svc: ReturnType<typeof createServiceClient>,
+) {
+  const sessionId = session.id as string
+  const metadata = (session.metadata ?? {}) as Record<string, string>
+  const holdId = metadata.hold_id
+
+  console.log(`action=session_expired session_id=${sessionId} hold_id=${holdId}`)
+
+  if (!holdId) {
+    console.log(`action=session_expired session_id=${sessionId} error=no_hold_id_in_metadata`)
+    return
+  }
+
+  const { error } = await svc.from('reservation_holds').delete().eq('id', holdId)
+  if (error) {
+    console.log(`action=session_expired hold_id=${holdId} error=${error.message}`)
+  } else {
+    console.log(`action=session_expired hold_id=${holdId} status=hold_deleted`)
+  }
+}

--- a/src/lib/public-booking/cors.ts
+++ b/src/lib/public-booking/cors.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * Returns the validated CORS origin or null if not allowed.
+ * Allowed origins are read from PUBLIC_BOOKING_ALLOWED_ORIGINS (comma-separated).
+ * Falls back to an open allowlist in development.
+ */
+export function getAllowedOrigin(requestOrigin: string | null): string | null {
+  if (!requestOrigin) return null
+
+  const raw = process.env.PUBLIC_BOOKING_ALLOWED_ORIGINS ?? ''
+  const allowed = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  // In development, always allow localhost and vercel previews
+  if (process.env.NODE_ENV === 'development') {
+    if (
+      requestOrigin.startsWith('http://localhost') ||
+      requestOrigin.startsWith('http://127.0.0.1') ||
+      requestOrigin.endsWith('.vercel.app')
+    ) {
+      return requestOrigin
+    }
+  }
+
+  if (allowed.includes(requestOrigin)) return requestOrigin
+  return null
+}
+
+/**
+ * Adds CORS headers to a NextResponse.
+ * If origin is not allowed, returns a 403 response instead.
+ */
+export function withCors(
+  response: NextResponse,
+  requestOrigin: string | null,
+): NextResponse {
+  const allowed = getAllowedOrigin(requestOrigin)
+  if (allowed) {
+    response.headers.set('Access-Control-Allow-Origin', allowed)
+    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+    response.headers.set(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Idempotency-Key',
+    )
+    response.headers.set('Access-Control-Max-Age', '86400')
+    response.headers.set('Vary', 'Origin')
+  }
+  return response
+}
+
+/**
+ * Handle preflight OPTIONS requests.
+ * Returns 204 with CORS headers if origin is allowed, else 403.
+ */
+export function handlePreflight(requestOrigin: string | null): NextResponse {
+  const allowed = getAllowedOrigin(requestOrigin)
+  if (!allowed) {
+    return NextResponse.json(
+      { error: { code: 'CORS_FORBIDDEN', message: 'Origin not allowed' } },
+      { status: 403 },
+    )
+  }
+  const res = new NextResponse(null, { status: 204 })
+  res.headers.set('Access-Control-Allow-Origin', allowed)
+  res.headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+  res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Idempotency-Key')
+  res.headers.set('Access-Control-Max-Age', '86400')
+  res.headers.set('Vary', 'Origin')
+  return res
+}
+
+/** Standard 404 when feature flag is off */
+export function featureDisabled(): NextResponse {
+  return NextResponse.json(
+    { error: { code: 'NOT_FOUND', message: 'Not found' } },
+    { status: 404 },
+  )
+}
+
+/** Standard rate-limit 429 */
+export function rateLimitExceeded(): NextResponse {
+  return NextResponse.json(
+    { error: { code: 'RATE_LIMITED', message: 'Too many requests. Slow down.' } },
+    { status: 429 },
+  )
+}
+
+/** Typed error response */
+export function errorResponse(
+  code: string,
+  message: string,
+  status = 400,
+): NextResponse {
+  return NextResponse.json({ error: { code, message } }, { status })
+}

--- a/src/lib/public-booking/pricing.ts
+++ b/src/lib/public-booking/pricing.ts
@@ -1,0 +1,79 @@
+import { Quote, QuoteBreakdownItem, PublicUnit } from './schemas'
+
+const IVA_RATE = 0.16 // 16% IVA México
+
+/**
+ * Count nights between two YYYY-MM-DD strings.
+ * Uses simple date arithmetic (midnight UTC).
+ */
+export function countNights(from: string, to: string): number {
+  const msPerDay = 86_400_000
+  return Math.round(
+    (new Date(to).getTime() - new Date(from).getTime()) / msPerDay,
+  )
+}
+
+/**
+ * Compute a full price quote for a unit.
+ * Throws if unit has no base_rate_mxn configured.
+ */
+export function computeQuote(
+  unit: Pick<PublicUnit, 'slug' | 'base_rate_mxn' | 'cleaning_fee_mxn' | 'max_guests' | 'min_nights'>,
+  from: string,
+  to: string,
+  guests: number,
+): Quote {
+  if (unit.base_rate_mxn === null || unit.base_rate_mxn === undefined) {
+    throw new Error('Unit has no base rate configured')
+  }
+  if (guests > unit.max_guests) {
+    throw new Error(`Unit supports max ${unit.max_guests} guests`)
+  }
+
+  const nights = countNights(from, to)
+  if (nights < unit.min_nights) {
+    throw new Error(`Minimum stay is ${unit.min_nights} night(s)`)
+  }
+  if (nights <= 0) {
+    throw new Error('"to" must be after "from"')
+  }
+
+  const baseRate = Number(unit.base_rate_mxn)
+  const cleaningFee = Number(unit.cleaning_fee_mxn ?? 0)
+
+  const subtotal = round2(baseRate * nights)
+  const preTaxTotal = round2(subtotal + cleaningFee)
+  const taxIva = round2(preTaxTotal * IVA_RATE)
+  const total = round2(preTaxTotal + taxIva)
+
+  const breakdown: QuoteBreakdownItem[] = [
+    {
+      label: `${nights} ${nights === 1 ? 'noche' : 'noches'} × $${baseRate.toLocaleString('es-MX')} MXN`,
+      amount_mxn: subtotal,
+    },
+  ]
+
+  if (cleaningFee > 0) {
+    breakdown.push({ label: 'Limpieza', amount_mxn: cleaningFee })
+  }
+
+  breakdown.push({ label: 'IVA (16%)', amount_mxn: taxIva })
+
+  return {
+    unit_slug: unit.slug,
+    from,
+    to,
+    guests,
+    nights,
+    subtotal_mxn: subtotal,
+    cleaning_fee_mxn: cleaningFee,
+    tax_iva_mxn: taxIva,
+    total_mxn: total,
+    currency: 'MXN',
+    breakdown,
+  }
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}

--- a/src/lib/public-booking/rate-limit.ts
+++ b/src/lib/public-booking/rate-limit.ts
@@ -1,0 +1,73 @@
+// Simple in-memory rate limiter keyed by "<route>:<ip>".
+// Sufficient for v1. Replace with Upstash Ratelimit for multi-instance deploys.
+
+interface RateLimitEntry {
+  count: number
+  resetAt: number // epoch ms
+}
+
+const store = new Map<string, RateLimitEntry>()
+
+// Cleanup stale entries every 2 minutes to avoid unbounded memory growth.
+let lastCleanup = Date.now()
+
+function maybeCleanup() {
+  const now = Date.now()
+  if (now - lastCleanup < 120_000) return
+  lastCleanup = now
+  store.forEach((entry, key) => {
+    if (entry.resetAt < now) store.delete(key)
+  })
+}
+
+export interface RateLimitResult {
+  allowed: boolean
+  remaining: number
+  resetAt: number // epoch ms
+}
+
+/**
+ * Check (and increment) the rate limit for a given key.
+ * @param key        Unique string, e.g. "availability:/api/...:<ip>"
+ * @param limit      Max requests per window
+ * @param windowMs   Window duration in milliseconds (default 60 000 = 1 min)
+ */
+export function checkRateLimit(
+  key: string,
+  limit: number,
+  windowMs = 60_000,
+): RateLimitResult {
+  maybeCleanup()
+
+  const now = Date.now()
+  const entry = store.get(key)
+
+  if (!entry || entry.resetAt < now) {
+    // New or expired window
+    const resetAt = now + windowMs
+    store.set(key, { count: 1, resetAt })
+    return { allowed: true, remaining: limit - 1, resetAt }
+  }
+
+  if (entry.count >= limit) {
+    return { allowed: false, remaining: 0, resetAt: entry.resetAt }
+  }
+
+  entry.count++
+  return { allowed: true, remaining: limit - entry.count, resetAt: entry.resetAt }
+}
+
+/**
+ * Convenience: rate-limit by route + IP.
+ * @param routeId  Short identifier, e.g. "buildings-slug"
+ * @param ip       Client IP string
+ * @param limit    Max requests per minute
+ */
+export function rateLimitByIp(
+  routeId: string,
+  ip: string,
+  limit: number,
+): RateLimitResult {
+  const key = `${routeId}:${ip}`
+  return checkRateLimit(key, limit)
+}

--- a/src/lib/public-booking/schemas.ts
+++ b/src/lib/public-booking/schemas.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod'
+
+// ── Date helpers ─────────────────────────────────────────────────────────────
+export const DateString = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be YYYY-MM-DD')
+  .refine((s) => !isNaN(Date.parse(s)), 'Must be a valid date')
+
+export const DateRange = z
+  .object({ from: DateString, to: DateString })
+  .refine((d) => new Date(d.from) < new Date(d.to), {
+    message: '"from" must be before "to"',
+    path: ['from'],
+  })
+
+// ── Guest info ────────────────────────────────────────────────────────────────
+export const GuestInfo = z.object({
+  name: z.string().min(2).max(120),
+  email: z.string().email(),
+  phone: z.string().min(7).max(20).optional(),
+})
+
+// ── Quote request ─────────────────────────────────────────────────────────────
+export const QuoteRequest = z.object({
+  unit_slug: z.string().min(1),
+  from: DateString,
+  to: DateString,
+  guests: z.coerce.number().int().min(1).max(20),
+})
+
+export type QuoteRequestInput = z.infer<typeof QuoteRequest>
+
+// ── Checkout request ──────────────────────────────────────────────────────────
+export const CheckoutRequest = z.object({
+  unit_slug: z.string().min(1),
+  from: DateString,
+  to: DateString,
+  guests: z.coerce.number().int().min(1).max(20),
+  guest: GuestInfo,
+})
+
+export type CheckoutRequestInput = z.infer<typeof CheckoutRequest>
+
+// ── Quote response ────────────────────────────────────────────────────────────
+export interface QuoteBreakdownItem {
+  label: string
+  amount_mxn: number
+}
+
+export interface Quote {
+  unit_slug: string
+  from: string
+  to: string
+  guests: number
+  nights: number
+  subtotal_mxn: number
+  cleaning_fee_mxn: number
+  tax_iva_mxn: number
+  total_mxn: number
+  currency: 'MXN'
+  breakdown: QuoteBreakdownItem[]
+}
+
+// ── Checkout response ─────────────────────────────────────────────────────────
+export interface CheckoutResponse {
+  checkout_url: string
+  session_id: string
+  hold_id: string
+  expires_at: string
+}
+
+// ── Unit row from v_public_units ──────────────────────────────────────────────
+export interface PublicUnit {
+  id: string
+  slug: string
+  building_id: string
+  building_slug: string
+  name: string | null
+  description: string | null
+  hero_url: string | null
+  amenities: unknown
+  base_rate_mxn: number | null
+  cleaning_fee_mxn: number
+  max_guests: number
+  min_nights: number
+}
+
+// ── Building row from v_public_buildings ──────────────────────────────────────
+export interface PublicBuilding {
+  id: string
+  slug: string
+  name: string | null
+  description: string | null
+  hero_url: string | null
+  gallery: unknown
+  amenities: unknown
+  faq: unknown
+  city: string | null
+  state: string | null
+  country: string | null
+  location_lat: number | null
+  location_lng: number | null
+}
+
+// ── Availability query params ─────────────────────────────────────────────────
+export const AvailabilityQuery = z.object({
+  from: DateString,
+  to: DateString,
+})
+
+export type AvailabilityQueryInput = z.infer<typeof AvailabilityQuery>
+
+// ── Units list query params ───────────────────────────────────────────────────
+export const UnitsListQuery = z.object({
+  from: DateString.optional(),
+  to: DateString.optional(),
+  guests: z.coerce.number().int().min(1).optional(),
+})
+
+export type UnitsListQueryInput = z.infer<typeof UnitsListQuery>

--- a/src/lib/public-booking/stripe-public.ts
+++ b/src/lib/public-booking/stripe-public.ts
@@ -1,0 +1,70 @@
+import Stripe from 'stripe'
+
+// Singleton Stripe client for public booking endpoints.
+// Uses the same STRIPE_SECRET_KEY as the internal client but a DIFFERENT
+// webhook secret (STRIPE_WEBHOOK_SECRET_PUBLIC) to keep public and internal
+// webhook flows isolated (ADR-018).
+let _stripe: Stripe | null = null
+
+export function getStripePublic(): Stripe {
+  if (!_stripe) {
+    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: '2024-04-10',
+      typescript: true,
+    })
+  }
+  return _stripe
+}
+
+// ── Session creation helper ───────────────────────────────────────────────────
+
+export interface CreateCheckoutSessionParams {
+  unitName: string
+  nights: number
+  from: string
+  to: string
+  guests: number
+  totalMxn: number           // pesos, not cents
+  metadata: Record<string, string>
+  idempotencyKey: string
+}
+
+export async function createCheckoutSession(
+  params: CreateCheckoutSessionParams,
+): Promise<Stripe.Checkout.Session> {
+  const stripe = getStripePublic()
+  const totalCents = Math.round(params.totalMxn * 100)
+
+  const successUrl =
+    process.env.PUBLIC_BOOKING_SUCCESS_URL?.replace('{HOLD_ID}', params.metadata.hold_id ?? '') ??
+    'https://809.mx/confirmacion/{HOLD_ID}'
+
+  const cancelUrl =
+    process.env.PUBLIC_BOOKING_CANCEL_URL ?? 'https://809.mx/reservar'
+
+  return stripe.checkout.sessions.create(
+    {
+      mode: 'payment',
+      currency: 'mxn',
+      line_items: [
+        {
+          price_data: {
+            currency: 'mxn',
+            unit_amount: totalCents,
+            product_data: {
+              name: `Reserva ${params.unitName} · ${params.nights} ${params.nights === 1 ? 'noche' : 'noches'}`,
+              description: `${params.from} → ${params.to} · ${params.guests} ${params.guests === 1 ? 'huésped' : 'huéspedes'}`,
+            },
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: params.metadata,
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+    },
+    {
+      idempotencyKey: params.idempotencyKey,
+    },
+  )
+}

--- a/src/lib/public-booking/supabase-public.ts
+++ b/src/lib/public-booking/supabase-public.ts
@@ -1,0 +1,26 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+/**
+ * Anon client — for reading public views (v_public_buildings, v_public_units).
+ * Has no write privileges. Safe to use for public GETs.
+ */
+export function createAnonClient(): SupabaseClient {
+  return createClient(supabaseUrl, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+/**
+ * Service-role client — for writes (reservation_holds, reservations, etc.).
+ * NEVER expose this client or its key to the browser/client side.
+ * Only used in server-side API route handlers.
+ */
+export function createServiceClient(): SupabaseClient {
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}

--- a/supabase/migrations/20260523_public_booking.sql
+++ b/supabase/migrations/20260523_public_booking.sql
@@ -1,0 +1,178 @@
+-- ============================================================
+-- BaW OS · Sprint 5B — Public Booking Engine (Mateos 809 / ADR-017 / ADR-018)
+-- ============================================================
+BEGIN;
+
+-- ── 1. buildings: campos públicos ────────────────────────────
+ALTER TABLE public.buildings
+  ADD COLUMN IF NOT EXISTS slug text UNIQUE,
+  ADD COLUMN IF NOT EXISTS public_name text,
+  ADD COLUMN IF NOT EXISTS public_description text,
+  ADD COLUMN IF NOT EXISTS hero_url text,
+  ADD COLUMN IF NOT EXISTS gallery jsonb NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS amenities_common jsonb NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS faq jsonb NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS location_lat numeric,
+  ADD COLUMN IF NOT EXISTS location_lng numeric,
+  ADD COLUMN IF NOT EXISTS is_public_listed boolean NOT NULL DEFAULT false;
+
+-- ── 2. units: campos públicos ────────────────────────────────
+ALTER TABLE public.units
+  ADD COLUMN IF NOT EXISTS public_name text,
+  ADD COLUMN IF NOT EXISTS public_description text,
+  ADD COLUMN IF NOT EXISTS hero_url text,
+  ADD COLUMN IF NOT EXISTS base_rate_mxn numeric,
+  ADD COLUMN IF NOT EXISTS cleaning_fee_mxn numeric NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS max_guests integer NOT NULL DEFAULT 2,
+  ADD COLUMN IF NOT EXISTS min_nights integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS building_id uuid REFERENCES public.buildings(id),
+  ADD COLUMN IF NOT EXISTS is_publicly_bookable boolean NOT NULL DEFAULT false;
+
+-- ── 3. Constraint anti double-booking en reservations ────────
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- usar DO/EXCEPTION porque ADD CONSTRAINT IF NOT EXISTS no está soportado
+-- en todas las versiones de Postgres para EXCLUDE constraints
+DO $$
+BEGIN
+  ALTER TABLE public.reservations
+    ADD CONSTRAINT no_overlap_per_unit
+    EXCLUDE USING gist (
+      unit_id WITH =,
+      daterange(check_in, check_out, '[)') WITH &&
+    ) WHERE (status IN ('confirmed', 'checked_in'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+  WHEN duplicate_table  THEN NULL;
+END;
+$$;
+
+-- ── 4. Hold temporal ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.reservation_holds (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  unit_id uuid NOT NULL REFERENCES public.units(id) ON DELETE CASCADE,
+  from_date date NOT NULL,
+  to_date date NOT NULL,
+  guests_count integer NOT NULL DEFAULT 1,
+  guest_email text,
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '15 minutes'),
+  stripe_session_id text UNIQUE,
+  idempotency_key text UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (to_date > from_date)
+);
+
+-- EXCLUDE en holds (separado del CREATE TABLE para poder usar DO/EXCEPTION)
+DO $$
+BEGIN
+  ALTER TABLE public.reservation_holds
+    ADD CONSTRAINT no_overlap_per_hold
+    EXCLUDE USING gist (
+      unit_id WITH =,
+      daterange(from_date, to_date, '[)') WITH &&
+    ) WHERE (expires_at > now());
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+  WHEN duplicate_table  THEN NULL;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS reservation_holds_expires_idx
+  ON public.reservation_holds(expires_at);
+
+CREATE INDEX IF NOT EXISTS reservation_holds_stripe_idx
+  ON public.reservation_holds(stripe_session_id);
+
+-- ── 5. Idempotencia webhook Stripe ───────────────────────────
+CREATE TABLE IF NOT EXISTS public.stripe_processed_events (
+  event_id text PRIMARY KEY,
+  event_type text NOT NULL,
+  processed_at timestamptz NOT NULL DEFAULT now(),
+  payload jsonb
+);
+
+-- ── 6. Idempotencia checkout cliente ─────────────────────────
+CREATE TABLE IF NOT EXISTS public.checkout_idempotency (
+  key text PRIMARY KEY,
+  response jsonb NOT NULL,
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '24 hours'),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS checkout_idempotency_expires_idx
+  ON public.checkout_idempotency(expires_at);
+
+-- ── 7. Vistas públicas ───────────────────────────────────────
+CREATE OR REPLACE VIEW public.v_public_buildings AS
+SELECT
+  id,
+  slug,
+  public_name      AS name,
+  public_description AS description,
+  hero_url,
+  gallery,
+  amenities_common AS amenities,
+  faq,
+  city,
+  state,
+  country,
+  location_lat,
+  location_lng
+FROM public.buildings
+WHERE is_public_listed = true;
+
+CREATE OR REPLACE VIEW public.v_public_units AS
+SELECT
+  u.id,
+  u.slug,
+  u.building_id,
+  b.slug         AS building_slug,
+  u.public_name  AS name,
+  u.public_description AS description,
+  u.hero_url,
+  u.amenities,
+  u.base_rate_mxn,
+  u.cleaning_fee_mxn,
+  u.max_guests,
+  u.min_nights
+FROM public.units u
+JOIN public.buildings b ON b.id = u.building_id
+WHERE u.is_publicly_bookable = true
+  AND b.is_public_listed    = true;
+
+-- ── 8. Función helper de disponibilidad ──────────────────────
+CREATE OR REPLACE FUNCTION public.fn_unit_is_available(
+  p_unit_id uuid,
+  p_from    date,
+  p_to      date
+) RETURNS boolean LANGUAGE sql STABLE AS $$
+  SELECT
+    NOT EXISTS (
+      SELECT 1 FROM public.reservations
+      WHERE unit_id = p_unit_id
+        AND status IN ('confirmed', 'checked_in', 'tentative')
+        AND daterange(check_in, check_out, '[)') && daterange(p_from, p_to, '[)')
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.reservation_holds
+      WHERE unit_id   = p_unit_id
+        AND expires_at > now()
+        AND daterange(from_date, to_date, '[)') && daterange(p_from, p_to, '[)')
+    );
+$$;
+
+-- ── 9. GRANTs públicos (solo vistas y función) ───────────────
+GRANT SELECT ON public.v_public_buildings TO anon;
+GRANT SELECT ON public.v_public_units     TO anon;
+GRANT EXECUTE ON FUNCTION public.fn_unit_is_available TO anon;
+
+-- ── 10. Seed: marcar Mateos 809 como edificio público ────────
+UPDATE public.buildings
+SET
+  slug               = 'mateos-809',
+  public_name        = '809',
+  public_description = 'Doce departamentos sobre Adolfo López Mateos 809 en León, Guanajuato. Estancias contemporáneas desde una noche.',
+  is_public_listed   = true
+WHERE org_id = 'ed4308c7-2bdb-46f2-be69-7c59674838e2';
+
+COMMIT;

--- a/tests/public-booking/cors.test.mjs
+++ b/tests/public-booking/cors.test.mjs
@@ -1,0 +1,124 @@
+// BaW OS · Sprint 5B — CORS helper tests (pure-logic, no HTTP)
+// Run: node tests/public-booking/cors.test.mjs
+// TODO(WS-4): expand with actual HTTP integration tests against the running server
+
+import { strict as assert } from 'node:assert'
+
+// ── Reimplementation of cors.ts getAllowedOrigin logic ────────────────────────
+// Mirrors src/lib/public-booking/cors.ts
+
+function getAllowedOrigin(requestOrigin, allowedEnv, nodeEnv = 'production') {
+  if (!requestOrigin) return null
+
+  const allowed = (allowedEnv ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  // In development, allow localhost and vercel previews
+  if (nodeEnv === 'development') {
+    if (
+      requestOrigin.startsWith('http://localhost') ||
+      requestOrigin.startsWith('http://127.0.0.1') ||
+      requestOrigin.endsWith('.vercel.app')
+    ) {
+      return requestOrigin
+    }
+  }
+
+  if (allowed.includes(requestOrigin)) return requestOrigin
+  return null
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+    failed++
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+console.log('cors.test.mjs')
+
+const allowedEnv = 'https://809.mx,https://baw-os.vercel.app'
+
+test('allowed origin returns origin string', () => {
+  const result = getAllowedOrigin('https://809.mx', allowedEnv)
+  assert.equal(result, 'https://809.mx')
+})
+
+test('second allowed origin is accepted', () => {
+  const result = getAllowedOrigin('https://baw-os.vercel.app', allowedEnv)
+  assert.equal(result, 'https://baw-os.vercel.app')
+})
+
+test('unknown origin returns null in production', () => {
+  const result = getAllowedOrigin('https://evil.com', allowedEnv, 'production')
+  assert.equal(result, null)
+})
+
+test('null origin returns null', () => {
+  const result = getAllowedOrigin(null, allowedEnv)
+  assert.equal(result, null)
+})
+
+test('empty origin string returns null', () => {
+  const result = getAllowedOrigin('', allowedEnv)
+  assert.equal(result, null)
+})
+
+test('localhost is allowed in development', () => {
+  const result = getAllowedOrigin('http://localhost:3000', allowedEnv, 'development')
+  assert.equal(result, 'http://localhost:3000')
+})
+
+test('127.0.0.1 is allowed in development', () => {
+  const result = getAllowedOrigin('http://127.0.0.1:3000', allowedEnv, 'development')
+  assert.equal(result, 'http://127.0.0.1:3000')
+})
+
+test('vercel preview is allowed in development', () => {
+  const result = getAllowedOrigin('https://my-branch.vercel.app', allowedEnv, 'development')
+  assert.equal(result, 'https://my-branch.vercel.app')
+})
+
+test('localhost is NOT allowed in production unless whitelisted', () => {
+  const result = getAllowedOrigin('http://localhost:3000', allowedEnv, 'production')
+  assert.equal(result, null)
+})
+
+test('http variant of allowed https origin is rejected', () => {
+  // https://809.mx is allowed but http://809.mx should not be
+  const result = getAllowedOrigin('http://809.mx', allowedEnv, 'production')
+  assert.equal(result, null)
+})
+
+test('subdomain of allowed origin is rejected in production', () => {
+  // api.809.mx is NOT https://809.mx
+  const result = getAllowedOrigin('https://api.809.mx', allowedEnv, 'production')
+  assert.equal(result, null)
+})
+
+test('empty allowedEnv rejects all origins in production', () => {
+  const result = getAllowedOrigin('https://809.mx', '', 'production')
+  assert.equal(result, null)
+})
+
+test('comma-separated env with spaces is parsed correctly', () => {
+  const env = '  https://809.mx , https://baw-os.vercel.app  '
+  const result = getAllowedOrigin('https://809.mx', env, 'production')
+  assert.equal(result, 'https://809.mx')
+})
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/tests/public-booking/idempotency.test.mjs
+++ b/tests/public-booking/idempotency.test.mjs
@@ -1,0 +1,140 @@
+// BaW OS · Sprint 5B — Idempotency logic tests (no DB, pure-logic)
+// Run: node tests/public-booking/idempotency.test.mjs
+// TODO(WS-4): expand with real DB integration tests once env is available
+
+import { strict as assert } from 'node:assert'
+
+// ── Reimplementation of checkout idempotency logic ────────────────────────────
+// Mirrors the logic in /api/public/v1/bookings/checkout/route.ts
+function makeIdemStore() {
+  const store = new Map()
+  return {
+    get(key) {
+      const entry = store.get(key)
+      if (!entry) return null
+      if (new Date(entry.expires_at) < new Date()) {
+        store.delete(key)
+        return null
+      }
+      return entry
+    },
+    set(key, response, ttlMs = 24 * 60 * 60 * 1000) {
+      store.set(key, {
+        key,
+        response,
+        expires_at: new Date(Date.now() + ttlMs).toISOString(),
+      })
+    },
+    size() {
+      return store.size
+    },
+  }
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+    failed++
+  }
+}
+
+async function testAsync(name, fn) {
+  try {
+    await fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+    failed++
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+console.log('idempotency.test.mjs')
+
+test('same key returns cached response', () => {
+  const store = makeIdemStore()
+  const key = 'test-key-001'
+  const response = { checkout_url: 'https://stripe.com/c/test', session_id: 'cs_001', hold_id: 'hold_001', expires_at: '2026-06-01T12:00:00Z' }
+
+  store.set(key, response)
+
+  const cached = store.get(key)
+  assert.ok(cached, 'should return cached entry')
+  assert.deepEqual(cached.response, response)
+})
+
+test('different key does not return cached response', () => {
+  const store = makeIdemStore()
+  store.set('key-A', { checkout_url: 'https://stripe.com/A' })
+
+  const result = store.get('key-B')
+  assert.equal(result, null, 'different key should return null')
+})
+
+test('expired entry returns null', () => {
+  const store = makeIdemStore()
+  const key = 'expired-key'
+
+  // Set with -1ms TTL (already expired)
+  store.set(key, { checkout_url: 'https://stripe.com/exp' }, -1)
+
+  const result = store.get(key)
+  assert.equal(result, null, 'expired entry should return null')
+})
+
+test('missing key returns null', () => {
+  const store = makeIdemStore()
+  assert.equal(store.get('nonexistent-key'), null)
+})
+
+test('same key called twice returns identical response', () => {
+  const store = makeIdemStore()
+  const key = 'idempotent-key-002'
+  const response = { checkout_url: 'https://stripe.com/c/abc123', session_id: 'cs_abc', hold_id: 'hold_abc', expires_at: '2026-07-01T00:00:00Z' }
+
+  store.set(key, response)
+
+  const first = store.get(key)
+  const second = store.get(key)
+
+  assert.deepEqual(first, second, 'both calls should return identical response')
+  assert.equal(first?.response.session_id, 'cs_abc')
+})
+
+test('store correctly records expires_at in future', () => {
+  const store = makeIdemStore()
+  const key = 'future-key'
+  const before = Date.now()
+  store.set(key, { msg: 'test' }, 3600_000) // 1 hour
+  const entry = store.get(key)
+  assert.ok(entry)
+  const expiresAt = new Date(entry.expires_at).getTime()
+  assert.ok(expiresAt > before, 'expires_at should be in the future')
+})
+
+test('multiple keys are independent', () => {
+  const store = makeIdemStore()
+  store.set('key-1', { session_id: 'cs_1' })
+  store.set('key-2', { session_id: 'cs_2' })
+  store.set('key-3', { session_id: 'cs_3' })
+
+  assert.equal(store.get('key-1')?.response.session_id, 'cs_1')
+  assert.equal(store.get('key-2')?.response.session_id, 'cs_2')
+  assert.equal(store.get('key-3')?.response.session_id, 'cs_3')
+  assert.equal(store.size(), 3)
+})
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/tests/public-booking/pricing.test.mjs
+++ b/tests/public-booking/pricing.test.mjs
@@ -1,0 +1,161 @@
+// BaW OS · Sprint 5B — Pure-logic pricing tests (no DB, no framework)
+// Run: node tests/public-booking/pricing.test.mjs
+
+import { strict as assert } from 'node:assert'
+
+// ── Reimport logic inline (mirrors src/lib/public-booking/pricing.ts) ────────
+const IVA_RATE = 0.16
+
+function round2(n) {
+  return Math.round(n * 100) / 100
+}
+
+function countNights(from, to) {
+  const msPerDay = 86_400_000
+  return Math.round((new Date(to).getTime() - new Date(from).getTime()) / msPerDay)
+}
+
+function computeQuote(unit, from, to, guests) {
+  if (unit.base_rate_mxn === null || unit.base_rate_mxn === undefined) {
+    throw new Error('Unit has no base rate configured')
+  }
+  if (guests > unit.max_guests) throw new Error(`Unit supports max ${unit.max_guests} guests`)
+
+  const nights = countNights(from, to)
+  if (nights < unit.min_nights) throw new Error(`Minimum stay is ${unit.min_nights} night(s)`)
+  if (nights <= 0) throw new Error('"to" must be after "from"')
+
+  const baseRate = Number(unit.base_rate_mxn)
+  const cleaningFee = Number(unit.cleaning_fee_mxn ?? 0)
+
+  const subtotal = round2(baseRate * nights)
+  const preTaxTotal = round2(subtotal + cleaningFee)
+  const taxIva = round2(preTaxTotal * IVA_RATE)
+  const total = round2(preTaxTotal + taxIva)
+
+  const breakdown = [
+    { label: `${nights} noches × $${baseRate}`, amount_mxn: subtotal },
+  ]
+  if (cleaningFee > 0) breakdown.push({ label: 'Limpieza', amount_mxn: cleaningFee })
+  breakdown.push({ label: 'IVA (16%)', amount_mxn: taxIva })
+
+  return { unit_slug: unit.slug, from, to, guests, nights, subtotal_mxn: subtotal, cleaning_fee_mxn: cleaningFee, tax_iva_mxn: taxIva, total_mxn: total, currency: 'MXN', breakdown }
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+    failed++
+  }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const baseUnit = {
+  slug: 'depa-1a',
+  base_rate_mxn: 1000,
+  cleaning_fee_mxn: 400,
+  max_guests: 4,
+  min_nights: 1,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+console.log('pricing.test.mjs')
+
+test('countNights: 3 nights between 2026-06-01 and 2026-06-04', () => {
+  assert.equal(countNights('2026-06-01', '2026-06-04'), 3)
+})
+
+test('countNights: 1 night', () => {
+  assert.equal(countNights('2026-07-15', '2026-07-16'), 1)
+})
+
+test('countNights: 7 nights (1 week)', () => {
+  assert.equal(countNights('2026-01-01', '2026-01-08'), 7)
+})
+
+test('computeQuote: 2 nights × $1000 + $400 cleaning + 16% IVA', () => {
+  const q = computeQuote(baseUnit, '2026-06-01', '2026-06-03', 2)
+  assert.equal(q.nights, 2)
+  assert.equal(q.subtotal_mxn, 2000)
+  assert.equal(q.cleaning_fee_mxn, 400)
+  // preTax = 2000 + 400 = 2400; IVA = 384; total = 2784
+  assert.equal(q.tax_iva_mxn, 384)
+  assert.equal(q.total_mxn, 2784)
+  assert.equal(q.currency, 'MXN')
+})
+
+test('computeQuote: 1 night minimum stay is respected', () => {
+  const q = computeQuote(baseUnit, '2026-08-10', '2026-08-11', 1)
+  assert.equal(q.nights, 1)
+  assert.equal(q.subtotal_mxn, 1000)
+})
+
+test('computeQuote: unit with 0 cleaning fee', () => {
+  const unit = { ...baseUnit, cleaning_fee_mxn: 0 }
+  const q = computeQuote(unit, '2026-06-01', '2026-06-03', 1)
+  assert.equal(q.cleaning_fee_mxn, 0)
+  // preTax = 2000; IVA = 320; total = 2320
+  assert.equal(q.tax_iva_mxn, 320)
+  assert.equal(q.total_mxn, 2320)
+})
+
+test('computeQuote: breakdown contains correct number of items (3: subtotal, cleaning, IVA)', () => {
+  const q = computeQuote(baseUnit, '2026-06-01', '2026-06-03', 2)
+  assert.equal(q.breakdown.length, 3)
+  assert.equal(q.breakdown[2].label, 'IVA (16%)')
+})
+
+test('computeQuote: breakdown without cleaning (2 items: subtotal, IVA)', () => {
+  const unit = { ...baseUnit, cleaning_fee_mxn: 0 }
+  const q = computeQuote(unit, '2026-06-01', '2026-06-03', 1)
+  assert.equal(q.breakdown.length, 2)
+})
+
+test('computeQuote: throws when guests exceed max_guests', () => {
+  assert.throws(() => computeQuote(baseUnit, '2026-06-01', '2026-06-03', 10), /max/)
+})
+
+test('computeQuote: throws when min_nights not met', () => {
+  const unit = { ...baseUnit, min_nights: 3 }
+  assert.throws(() => computeQuote(unit, '2026-06-01', '2026-06-02', 1), /Minimum stay/)
+})
+
+test('computeQuote: throws when base_rate_mxn is null', () => {
+  const unit = { ...baseUnit, base_rate_mxn: null }
+  assert.throws(() => computeQuote(unit, '2026-06-01', '2026-06-03', 1), /base rate/)
+})
+
+test('computeQuote: IVA is 16% of (subtotal + cleaning_fee)', () => {
+  const q = computeQuote(baseUnit, '2026-06-01', '2026-06-04', 2) // 3 nights
+  const expected = round2((q.subtotal_mxn + q.cleaning_fee_mxn) * 0.16)
+  assert.equal(q.tax_iva_mxn, expected)
+})
+
+test('computeQuote: total = subtotal + cleaning + IVA', () => {
+  const q = computeQuote(baseUnit, '2026-06-01', '2026-06-06', 3) // 5 nights
+  const expected = round2(q.subtotal_mxn + q.cleaning_fee_mxn + q.tax_iva_mxn)
+  assert.equal(q.total_mxn, expected)
+})
+
+test('computeQuote: large reservation (30 nights) rounds correctly', () => {
+  const unit = { ...baseUnit, base_rate_mxn: 799, cleaning_fee_mxn: 350 }
+  const q = computeQuote(unit, '2026-07-01', '2026-07-31', 2)
+  assert.equal(q.nights, 30)
+  const expectedSubtotal = round2(799 * 30)  // 23970
+  assert.equal(q.subtotal_mxn, expectedSubtotal)
+  const expectedTotal = round2((expectedSubtotal + 350) * 1.16)
+  assert.equal(q.total_mxn, expectedTotal)
+})
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/tests/public-booking/rate-limit.test.mjs
+++ b/tests/public-booking/rate-limit.test.mjs
@@ -1,0 +1,171 @@
+// BaW OS · Sprint 5B — Rate limiter tests (pure-logic, in-memory)
+// Run: node tests/public-booking/rate-limit.test.mjs
+// TODO(WS-4): replace with Upstash Ratelimit tests when configured
+
+import { strict as assert } from 'node:assert'
+
+// ── Reimplementation of rate-limit.ts ────────────────────────────────────────
+// Mirrors src/lib/public-booking/rate-limit.ts
+
+function makeRateLimiter() {
+  const store = new Map()
+
+  function checkRateLimit(key, limit, windowMs = 60_000) {
+    const now = Date.now()
+    const entry = store.get(key)
+
+    if (!entry || entry.resetAt < now) {
+      const resetAt = now + windowMs
+      store.set(key, { count: 1, resetAt })
+      return { allowed: true, remaining: limit - 1, resetAt }
+    }
+
+    if (entry.count >= limit) {
+      return { allowed: false, remaining: 0, resetAt: entry.resetAt }
+    }
+
+    entry.count++
+    return { allowed: true, remaining: limit - entry.count, resetAt: entry.resetAt }
+  }
+
+  function rateLimitByIp(routeId, ip, limit) {
+    return checkRateLimit(`${routeId}:${ip}`, limit)
+  }
+
+  return { checkRateLimit, rateLimitByIp, store }
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+    failed++
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+console.log('rate-limit.test.mjs')
+
+test('first request is allowed', () => {
+  const rl = makeRateLimiter()
+  const result = rl.checkRateLimit('route:ip-1', 5)
+  assert.equal(result.allowed, true)
+  assert.equal(result.remaining, 4)
+})
+
+test('requests up to limit are allowed', () => {
+  const rl = makeRateLimiter()
+  const key = 'route:ip-2'
+  const limit = 5
+  for (let i = 0; i < limit; i++) {
+    const r = rl.checkRateLimit(key, limit)
+    assert.equal(r.allowed, true, `request ${i + 1} should be allowed`)
+  }
+})
+
+test('request over limit is blocked', () => {
+  const rl = makeRateLimiter()
+  const key = 'route:ip-3'
+  const limit = 3
+  for (let i = 0; i < limit; i++) {
+    rl.checkRateLimit(key, limit) // exhaust
+  }
+  const over = rl.checkRateLimit(key, limit)
+  assert.equal(over.allowed, false, 'over-limit request should be blocked')
+  assert.equal(over.remaining, 0)
+})
+
+test('remaining count decrements correctly', () => {
+  const rl = makeRateLimiter()
+  const key = 'route:ip-4'
+  const limit = 10
+  for (let i = 0; i < 5; i++) {
+    rl.checkRateLimit(key, limit)
+  }
+  const next = rl.checkRateLimit(key, limit)
+  assert.equal(next.remaining, limit - 6)
+})
+
+test('different IPs have independent counters', () => {
+  const rl = makeRateLimiter()
+  const limit = 2
+  rl.checkRateLimit('route:ip-A', limit)
+  rl.checkRateLimit('route:ip-A', limit)
+  const blockedA = rl.checkRateLimit('route:ip-A', limit)
+  assert.equal(blockedA.allowed, false, 'ip-A should be blocked')
+
+  const allowedB = rl.checkRateLimit('route:ip-B', limit)
+  assert.equal(allowedB.allowed, true, 'ip-B should still be allowed')
+})
+
+test('rateLimitByIp uses route+ip composite key', () => {
+  const rl = makeRateLimiter()
+  const limit = 1
+
+  rl.rateLimitByIp('buildings', '1.2.3.4', limit)
+  const blocked = rl.rateLimitByIp('buildings', '1.2.3.4', limit)
+  assert.equal(blocked.allowed, false)
+
+  const otherRoute = rl.rateLimitByIp('units', '1.2.3.4', limit)
+  assert.equal(otherRoute.allowed, true, 'different route should be independent')
+})
+
+test('window expires and resets count', () => {
+  const rl = makeRateLimiter()
+  const key = 'route:ip-expire'
+  const limit = 1
+  const windowMs = 10 // tiny window
+
+  rl.checkRateLimit(key, limit, windowMs)
+  const blocked = rl.checkRateLimit(key, limit, windowMs)
+  assert.equal(blocked.allowed, false, 'should be blocked immediately')
+
+  // Wait for window to expire
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const after = rl.checkRateLimit(key, limit, windowMs)
+      assert.equal(after.allowed, true, 'should be allowed after window expires')
+      resolve()
+    }, 15)
+  })
+})
+
+test('limit of 60 for GETs is enforced', () => {
+  const rl = makeRateLimiter()
+  const key = 'get-route:ip-get'
+  const limit = 60
+
+  for (let i = 0; i < 60; i++) {
+    const r = rl.checkRateLimit(key, limit)
+    assert.equal(r.allowed, true, `GET request ${i + 1} should be allowed`)
+  }
+
+  const over = rl.checkRateLimit(key, limit)
+  assert.equal(over.allowed, false, '61st GET request should be blocked')
+})
+
+test('limit of 10 for POSTs is enforced', () => {
+  const rl = makeRateLimiter()
+  const key = 'post-route:ip-post'
+  const limit = 10
+
+  for (let i = 0; i < 10; i++) {
+    const r = rl.checkRateLimit(key, limit)
+    assert.equal(r.allowed, true, `POST request ${i + 1} should be allowed`)
+  }
+
+  const over = rl.checkRateLimit(key, limit)
+  assert.equal(over.allowed, false, '11th POST request should be blocked')
+})
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/tests/public-booking/run-all.sh
+++ b/tests/public-booking/run-all.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# BaW OS · Sprint 5B — Pure-logic tests for public booking (no DB, no framework)
+# Run: bash tests/public-booking/run-all.sh
+set -e
+cd "$(dirname "$0")/../.."
+
+echo "=== pricing.test.mjs ==="
+node tests/public-booking/pricing.test.mjs
+
+echo ""
+echo "=== idempotency.test.mjs ==="
+node tests/public-booking/idempotency.test.mjs
+
+echo ""
+echo "=== cors.test.mjs ==="
+node tests/public-booking/cors.test.mjs
+
+echo ""
+echo "=== rate-limit.test.mjs ==="
+node tests/public-booking/rate-limit.test.mjs
+
+echo ""
+echo "All public-booking pure-logic tests passed."


### PR DESCRIPTION
## Sprint 5B / WS-1 — Backend Público Motor de Reservas 809

Implementa el backend completo del motor de reservas público para el edificio Mateos 809 (marca **809**) según ADR-017 y ADR-018.

---

### Archivos creados

#### Migración
- `supabase/migrations/20260523_public_booking.sql` — campos públicos en `buildings` y `units`, tabla `reservation_holds` con constraint GIST anti double-booking, `stripe_processed_events`, `checkout_idempotency`, vistas `v_public_buildings` / `v_public_units`, función `fn_unit_is_available`, GRANTs a `anon`, seed de Mateos 809.

#### Utilidades (`src/lib/public-booking/`)
- `schemas.ts` — zod schemas compartidos (DateRange, GuestInfo, QuoteRequest, CheckoutRequest, tipos PublicUnit/Building/Quote/CheckoutResponse)
- `pricing.ts` — `computeQuote()` con IVA 16%, cleanup fee, min_nights, max_guests
- `cors.ts` — `getAllowedOrigin()`, `withCors()`, `handlePreflight()`, helpers de error
- `rate-limit.ts` — rate limiter in-memory (Map + cleanup) por ruta+IP
- `supabase-public.ts` — `createAnonClient()` para lecturas sobre vistas, `createServiceClient()` para escrituras server-side
- `stripe-public.ts` — singleton Stripe + `createCheckoutSession()` con `price_data` ad-hoc en MXN

#### Endpoints (`src/app/api/public/v1/`)
| Método | Ruta | Descripción |
|---|---|---|
| GET | `/buildings/[slug]` | Info edificio desde `v_public_buildings` |
| GET | `/buildings/[slug]/units` | Unidades con filtro `?from&to&guests` + disponibilidad |
| GET | `/units/[slug]` | Detalle unidad |
| GET | `/units/[slug]/availability` | Bool + blocked_days (max 90 días) |
| POST | `/quotes` | Cálculo de precio (noches, cleaning, IVA 16%) |
| POST | `/bookings/checkout` | Idempotency-Key + hold + Stripe Checkout Session |
| POST | `/webhooks/stripe` | Firma verificada; promueve hold → reservation; limpia holds expirados |

Todos los endpoints: feature flag (`PUBLIC_BOOKING_ENABLED`), CORS estricto, rate limit (60 GET / 10 POST por IP/min), errores en forma `{error:{code,message}}`, logs `key=value`.

#### Tests (`tests/public-booking/`)
- `pricing.test.mjs` — 14 tests (noches, IVA, cleaning fee, edge cases)
- `idempotency.test.mjs` — 7 tests (cache hit, expiración, claves independientes)
- `cors.test.mjs` — 13 tests (origins permitidos/rechazados, development vs production)
- `rate-limit.test.mjs` — 9 tests (límites GET/POST, ventanas, IPs independientes)
- **43 tests pasan** (`bash tests/public-booking/run-all.sh`)

#### Documentación
- `docs/sprints/SPRINT_5B_ENV.md` — vars de entorno, checklist de producción, template `.env.local`

---

### ADRs implementados
- **ADR-017**: endpoints `/api/public/v1/*`, vistas RLS, feature flag, CORS, rate limit, idempotencia
- **ADR-018**: Stripe Checkout hosted, idempotencia en 3 capas (checkout cache / Stripe API idem key / `stripe_processed_events`), constraint GIST anti double-booking, hold 15 min

---

### Variables de entorno necesarias (ver `docs/sprints/SPRINT_5B_ENV.md`)
```
PUBLIC_BOOKING_ENABLED=false
NEXT_PUBLIC_PUBLIC_BOOKING_ENABLED=false
PUBLIC_BOOKING_ALLOWED_ORIGINS=https://809.mx,https://baw-os.vercel.app
STRIPE_SECRET_KEY=sk_test_...
STRIPE_WEBHOOK_SECRET_PUBLIC=whsec_...
PUBLIC_BOOKING_SUCCESS_URL=https://809.mx/confirmacion/{HOLD_ID}
PUBLIC_BOOKING_CANCEL_URL=https://809.mx/reservar
```

---

### Notas técnicas
- **TypeScript**: `tsc --noEmit` pasa sin errores.
- **Build**: `npm run build` falla por `baw-design/tokens/index.css` ausente — **error pre-existente en `main`**, no introducido por este PR.
- Rate limiter es in-memory por instancia Vercel (aceptable para v1). Reemplazar con Upstash para multi-instancia (WS-4 o Sprint 6).
- El cliente Supabase de service role se usa solo server-side; nunca se expone al navegador.

---

### TODOs para WS-2 / WS-4
- **WS-2**: Frontend `(public-booking)` group — páginas landing, wizard reserva, confirmación
- **WS-4**: Stripe CLI test end-to-end, email confirmación (Resend), cron de reconciliación (Vercel Cron cada 15 min), smoke test con tarjeta real
- **WS-5**: Playwright E2E — doble-booking simultáneo, webhook replay, activar flag en producción

**No auto-merge. Requiere revisión de Fran + WS-4 antes de activar `PUBLIC_BOOKING_ENABLED=true`.**