### PR TITLE
chore(ci): GitHub Actions CI workflow — precondición handoff Andrés Mark II

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,157 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-and-typecheck:
+    name: lint-and-typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: |
+          if npm run typecheck --if-present 2>/dev/null; then
+            echo "Typecheck passed via npm run typecheck"
+          else
+            npx tsc --noEmit
+          fi
+
+      - name: Lint
+        run: npm run lint --if-present
+
+  build:
+    name: build
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
+          SUPABASE_SERVICE_ROLE_KEY: placeholder
+          PUBLIC_BOOKING_ENABLED: 'false'
+          NEXT_PUBLIC_PUBLIC_BOOKING_ENABLED: 'false'
+          PUBLIC_BOOKING_ALLOWED_ORIGINS: 'https://placeholder.example.com'
+          STRIPE_SECRET_KEY: sk_test_placeholder
+          STRIPE_WEBHOOK_SECRET_PUBLIC: whsec_placeholder
+          PUBLIC_BOOKING_SUCCESS_URL: 'https://placeholder.example.com/confirmacion/{HOLD_ID}'
+          PUBLIC_BOOKING_CANCEL_URL: 'https://placeholder.example.com/reservar'
+          NEXT_PUBLIC_APP_URL: 'https://placeholder.example.com'
+          BAWOS_API_KEY: 'placeholder'
+          CRON_SECRET: 'placeholder'
+        run: npm run build
+
+  tests:
+    name: tests
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests (public-booking)
+        run: bash tests/public-booking/run-all.sh
+
+      - name: Run tests (v1)
+        run: bash tests/v1/run-all.sh
+
+  smoke-supabase:
+    name: smoke-supabase
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+    if: ${{ secrets.SUPABASE_STAGING_URL != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Supabase health check
+        run: |
+          echo "Running Supabase smoke test against staging..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "${{ secrets.SUPABASE_STAGING_URL }}/rest/v1/" \
+            -H "apikey: ${{ secrets.SUPABASE_STAGING_ANON_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_STAGING_ANON_KEY }}")
+          echo "HTTP status: $STATUS"
+          if [ "$STATUS" -ge 200 ] && [ "$STATUS" -lt 400 ]; then
+            echo "Supabase health check passed."
+          else
+            echo "Supabase health check failed with status $STATUS"
+            exit 1
+          fi
+
+  all-checks-pass:
+    name: all-checks-pass
+    needs: [lint-and-typecheck, build, tests, smoke-supabase]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify all required jobs passed
+        run: |
+          if [ "${{ needs.lint-and-typecheck.result }}" != "success" ]; then
+            echo "lint-and-typecheck failed"
+            exit 1
+          fi
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "build failed"
+            exit 1
+          fi
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "tests failed"
+            exit 1
+          fi
+          # smoke-supabase is optional — passes if skipped (secret not set) or succeeded
+          if [ "${{ needs.smoke-supabase.result }}" != "success" ] && [ "${{ needs.smoke-supabase.result }}" != "skipped" ]; then
+            echo "smoke-supabase failed"
+            exit 1
+          fi
+          echo "All checks passed"

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1,0 +1,178 @@
+# CI/CD — baw-os
+
+GitHub Actions workflow que actúa como **precondición de merge a main**. Sin CI verde, no se mergea.
+
+---
+
+## Jobs del workflow (`.github/workflows/ci.yml`)
+
+El workflow se dispara en:
+- `pull_request` hacia `main`
+- `push` a `main`
+
+### Job 1 — `lint-and-typecheck`
+
+| Detalle | Valor |
+|---|---|
+| Runner | ubuntu-latest, Node 20 |
+| Checkout | `actions/checkout@v4` con `submodules: recursive` |
+| Cache | `actions/setup-node@v4` con `cache: 'npm'` |
+
+Pasos:
+1. `npm ci`
+2. Typecheck: usa `npm run typecheck` si existe en `package.json`; si no, corre `npx tsc --noEmit`
+3. `npm run lint --if-present`
+
+---
+
+### Job 2 — `build`
+
+| Detalle | Valor |
+|---|---|
+| Runner | ubuntu-latest, Node 20 |
+| Necesita | `lint-and-typecheck` |
+
+Pasos:
+1. `npm ci`
+2. `npm run build` con variables de entorno dummy para CI (ver `.env.example` y `docs/sprints/SPRINT_5B_ENV.md`)
+
+Variables configuradas como dummy en CI (no son secretos críticos en build time):
+
+```
+NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder
+SUPABASE_SERVICE_ROLE_KEY=placeholder
+PUBLIC_BOOKING_ENABLED=false
+NEXT_PUBLIC_PUBLIC_BOOKING_ENABLED=false
+PUBLIC_BOOKING_ALLOWED_ORIGINS=https://placeholder.example.com
+STRIPE_SECRET_KEY=sk_test_placeholder
+STRIPE_WEBHOOK_SECRET_PUBLIC=whsec_placeholder
+PUBLIC_BOOKING_SUCCESS_URL=https://placeholder.example.com/confirmacion/{HOLD_ID}
+PUBLIC_BOOKING_CANCEL_URL=https://placeholder.example.com/reservar
+NEXT_PUBLIC_APP_URL=https://placeholder.example.com
+BAWOS_API_KEY=placeholder
+CRON_SECRET=placeholder
+```
+
+> **Nota:** Si en el futuro el build requiere vars adicionales que no son críticas en runtime de CI, agregarlas como dummy en `env:` del job `build` en el workflow.
+
+---
+
+### Job 3 — `tests`
+
+| Detalle | Valor |
+|---|---|
+| Runner | ubuntu-latest, Node 20 |
+| Necesita | `lint-and-typecheck` |
+
+Pasos:
+1. `npm ci`
+2. `bash tests/public-booking/run-all.sh` — 43 tests de pure-logic (pricing, idempotency, cors, rate-limit)
+3. `bash tests/v1/run-all.sh` — 28 tests de pure-logic (classifier, idempotency, pagination)
+
+> Los tests son scripts Node puro (.mjs), no requieren Vitest. Se corren en paralelo con `build`.
+
+---
+
+### Job 4 — `smoke-supabase`
+
+| Detalle | Valor |
+|---|---|
+| Runner | ubuntu-latest, Node 20 |
+| Necesita | `lint-and-typecheck` |
+| Condición | Solo corre si `secrets.SUPABASE_STAGING_URL != ''` |
+
+Si el secret no está configurado, el job se **skipea sin falla** — no bloquea el merge.
+
+Si está configurado:
+1. `curl` al endpoint `/rest/v1/` del proyecto Supabase staging con el anon key
+2. Verifica que el HTTP status es 2xx/3xx
+
+Secrets requeridos (opcionales para CI básico):
+- `SUPABASE_STAGING_URL` — URL del proyecto Supabase staging
+- `SUPABASE_STAGING_ANON_KEY` — Anon key del proyecto staging
+
+---
+
+### Job 5 — `all-checks-pass` (merge gate)
+
+| Detalle | Valor |
+|---|---|
+| Runner | ubuntu-latest |
+| Necesita | `lint-and-typecheck`, `build`, `tests`, `smoke-supabase` |
+| Condición | `if: always()` — siempre corre para verificar resultados |
+
+Este job valida que todos los jobs requeridos (`lint-and-typecheck`, `build`, `tests`) hayan terminado en `success`. `smoke-supabase` puede ser `skipped` o `success`.
+
+**Este es el job que se configura como required check en branch protection.**
+
+---
+
+## Agregar el secret `SUPABASE_STAGING_URL` (gh CLI)
+
+```bash
+# Agrega el secret al repositorio
+gh secret set SUPABASE_STAGING_URL --body "https://your-staging-project.supabase.co" --repo zxy-vc/baw-os
+
+# Agrega también el anon key de staging
+gh secret set SUPABASE_STAGING_ANON_KEY --body "eyJ..." --repo zxy-vc/baw-os
+```
+
+Para verificar que los secrets existen:
+```bash
+gh secret list --repo zxy-vc/baw-os
+```
+
+---
+
+## Activar branch protection en `main` requiriendo `all-checks-pass` (gh CLI)
+
+```bash
+gh api repos/zxy-vc/baw-os/branches/main/protection \
+  --method PUT \
+  --field required_status_checks='{"strict":true,"contexts":["all-checks-pass"]}' \
+  --field enforce_admins=false \
+  --field required_pull_request_reviews=null \
+  --field restrictions=null
+```
+
+Para verificar la protección activa:
+```bash
+gh api repos/zxy-vc/baw-os/branches/main/protection
+```
+
+Para actualizar si ya existe protección y quieres agregar más checks:
+```bash
+gh api repos/zxy-vc/baw-os/branches/main/protection \
+  --method PUT \
+  --field required_status_checks='{"strict":true,"contexts":["all-checks-pass","lint-and-typecheck","build","tests"]}' \
+  --field enforce_admins=false \
+  --field required_pull_request_reviews=null \
+  --field restrictions=null
+```
+
+---
+
+## Convención de merge
+
+**NO se mergea a `main` sin CI verde.**
+
+- El agente Andrés Mark II solo puede mergear PRs donde el check `all-checks-pass` esté en estado `success`.
+- Si algún job falla, el PR queda bloqueado hasta que se corrija.
+- Para emergencias (hotfix urgente), un admin puede hacer bypass del branch protection, pero debe documentarse en el PR.
+
+---
+
+## Troubleshooting
+
+**Build falla por variables de entorno faltantes:**
+Agregar la variable como dummy en la sección `env:` del job `build` en `.github/workflows/ci.yml`.
+
+**Tests fallan en CI pero pasan local:**
+Los tests son Node puro, sin dependencias externas. Verificar versión de Node (debe ser 20).
+
+**smoke-supabase siempre se skipea:**
+Comportamiento esperado si `SUPABASE_STAGING_URL` no está configurado como secret. Ver sección "Agregar el secret" para configurarlo.
+
+**`all-checks-pass` falla aunque los jobs individuales pasaron:**
+Verificar que `smoke-supabase` terminó en `success` o `skipped` (no `failure` ni `cancelled`).


### PR DESCRIPTION
## Resumen

Agrega el workflow de GitHub Actions que actúa como **precondición de merge a main** para el handoff al agente Andrés Mark II. Sin CI verde, no se mergea.

## Archivos modificados

- `.github/workflows/ci.yml` — Workflow principal con 5 jobs
- `docs/CI_CD.md` — Documentación del pipeline, secrets y branch protection

## Jobs configurados

| Job | Descripción | Condición |
|---|---|---|
| `lint-and-typecheck` | `npm ci` → `npx tsc --noEmit` → `npm run lint` | Siempre |
| `build` | `npm ci` → `npm run build` con env vars dummy | needs: lint-and-typecheck |
| `tests` | `bash tests/public-booking/run-all.sh` + `bash tests/v1/run-all.sh` (71 tests pure-node) | needs: lint-and-typecheck |
| `smoke-supabase` | curl health check a `/rest/v1/` de staging | needs: lint-and-typecheck; skip si secret no existe |
| `all-checks-pass` | Verifica que todos los jobs pasaron — **merge gate** | needs: todos |

## Variables de entorno en CI

El build requiere vars de Supabase y Stripe en compile time. Se usan valores dummy no-secretos en CI:

```
NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co
NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder
SUPABASE_SERVICE_ROLE_KEY=placeholder
PUBLIC_BOOKING_ENABLED=false
NEXT_PUBLIC_PUBLIC_BOOKING_ENABLED=false
```

(Ver `docs/CI_CD.md` para la lista completa.)

## Validación local

- ✓ `npx tsc --noEmit` — sin errores
- ✓ `npm run build` con env vars dummy — compilación exitosa
- ✓ `bash tests/public-booking/run-all.sh` — 43/43 passed
- ✓ `bash tests/v1/run-all.sh` — 28/28 passed
- ✓ YAML syntax válido

## Branch protection (activar después del merge)

```bash
gh api repos/zxy-vc/baw-os/branches/main/protection \
  --method PUT \
  --field required_status_checks='{"strict":true,"contexts":["all-checks-pass"]}' \
  --field enforce_admins=false \
  --field required_pull_request_reviews=null \
  --field restrictions=null
```

## Notas

- Los tests son scripts Node puro (.mjs), no requieren Vitest — `package.json` no tiene script `test` ni Vitest instalado. Los tests se corren directamente con `bash tests/*/run-all.sh`.
- `smoke-supabase` se skipea automáticamente si el secret `SUPABASE_STAGING_URL` no está configurado — no bloquea el merge.
- `all-checks-pass` usa `if: always()` para correr aunque jobs anteriores fallen, y valida los resultados explícitamente.