### PR TITLE
fix(sprint5b): correct canonical org_id and building_id in docs and seeds

### DIFF
--- a/BUG_BASH_S6.md
+++ b/BUG_BASH_S6.md
@@ -17,7 +17,7 @@
 
 ### Bug #1 (BLOCKER, parche temporal aplicado)
 
-**Síntoma:** tras el wipe operativo de S1, todas las APIs legacy (~73 archivos: `/api/units`, `/api/contracts`, `/api/payments`, `/api/tasks`, `/api/notifications`, `/api/whatsapp/*`, etc.) seguían apuntando a `ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'` (la UUID Mateos eliminada en S1). Resultado esperado: cualquier query legacy retorna 0 filas o error de FK contra una org inexistente.
+**Síntoma:** tras el wipe operativo de S1, todas las APIs legacy (~73 archivos: `/api/units`, `/api/contracts`, `/api/payments`, `/api/tasks`, `/api/notifications`, `/api/whatsapp/*`, etc.) seguían apuntando a `ORG_ID` hardcoded con la UUID legacy pre-wipe (ya no válida en prod). UUID canónico actual: `org_id=81a011c4-4ea6-4b79-924d-73dbe6d35e14` / `building_id=0d05c6d8-a9cd-437c-8b26-bd637bed7d49`. Resultado esperado: cualquier query legacy retorna 0 filas o error de FK contra una org inexistente.
 
 **Causa raíz:** `src/lib/api-auth.ts` definía `ORG_ID` como constante hardcoded.
 

--- a/src/hooks/useOrgContext.ts
+++ b/src/hooks/useOrgContext.ts
@@ -1,6 +1,7 @@
 // BaW OS — useOrgContext hook (Sprint 4 / S4-1)
 // Hook para client components que necesitan el org_id activo del usuario logueado.
-// Reemplaza el patrón legacy: const ORG_ID = 'ed4308c7-2bdb-46f2-be69-7c59674838e2'
+// Reemplaza el patrón legacy: const ORG_ID = '<hardcoded>' (e.g. org pre-Sprint3 wipe)
+// UUID canónico prod actual: org=81a011c4-4ea6-4b79-924d-73dbe6d35e14 building=0d05c6d8-a9cd-437c-8b26-bd637bed7d49
 
 'use client'
 

--- a/supabase/seed-examples/README.md
+++ b/supabase/seed-examples/README.md
@@ -9,7 +9,7 @@ local o testing, pero el flujo canónico de creación de datos en producción es
 
 ## Archivos
 
-- `mateos-809.sql` — Seed original del MVP Mateos (Sprint 2, Org `ed4308c7-2bdb-46f2-be69-7c59674838e2`).
+- `mateos-809.sql` — Seed original del MVP Mateos (Sprint 2, Org `81a011c4-4ea6-4b79-924d-73dbe6d35e14` / building `0d05c6d8-a9cd-437c-8b26-bd637bed7d49`).
   Estructura pre-Sprint 3: usa `units.org_id` directo (sin `building_id`),
   enum `member_role` con `owner/admin/operator/viewer/agent`. **NO se puede correr
   tal cual en BaW OS post-Sprint 3** porque el schema cambió (units ahora requiere

--- a/supabase/seed-examples/mateos-809.sql
+++ b/supabase/seed-examples/mateos-809.sql
@@ -2,7 +2,9 @@
 -- Idempotente: usa funciones helper que UPDATE si existe, INSERT si no.
 -- No depende de UNIQUE constraints específicos.
 -- Datos vivos del Notion "BaW Mateos 809P — Estado Operativo Vivo".
--- Org Mateos: ed4308c7-2bdb-46f2-be69-7c59674838e2 (preexistente).
+-- Org Mateos: 81a011c4-4ea6-4b79-924d-73dbe6d35e14 (canonical prod UUID).
+-- Building Mateos 809P: 0d05c6d8-a9cd-437c-8b26-bd637bed7d49 (canonical prod UUID).
+-- NOTE: ed4308c7-2bdb-46f2-be69-7c59674838e2 was the legacy UUID from Sprint 1 wipe — no longer valid.
 
 -- ============================================================
 -- HELPER FUNCTIONS (idempotentes, scope: este seed)
@@ -90,7 +92,7 @@ END $fn$;
 
 DO $$
 DECLARE
-  v_org uuid := 'ed4308c7-2bdb-46f2-be69-7c59674838e2';
+  v_org uuid := '81a011c4-4ea6-4b79-924d-73dbe6d35e14';
   u_d102 uuid; u_d202 uuid; u_d203 uuid; u_d204 uuid;
   u_d301 uuid; u_d302 uuid; u_d401 uuid; u_d402 uuid; u_d404 uuid;
   o_erik uuid; o_pat uuid; o_let uuid; o_jose uuid; o_humb uuid;


### PR DESCRIPTION
## Summary

Replaces legacy UUID `ed4308c7-2bdb-46f2-be69-7c59674838e2` with the canonical production UUIDs in docs, seeds, and reference files.

**Canonical prod UUIDs (verified 2026-05-23):**
- `org_id = 81a011c4-4ea6-4b79-924d-73dbe6d35e14` (BaW Operations)
- `building_id = 0d05c6d8-a9cd-437c-8b26-bd637bed7d49` (Mateos 809P)

## Files changed

- `supabase/seed-examples/README.md` — updated org UUID and added building UUID reference
- `supabase/seed-examples/mateos-809.sql` — corrected `v_org` constant and header comment
- `src/hooks/useOrgContext.ts` — updated comment with canonical UUIDs (no functional change)
- `BUG_BASH_S6.md` — annotated bug description with canonical UUIDs

## What was NOT changed

- Historical migrations (`20260401_*`, `20260404_*`, `20260523_public_booking.sql`) — preserved as immutable history per team rules.

## Context

Sprint 5B WS-1 migration (`20260523_public_booking`) was applied to prod separately with the correct UUID in the seed step. This PR ensures docs and seeds are consistent for future development.