### PR TITLE
fix(vercel) init git submodules before npm install

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,6 @@
       "path": "/api/cron/payments",
       "schedule": "0 6 1 * *"
     }
-  ]
+  ],
+  "installCommand": "git submodule update --init --recursive && npm install"
 }


### PR DESCRIPTION
## Contexto

Detectado durante el smoke build de WS-1 (PR #59): `npm run build` falla en local fresh-clone con error sobre `design/baw-design/tokens/index.css`. Causa: el directorio es **submódulo git** que apunta al repo `zxy-vc/baw-design`, y ni Vercel ni un `gh repo clone` lo inicializan automáticamente.

## Fix

Añade `installCommand` a `vercel.json`:

```json
"installCommand": "git submodule update --init --recursive && npm install"
```

## Verificación

```
git submodule update --init --recursive
npm install
npm run build   # ✓ pasa
```

## Por qué mergear antes que PR #59

Si #59 entra primero sin este fix, los deploys preview en Vercel pueden fallar al construir incluso código no relacionado con el sprint. Mergear este primero garantiza que cualquier futuro PR del sprint 5B tenga preview funcional.

## Sin auto-merge