### PR TITLE
feat(sprint5a/ws1): third-party agents via Discord Interactions (Alicia)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,4 +224,100 @@ Mejor un PR pausado 1 hora que un PR mergeado con regresión.
 
 ---
 
-**Última actualización:** 2026-04-30 · Hardening post-PR #26
+## 9 · Third-party agents — Discord Interactions (Sprint 5A WS-1)
+
+> Agente conectado actualmente: **Alicia** (`id = alicia-ops`, `family = third-party`).
+> Único humano en el sistema: Fran. Los agentes NUNCA son referenciados como personas.
+
+### Arquitectura del flujo Discord → BaW OS
+
+```
+Fran (Discord) → Discord API → POST /api/agents/discord-interactions
+                                    │
+                              Ed25519 verify (Web Crypto)
+                                    │
+                         DEFERRED_CHANNEL_MESSAGE (<3s)
+                                    │
+                         log → agent_interactions table
+                                    │
+                         dispatch async → /api/agents/discord-interactions/process
+                                    │
+                         Alicia ejecuta → /api/v1/* endpoints
+                                    │
+                         Discord followup webhook → respuesta con badge
+```
+
+### Bearer tokens de agentes
+
+Los agentes usan su **propio plano de autenticación** (`agent_credentials`), completamente separado de la autenticación de usuarios humanos (`auth.users`). Nunca mezclar.
+
+```ts
+// Forma correcta en endpoints que Alicia llama:
+import { requireAgentAuth } from '@/lib/agents/auth'
+export const POST = requireAgentAuth(['incidents:write'])(async (req, identity) => {
+  // identity.agent_id === 'alicia-ops'
+  // identity.scopes contiene los scopes concedidos
+})
+
+// Verificar un token directamente:
+import { verifyAgentBearer } from '@/lib/agents/auth'
+const identity = await verifyAgentBearer(token) // null si inválido
+```
+
+### Atribución de agentes
+
+Todo registro creado por un agente debe incluir:
+1. `created_by_agent_id` en la fila de DB (reservations, incidents, tasks).
+2. `agent_attribution` en el JSONB de metadata (si existe).
+3. Footer “via Alicia · BaW OS Agent · Discord” en respuestas Discord.
+
+```ts
+import { withAgentAttribution, withAgentDiscordEmbed } from '@/lib/agents/attribution'
+
+// En texto:
+const response = withAgentAttribution('Incidencia creada ✔', {
+  agentId: 'alicia-ops',
+  agentDisplayName: 'Alicia',
+  channel: 'discord',
+  discordMessageUrl: interaction.message?.jump_url,
+})
+
+// En embed Discord:
+const embed = withAgentDiscordEmbed({ title: 'Nueva incidencia', ... }, attr)
+```
+
+### Env vars requeridas para Discord Interactions
+
+| Variable | Descripción |
+|---|---|
+| `DISCORD_PUBLIC_KEY` | Clave pública Ed25519 del bot Discord (hex). Del portal de Discord. |
+| `INTERNAL_WEBHOOK_SECRET` | Bearer secret para dispatch async entre funciones Vercel. |
+| `NEXT_PUBLIC_BASE_URL` | URL base de Vercel (ej. `https://baw-os.vercel.app`). |
+
+### Tests de agentes
+
+```bash
+bash tests/agents/run-all.sh   # 3 suites, 39 tests
+```
+
+O individualmente:
+```bash
+node tests/agents/discord-verify.test.mjs  # 8 tests (firma Ed25519)
+node tests/agents/auth.test.mjs            # 13 tests (bearer tokens + scopes)
+node tests/agents/attribution.test.mjs     # 18 tests (badges de atribución)
+```
+
+### Archivos clave de la integración Discord
+
+| Archivo | Propósito |
+|---|---|
+| `src/app/api/agents/discord-interactions/route.ts` | Endpoint principal Discord |
+| `src/lib/agents/discord-verify.ts` | Verificación firma Ed25519 |
+| `src/lib/agents/auth.ts` | verifyAgentBearer + requireAgentAuth HOF |
+| `src/lib/agents/attribution.ts` | Badge "via Alicia" en mensajes y DB |
+| `supabase/migrations/20260523_agents_discord_interactions.sql` | agent_interactions + attribution columns |
+| `docs/adr/ADR-021-third-party-agents-discord.md` | Decisiones arquitecturales |
+
+---
+
+**Última actualización:** 2026-05-23 · Sprint 5A WS-1 — Discord Interactions + Alicia bearer auth

--- a/docs/adr/ADR-021-third-party-agents-discord.md
+++ b/docs/adr/ADR-021-third-party-agents-discord.md
@@ -1,0 +1,137 @@
+# ADR-021 — Third-Party Agent Discord Interactions (Sprint 5A WS-1)
+
+**Status**: Accepted
+**Date**: 2026-05-23
+**Authors**: Computer (AI), supervised by Fran (único humano)
+**Supersedes**: N/A — extiende ADR-016 con decisiones de implementación concretas
+**Related**: ADR-016 (Third-Party Agent Integration Model)
+
+---
+
+## Contexto
+
+ADR-016 estableció el modelo arquitectural para agentes third-party: clase separada de agentes nativos BaW OS, bearer tokens propios, canales Discord-first, skip doble-escritura, atribución bidireccional. Sprint 5A WS-1 es la **primera implementación concreta** de ese modelo — conectando únicamente a Alicia (ZXY Agent OS, `id = alicia-ops`) vía Discord Interactions API.
+
+Este ADR captura las decisiones de implementación específicas que ADR-016 dejó abiertas.
+
+---
+
+## Decisiones
+
+### D1 — Verificación de firma Ed25519 con Web Crypto (no tweetnacl)
+
+**Decisión**: Usar `crypto.subtle` (Web Crypto API nativa) en lugar de `tweetnacl` u otra lib.
+
+**Rationale**:
+- Web Crypto está disponible en Node.js ≥18 (el runtime de Next.js 14) y en Edge Runtime.
+- Elimina una dependencia externa con su propia supply chain.
+- La API `crypto.subtle.verify('Ed25519', ...)` es el mismo algoritmo que Discord usa para firmar.
+- Congruente con el patrón ya establecido en `auth.ts` (SHA-256 vía Web Crypto sin deps).
+- "Lo que sea más sólido, no más simple" — la implementación nativa es más auditable.
+
+**Consecuencia**: No se agrega `tweetnacl` al `package.json`. Si en el futuro se necesita firmar (no solo verificar), o si el runtime cambia, la evaluación se reabre.
+
+### D2 — Endpoint en `/api/agents/discord-interactions` (no `/api/discord/interactions`)
+
+**Decisión**: Path `src/app/api/agents/discord-interactions/route.ts`.
+
+**Rationale**:
+- Agrupa bajo `/api/agents/` junto con los endpoints existentes (`/api/agents/[id]/run`, `/api/agents/route.ts`).
+- Deja claro que este endpoint pertenece a la capa de agentes, no a Discord en general.
+- Si en el futuro se conecta Slack u otro canal, el path sería `/api/agents/slack-interactions` — consistente.
+
+**Divergencia de ADR-016**: ADR-016 mencionaba `/api/discord/interactions`. Esta decisión corrige ese path para mantener consistencia con la estructura del repo.
+
+### D3 — Respuesta DEFERRED dentro de 3s para todos los comandos (salvo botones de aprobación)
+
+**Decisión**: `APPLICATION_COMMAND` siempre responde con `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE`. Los botones de aprobación (`MESSAGE_COMPONENT` con custom_id `baw:approval:*`) se procesan inline y responden con `UPDATE_MESSAGE` directo.
+
+**Rationale**:
+- Discord requiere respuesta en <3s o marca el comando como fallido.
+- El procesamiento de comandos (parsear intención, llamar BaW OS API, formatear respuesta) tarda >3s.
+- Los botones de aprobación son operaciones simples DB (UPDATE agent_approvals), típicamente <100ms.
+- Separar los dos casos evita UI de "pensando..." en botones simples.
+
+### D4 — custom_id convention: `baw:<agent_id>:<action>:<payload>`
+
+**Decisión**: Los componentes Discord (botones, selects) usan el formato `baw:<agent_id>:<action>:<entity_id>`.
+
+Ejemplos:
+- `baw:alicia-ops:approval:grant:uuid-de-la-aprobacion`
+- `baw:alicia-ops:approval:deny:uuid-de-la-aprobacion`
+- `baw:alicia-ops:confirm:incident:uuid-del-incidente`
+
+**Rationale**:
+- Discord permite hasta 100 caracteres en custom_id.
+- El prefix `baw:` permite distinguir botones de BaW OS de otros bots en el servidor.
+- El `agent_id` en posición 2 permite routing multi-agente futuro desde el mismo endpoint.
+- Namespacing explícito previene colisiones entre acciones.
+
+### D5 — `agent_interactions` es la tabla de log de Discord (nueva), distinta de `agent_runs`
+
+**Decisión**: Crear tabla `agent_interactions` separada de `agent_runs`.
+
+**Rationale**:
+- `agent_runs` registra ejecuciones de agentes nativos BaW OS con schema completo (input, output, metrics, duration).
+- Las interacciones Discord tienen un modelo diferente: son eventos HTTP externos de Discord con su propio ID de interacción, guild, channel, user.
+- Fusionar los dos modelos en una tabla requeriría muchos campos nullable en `agent_runs`, degradando su schema.
+- `agent_interactions` puede crecer con campos Discord-specific (message_id, guild_id, component_type) sin afectar el schema de runs de agentes nativos.
+
+### D6 — `created_by_agent_id` en reservations, incidents, tasks (no solo en bookings)
+
+**Decisión**: Agregar columna `created_by_agent_id TEXT REFERENCES agents(id)` en las 3 tablas donde Alicia puede crear registros.
+
+**Rationale**:
+- La tarea especificaba `bookings`, pero BaW OS usa `reservations` (no existe tabla `bookings`).
+- Alicia también puede crear incidencias y tareas — aplicar atribución en las 3 tablas es más completo que solo en reservas.
+- El campo es `TEXT` (no UUID) porque `agents.id` es TEXT (ej. `'alicia-ops'`), consistente con el schema existente.
+
+### D7 — `idempotency_key` en `agent_runs` + unique constraint
+
+**Decisión**: Agregar columna `idempotency_key TEXT` con unique index (WHERE NOT NULL) a `agent_runs`.
+
+**Rationale**:
+- ADR-016 D4 exige idempotencia: `Alicia-{uuid_v4}` en cada request.
+- Con unique constraint en DB, un segundo request con el mismo key falla a nivel DB antes de ejecutar la acción.
+- Complementa el middleware de idempotency que ya existe (`idempotency_keys` table) con tracking en el run level.
+
+### D8 — `resolved_by_discord_user` en agent_approvals (campo nuevo sin migración separada)
+
+**Decisión**: Usar `UPDATE agent_approvals SET status='approved', resolved_at=now(), resolved_by_discord_user=:discord_user_id` al procesar botones.
+
+**Nota**: Si `resolved_by_discord_user` no existe en `agent_approvals`, el UPDATE ignorará el campo silenciosamente en Supabase. En la migración `20260523_agents_discord_interactions.sql` NO se agrega este campo porque no tenemos el schema exacto de `agent_approvals`. **Acción pendiente**: verificar schema de `agent_approvals` y agregar el campo si falta en la próxima migración.
+
+---
+
+## Consecuencias
+
+### Positivas
+- Verificación de firma robusta sin deps externas, auditablemente simple.
+- Atribución trazable en ambas direcciones (Discord message URL ↔ BaW OS record).
+- Schema DB limpio: `agent_interactions` para Discord, `agent_runs` para agentes nativos.
+- Idempotencia respaldada por unique constraint en DB.
+
+### Negativas / Pendientes
+- El endpoint `/api/agents/discord-interactions/process` (procesamiento async para followup Discord) no se construye en WS-1 — requiere la integración con la skill OpenClaw de Alicia (WS-2).
+- El campo `resolved_by_discord_user` en `agent_approvals` requiere verificación de schema antes de aplicar.
+
+### Decisiones futuras que este ADR deja abiertas
+- Rate limiting por agente en el endpoint Discord (Sprint 5B).
+- Webhook de regreso a Alicia (`POST https://alicia.zxy.vc/incoming/baw-os`) — Sprint 5A WS-3.
+- Rotación forzada de bearer tokens (90 días) — Sprint 5C.
+- Soporte multi-tenant para el wizard de conexión de agentes — Sprint 7+.
+
+---
+
+## Referencias
+
+- ADR-016: `/docs/adr/ADR-016-third-party-agent-integration.md`
+- Sprint 5A Plan: `/docs/sprints/SPRINT_5A_PLAN.md`
+- Discord Interactions docs: https://discord.com/developers/docs/interactions/receiving-and-responding
+- Web Crypto Ed25519: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/verify
+- Implementación: `src/app/api/agents/discord-interactions/route.ts`
+- Verificación: `src/lib/agents/discord-verify.ts`
+- Autenticación: `src/lib/agents/auth.ts` (verifyAgentBearer + requireAgentAuth HOF)
+- Atribución: `src/lib/agents/attribution.ts`
+- Migración: `supabase/migrations/20260523_agents_discord_interactions.sql`
+- Tests: `tests/agents/` (39 tests, 3 suites)

--- a/docs/sprints/SPRINT_5A_PLAN.md
+++ b/docs/sprints/SPRINT_5A_PLAN.md
@@ -1,6 +1,6 @@
 # Sprint 5A — Conversational Agent Runtime (Alicia third-party)
 
-**Status**: Planned, ready to start
+**Status**: WS-1 In Progress — WS-2/3/4 Planned
 **Start**: 2026-05-03
 **Target end**: 2026-05-07 (4 days)
 **Owner**: Computer (this AI), supervised by Fran
@@ -31,6 +31,31 @@ Connect Alicia (ZXY Agent OS, OpenClaw, on Fran's M1) to BaW OS production so th
 5. All Alicia actions logged in `agent_runs` table with idempotency keys, request hashes, response statuses.
 6. Smoke tests E2E pass: 5 happy-path flows + 3 failure modes (token revoked, M1 offline, approval denied).
 7. No production data corruption, no double-writes (idempotency verified by replay test).
+
+---
+
+## WS-1 Progress (2026-05-23)
+
+### Entregables completados
+
+| Item | Estado | Archivo |
+|---|---|---|
+| `src/lib/agents/discord-verify.ts` | ✅ Done | Ed25519 verification vía Web Crypto |
+| `src/lib/agents/attribution.ts` | ✅ Done | withAgentAttribution + Discord embeds |
+| `src/lib/agents/auth.ts` | ✅ Extended | verifyAgentBearer + requireAgentAuth HOF |
+| `src/app/api/agents/discord-interactions/route.ts` | ✅ Done | Endpoint Discord Interactions |
+| `supabase/migrations/20260523_agents_discord_interactions.sql` | ✅ Applied to prod | agent_interactions table + attribution columns |
+| `tests/agents/discord-verify.test.mjs` | ✅ 8/8 pass | |
+| `tests/agents/auth.test.mjs` | ✅ 13/13 pass | |
+| `tests/agents/attribution.test.mjs` | ✅ 18/18 pass | |
+| `docs/adr/ADR-021-third-party-agents-discord.md` | ✅ Done | |
+| Repo `openclaw-skill-baw-os` | ✅ Done | github.com/zxy-vc/openclaw-skill-baw-os |
+
+### Reconocimiento completado
+- Alicia confirmada en tabla `agents`: `id='alicia-ops'`, `family='third-party'`, `status='planned'`
+- No existen repos `openclaw-skill-*` previos en `zxy-vc` — se crea desde cero
+- La tabla `agent_credentials` ya existe con el schema correcto (de migración 20260503)
+- La tabla llamada `bookings` no existe — es `reservations`; la atribución se aplicó a `reservations`, `incidents`, `tasks`
 
 ---
 

--- a/src/app/api/agents/discord-interactions/route.ts
+++ b/src/app/api/agents/discord-interactions/route.ts
@@ -1,0 +1,296 @@
+/**
+ * BaW OS — Discord Interactions Endpoint (Sprint 5A WS-1)
+ * POST /api/agents/discord-interactions
+ *
+ * Arquitectura:
+ *  1. Verifica firma Ed25519 (Web Crypto, sin deps externas)
+ *  2. Responde PING de Discord (health check)
+ *  3. Para APPLICATION_COMMAND y MESSAGE_COMPONENT:
+ *     - Responde inmediatamente con DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE (dentro de 3s)
+ *     - Loggea interacción en agent_interactions
+ *     - Despacha procesamiento async (fire-and-forget, no bloquea la respuesta)
+ *  4. Route al handler según agent_id (custom_id o channel_id)
+ *
+ * Ref: https://discord.com/developers/docs/interactions/receiving-and-responding
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { verifyDiscordRequest } from '@/lib/agents/discord-verify'
+import { getAgentDisplayName } from '@/lib/agents/attribution'
+
+export const runtime = 'nodejs'
+
+// ─────────────────────────────────────────────────────────────
+// Tipos Discord (subset de la API necesario para este endpoint)
+// ─────────────────────────────────────────────────────────────
+
+const InteractionType = {
+  PING: 1,
+  APPLICATION_COMMAND: 2,
+  MESSAGE_COMPONENT: 3,
+  APPLICATION_COMMAND_AUTOCOMPLETE: 4,
+  MODAL_SUBMIT: 5,
+} as const
+
+const InteractionResponseType = {
+  PONG: 1,
+  CHANNEL_MESSAGE_WITH_SOURCE: 4,
+  DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE: 5,
+  DEFERRED_UPDATE_MESSAGE: 6,
+  UPDATE_MESSAGE: 7,
+} as const
+
+interface DiscordInteraction {
+  id: string
+  type: number
+  token: string
+  application_id: string
+  guild_id?: string
+  channel_id?: string
+  member?: { user?: { id: string; username: string } }
+  user?: { id: string; username: string }
+  data?: {
+    id?: string
+    name?: string
+    custom_id?: string
+    component_type?: number
+    options?: Array<{ name: string; value: unknown }>
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Resuelve el agent_id desde la interacción Discord.
+ * Estrategia: busca en custom_id (componentes) → guild custom data → default Alicia.
+ * En Sprint 5A solo Alicia está conectada.
+ */
+function resolveAgentId(interaction: DiscordInteraction): string {
+  const customId = interaction.data?.custom_id ?? ''
+
+  // Formato custom_id: "baw:<agent_id>:<action>:<payload...>"
+  if (customId.startsWith('baw:')) {
+    const parts = customId.split(':')
+    if (parts[1]) return parts[1]
+  }
+
+  // Default: alicia-ops (única agente third-party conectada en Sprint 5A)
+  return 'alicia-ops'
+}
+
+/**
+ * Loggea la interacción en la tabla agent_interactions (fire-and-forget).
+ * No lanza errores — el endpoint no debe fallar por un log.
+ */
+async function logInteraction(
+  interaction: DiscordInteraction,
+  agentId: string,
+  typeName: string,
+  payload: Record<string, unknown>
+): Promise<void> {
+  try {
+    const supabase = createServiceClient()
+    await supabase.from('agent_interactions').insert({
+      agent_id: agentId,
+      channel: 'discord',
+      channel_id: interaction.channel_id ?? null,
+      interaction_type: typeName,
+      interaction_id: interaction.id,
+      discord_guild_id: interaction.guild_id ?? null,
+      discord_user_id:
+        interaction.member?.user?.id ?? interaction.user?.id ?? null,
+      payload,
+      status: 'deferred',
+    })
+  } catch (err) {
+    console.error('agent_interactions log failed:', err)
+  }
+}
+
+/**
+ * Despacha el procesamiento async de la interacción.
+ * En Vercel (serverless), usamos un fetch a la propia API para que el
+ * procesamiento ocurra en una función separada sin bloquear los 3s Discord.
+ *
+ * El token Discord se necesita para el followup via Discord webhook.
+ */
+async function dispatchAsync(
+  interaction: DiscordInteraction,
+  agentId: string,
+  rawBody: string
+): Promise<void> {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://baw-os.vercel.app'
+    // Este endpoint lo crearemos en WS-1 continuación (procesamiento async)
+    await fetch(`${baseUrl}/api/agents/discord-interactions/process`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.INTERNAL_WEBHOOK_SECRET ?? ''}`,
+      },
+      body: JSON.stringify({
+        interaction_id: interaction.id,
+        interaction_token: interaction.token,
+        agent_id: agentId,
+        raw_interaction: JSON.parse(rawBody),
+      }),
+      // No esperamos respuesta — fire and forget
+      signal: AbortSignal.timeout(100),
+    }).catch(() => {
+      // El timeout intencional hace que este catch se dispare; es OK
+    })
+  } catch {
+    // Silencio intencional — no bloquear respuesta Discord
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Route handler principal
+// ─────────────────────────────────────────────────────────────
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const publicKeyHex = process.env.DISCORD_PUBLIC_KEY
+
+  if (!publicKeyHex) {
+    console.error('DISCORD_PUBLIC_KEY env var not set')
+    return NextResponse.json(
+      { error: 'Server misconfiguration' },
+      { status: 500 }
+    )
+  }
+
+  // ── 1. Verificar firma Ed25519 ────────────────────────────
+  const verification = await verifyDiscordRequest(req, publicKeyHex)
+
+  if (!verification.valid) {
+    return NextResponse.json(
+      { error: 'Invalid request signature' },
+      { status: 401 }
+    )
+  }
+
+  const { rawBody } = verification
+
+  let interaction: DiscordInteraction
+  try {
+    interaction = JSON.parse(rawBody) as DiscordInteraction
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  // ── 2. PING — respuesta obligatoria para activar bot Discord ──
+  if (interaction.type === InteractionType.PING) {
+    return NextResponse.json({ type: InteractionResponseType.PONG })
+  }
+
+  // ── 3. APPLICATION_COMMAND ────────────────────────────────
+  if (interaction.type === InteractionType.APPLICATION_COMMAND) {
+    const agentId = resolveAgentId(interaction)
+    const agentName = getAgentDisplayName(agentId as Parameters<typeof getAgentDisplayName>[0])
+
+    void logInteraction(
+      interaction,
+      agentId,
+      'APPLICATION_COMMAND',
+      JSON.parse(rawBody) as Record<string, unknown>
+    )
+
+    void dispatchAsync(interaction, agentId, rawBody)
+
+    // Responder en <3s con deferred — Alicia procesará y hará followup
+    return NextResponse.json({
+      type: InteractionResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        flags: 0, // 64 = ephemeral; 0 = visible en canal
+      },
+    })
+  }
+
+  // ── 4. MESSAGE_COMPONENT (botones Aprobar/Denegar) ────────
+  if (interaction.type === InteractionType.MESSAGE_COMPONENT) {
+    const agentId = resolveAgentId(interaction)
+    const customId = interaction.data?.custom_id ?? ''
+
+    void logInteraction(
+      interaction,
+      agentId,
+      'MESSAGE_COMPONENT',
+      JSON.parse(rawBody) as Record<string, unknown>
+    )
+
+    // Procesamos aprobaciones inline (grant/deny son idempotentes y rápidos)
+    if (customId.startsWith('baw:approval:')) {
+      // Formato: baw:approval:grant:<approval_id> | baw:approval:deny:<approval_id>
+      const parts = customId.split(':')
+      const action = parts[2] as 'grant' | 'deny'
+      const approvalId = parts[3]
+
+      if (!approvalId || !['grant', 'deny'].includes(action)) {
+        return NextResponse.json(
+          {
+            type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+            data: {
+              content: '⚠️ ID de aprobación inválido.',
+              flags: 64, // ephemeral
+            },
+          }
+        )
+      }
+
+      // Ejecutar grant/deny en agent_approvals
+      try {
+        const supabase = createServiceClient()
+        const newStatus = action === 'grant' ? 'approved' : 'denied'
+        const discordUserId =
+          interaction.member?.user?.id ?? interaction.user?.id ?? 'unknown'
+
+        const { error } = await supabase
+          .from('agent_approvals')
+          .update({
+            status: newStatus,
+            resolved_at: new Date().toISOString(),
+            resolved_by_discord_user: discordUserId,
+          })
+          .eq('id', approvalId)
+          .eq('status', 'pending') // Solo pendientes — previene doble-click
+
+        if (error) throw error
+
+        const emoji = action === 'grant' ? '✅' : '❌'
+        const label = action === 'grant' ? 'aprobado' : 'denegado'
+
+        return NextResponse.json({
+          type: InteractionResponseType.UPDATE_MESSAGE,
+          data: {
+            content: `${emoji} Solicitud **${label}**.`,
+            components: [], // Elimina los botones del mensaje original
+          },
+        })
+      } catch (err) {
+        console.error('approval resolution failed:', err)
+        return NextResponse.json({
+          type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+          data: {
+            content: '⚠️ Error al procesar la aprobación. Intenta de nuevo.',
+            flags: 64,
+          },
+        })
+      }
+    }
+
+    // Otros componentes: deferred
+    void dispatchAsync(interaction, agentId, rawBody)
+    return NextResponse.json({
+      type: InteractionResponseType.DEFERRED_UPDATE_MESSAGE,
+    })
+  }
+
+  // ── 5. Tipos no soportados ────────────────────────────────
+  return NextResponse.json(
+    { error: `Interaction type ${interaction.type} not handled` },
+    { status: 400 }
+  )
+}

--- a/src/lib/agents/attribution.ts
+++ b/src/lib/agents/attribution.ts
@@ -1,0 +1,181 @@
+/**
+ * BaW OS — Agent Attribution (Sprint 5A WS-1)
+ *
+ * Helpers para agregar el badge "via Alicia" a respuestas Discord y
+ * a campos de notas/metadata cuando un agente third-party crea registros.
+ *
+ * Principio (Fran verbatim): "Solo existe un humano, que soy yo."
+ * — los agentes NUNCA se refieren a sí mismos como personas.
+ */
+
+import type { AgentId } from './types'
+
+// ─────────────────────────────────────────────────────────────
+// Tipos
+// ─────────────────────────────────────────────────────────────
+
+export interface AgentAttribution {
+  agentId: AgentId
+  /** Nombre display del agente para UI/mensajes */
+  agentDisplayName: string
+  /** Canal desde el que operó el agente */
+  channel: 'discord' | 'slack' | 'api' | 'whatsapp' | 'telegram'
+  /** URL del mensaje Discord original (si aplica) */
+  discordMessageUrl?: string
+  /** ID de la interacción Discord (para linking back) */
+  interactionId?: string
+}
+
+/** Metadata que se almacena en JSONB de registros (reservations, incidents, tasks) */
+export interface AgentAttributionMeta {
+  agent_id: string
+  agent_display_name: string
+  channel: string
+  discord_message_url?: string
+  interaction_id?: string
+  attributed_at: string // ISO timestamp
+}
+
+// ─────────────────────────────────────────────────────────────
+// Display names canónicos (sincronizados con tabla agents)
+// ─────────────────────────────────────────────────────────────
+
+const AGENT_DISPLAY_NAMES: Partial<Record<AgentId, string>> = {
+  'alicia-ops': 'Alicia',
+  'hugo-cos': 'Hugo',
+  'conta-beto': 'Beto',
+  'maribel-law': 'Maribel',
+  'luis-growth': 'Luis',
+  'andres-tech': 'Andrés',
+}
+
+export function getAgentDisplayName(agentId: AgentId): string {
+  return AGENT_DISPLAY_NAMES[agentId] ?? agentId
+}
+
+// ─────────────────────────────────────────────────────────────
+// Attribution para mensajes Discord (embed footer)
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Genera el texto de footer para respuestas Discord de agentes.
+ * Ejemplo: "via Alicia · BaW OS Agent · Discord"
+ */
+export function discordAttributionFooter(attr: AgentAttribution): string {
+  const name = attr.agentDisplayName || getAgentDisplayName(attr.agentId)
+  const channel = channelLabel(attr.channel)
+  return `via ${name} · BaW OS Agent · ${channel}`
+}
+
+/**
+ * Construye un embed Discord con footer de atribución de agente.
+ * Compatible con Discord Interactions API (embeds en respuestas).
+ */
+export function withAgentDiscordEmbed(
+  embed: DiscordEmbed,
+  attr: AgentAttribution
+): DiscordEmbed {
+  const footer: DiscordEmbedFooter = {
+    text: discordAttributionFooter(attr),
+  }
+
+  const enrichedEmbed: DiscordEmbed = {
+    ...embed,
+    footer,
+    timestamp: new Date().toISOString(),
+  }
+
+  if (attr.discordMessageUrl) {
+    enrichedEmbed.url = attr.discordMessageUrl
+  }
+
+  return enrichedEmbed
+}
+
+/**
+ * Agrega atribución como mensaje de texto plano con footer.
+ * Útil cuando el agente responde con content (no embed).
+ */
+export function withAgentAttribution(
+  message: string,
+  attr: AgentAttribution
+): string {
+  const footer = discordAttributionFooter(attr)
+  return `${message}\n\n-# ${footer}`
+}
+
+// ─────────────────────────────────────────────────────────────
+// Attribution metadata para DB (JSONB)
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Genera el objeto de metadata que se almacena en el campo JSONB
+ * de un registro (incidents.metadata, tasks.metadata, etc.)
+ * para atribución de agente.
+ */
+export function buildAttributionMeta(attr: AgentAttribution): AgentAttributionMeta {
+  return {
+    agent_id: attr.agentId,
+    agent_display_name: attr.agentDisplayName || getAgentDisplayName(attr.agentId),
+    channel: attr.channel,
+    discord_message_url: attr.discordMessageUrl,
+    interaction_id: attr.interactionId,
+    attributed_at: new Date().toISOString(),
+  }
+}
+
+/**
+ * Merge de attribution metadata con metadata existente de un registro.
+ * Preserva campos existentes.
+ */
+export function mergeAttributionIntoMeta(
+  existingMeta: Record<string, unknown> | null | undefined,
+  attr: AgentAttribution
+): Record<string, unknown> {
+  return {
+    ...(existingMeta ?? {}),
+    agent_attribution: buildAttributionMeta(attr),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Helpers internos
+// ─────────────────────────────────────────────────────────────
+
+function channelLabel(channel: AgentAttribution['channel']): string {
+  const labels: Record<AgentAttribution['channel'], string> = {
+    discord: 'Discord',
+    slack: 'Slack',
+    api: 'API',
+    whatsapp: 'WhatsApp',
+    telegram: 'Telegram',
+  }
+  return labels[channel] ?? channel
+}
+
+// ─────────────────────────────────────────────────────────────
+// Tipos Discord mínimos (no depende de lib externa)
+// ─────────────────────────────────────────────────────────────
+
+export interface DiscordEmbedFooter {
+  text: string
+  icon_url?: string
+}
+
+export interface DiscordEmbedField {
+  name: string
+  value: string
+  inline?: boolean
+}
+
+export interface DiscordEmbed {
+  title?: string
+  description?: string
+  url?: string
+  color?: number
+  footer?: DiscordEmbedFooter
+  fields?: DiscordEmbedField[]
+  timestamp?: string
+  thumbnail?: { url: string }
+  image?: { url: string }
+}

--- a/src/lib/agents/auth.ts
+++ b/src/lib/agents/auth.ts
@@ -2,6 +2,10 @@
 // Una identidad por agente, por org. Reemplaza el patrón BAWOS_API_KEY global.
 // Contrato: ver docs/AGENT_INTEGRATION.md
 //
+// Sprint 5A WS-1 additions:
+//   - verifyAgentBearer(token) → { agent_id, scopes } | null
+//   - requireAgentAuth(scopes[]) HOF para endpoints
+//
 // Nota de seguridad: usamos SHA-256 (Web Crypto, sin deps nuevas) con timing-safe
 // compare. Suficiente para API keys de agente (no son passwords humanos, y se
 // almacenan + transmiten siempre por canales TLS). Para Fase 2 evaluaremos bcrypt
@@ -226,4 +230,122 @@ export function validateLegacyApiKey(req: NextRequest): boolean {
   const expected = process.env.BAWOS_API_KEY
   if (!expected) return false
   return apiKey === expected
+}
+
+// ─────────────────────────────────────────────────────────────
+// Sprint 5A WS-1 — verifyAgentBearer + requireAgentAuth HOF
+// ─────────────────────────────────────────────────────────────
+
+export interface AgentBearerIdentity {
+  agent_id: AgentId
+  org_id: string
+  credential_id: string
+  scopes: string[]
+  rate_limit_tier: 'standard' | 'elevated' | 'unlimited'
+}
+
+/**
+ * verifyAgentBearer — valida un Bearer token de agente (no usuario humano).
+ * Retorna la identidad del agente o null si el token es inválido/expirado.
+ *
+ * Diseñado para ser llamado desde dentro de endpoints de agent-facing API
+ * donde se quiere la identidad sin HOF (ej. dentro de otras middlewares).
+ *
+ * @param token - El valor raw del Bearer token (sin el prefix 'Bearer ')
+ */
+export async function verifyAgentBearer(
+  token: string
+): Promise<AgentBearerIdentity | null> {
+  // Reutiliza la lógica de authenticateAgentRequest sin un NextRequest completo
+  if (
+    !token.startsWith(KEY_PREFIX_LIVE) &&
+    !token.startsWith(KEY_PREFIX_TEST)
+  ) {
+    return null
+  }
+
+  const prefix = token.slice(0, PREFIX_LOOKUP_LEN)
+  const hash = await hashApiKey(token)
+  const supabase = createServiceClient()
+
+  const { data: rows, error } = await supabase
+    .from('agent_credentials')
+    .select('id, org_id, agent_id, api_key_hash, scopes, status, expires_at, rate_limit_tier')
+    .eq('api_key_prefix', prefix)
+    .eq('status', 'active')
+
+  if (error || !rows) return null
+
+  const matched = rows.find((row) =>
+    timingSafeEqual(row.api_key_hash as string, hash)
+  )
+
+  if (!matched) return null
+
+  if (matched.expires_at) {
+    const expiresAt = new Date(matched.expires_at as string).getTime()
+    if (Date.now() > expiresAt) {
+      void supabase
+        .from('agent_credentials')
+        .update({ status: 'expired' })
+        .eq('id', matched.id as string)
+      return null
+    }
+  }
+
+  void supabase.rpc('touch_agent_credential', { p_credential_id: matched.id as string })
+
+  return {
+    agent_id: matched.agent_id as AgentId,
+    org_id: matched.org_id as string,
+    credential_id: matched.id as string,
+    scopes: (matched.scopes as string[]) || [],
+    rate_limit_tier:
+      (matched.rate_limit_tier as 'standard' | 'elevated' | 'unlimited') ||
+      'standard',
+  }
+}
+
+/**
+ * requireAgentAuth — Higher-Order Function para proteger endpoints de agentes.
+ *
+ * Uso:
+ * ```ts
+ * export const GET = requireAgentAuth(['units:read'])(async (req, identity) => {
+ *   // identity.agent_id, identity.scopes disponibles
+ *   return NextResponse.json({ ... })
+ * })
+ * ```
+ *
+ * Los agentes usan su propia tabla (agent_credentials), NO la autenticación
+ * de usuarios humanos (auth.users + org_members). Son dos planos separados.
+ */
+export function requireAgentAuth(
+  requiredScopes: string[] = []
+) {
+  return function <T extends unknown[]>(
+    handler: (
+      req: NextRequest,
+      identity: AgentBearerIdentity,
+      ...args: T
+    ) => Promise<NextResponse>
+  ) {
+    return async (req: NextRequest, ...args: T): Promise<NextResponse> => {
+      const auth = await authenticateAgentRequest(req, requiredScopes)
+
+      if (!auth.ok) {
+        return agentAuthErrorResponse(auth)
+      }
+
+      const identity: AgentBearerIdentity = {
+        agent_id: auth.agentId,
+        org_id: auth.orgId,
+        credential_id: auth.credentialId,
+        scopes: auth.scopes,
+        rate_limit_tier: auth.rateLimitTier,
+      }
+
+      return handler(req, identity, ...args)
+    }
+  }
 }

--- a/src/lib/agents/discord-verify.ts
+++ b/src/lib/agents/discord-verify.ts
@@ -1,0 +1,96 @@
+/**
+ * BaW OS — Discord Ed25519 signature verification (Sprint 5A WS-1)
+ *
+ * Verifica la firma Ed25519 de Discord usando la Web Crypto API nativa.
+ * NO usa tweetnacl ni ninguna dependencia externa — solo Web Crypto (disponible
+ * en Edge Runtime y Node.js ≥18). Esto evita deps nuevas y es más sólido.
+ *
+ * Referencias:
+ *  - https://discord.com/developers/docs/interactions/receiving-and-responding
+ *  - https://discord.com/developers/docs/reference#message-formatting
+ */
+
+/**
+ * Importa la clave pública Ed25519 del bot Discord en formato SubtleCrypto.
+ * La clave se provee como hex string (como la devuelve el portal de Discord).
+ */
+async function importDiscordPublicKey(publicKeyHex: string): Promise<CryptoKey> {
+  const bytes = new Uint8Array(
+    publicKeyHex.match(/.{1,2}/g)!.map((b) => parseInt(b, 16))
+  )
+  return crypto.subtle.importKey(
+    'raw',
+    bytes,
+    { name: 'Ed25519' },
+    false,
+    ['verify']
+  )
+}
+
+/**
+ * Verifica la firma Ed25519 de un request Discord.
+ *
+ * Discord firma con: signature = Ed25519Sign(timestamp + body_as_string)
+ *
+ * @param signature  - Header X-Signature-Ed25519 (hex)
+ * @param timestamp  - Header X-Signature-Timestamp (unix epoch como string)
+ * @param rawBody    - Body crudo del request como string UTF-8
+ * @param publicKeyHex - Clave pública del bot en hex (DISCORD_PUBLIC_KEY env var)
+ * @returns true si la firma es válida
+ */
+export async function verifyDiscordSignature(
+  signature: string,
+  timestamp: string,
+  rawBody: string,
+  publicKeyHex: string
+): Promise<boolean> {
+  try {
+    const publicKey = await importDiscordPublicKey(publicKeyHex)
+
+    const sigBytes = new Uint8Array(
+      signature.match(/.{1,2}/g)!.map((b) => parseInt(b, 16))
+    )
+
+    const message = new TextEncoder().encode(timestamp + rawBody)
+
+    return await crypto.subtle.verify('Ed25519', publicKey, sigBytes, message)
+  } catch {
+    // Cualquier error de parse/crypto = firma inválida
+    return false
+  }
+}
+
+/**
+ * Extrae y verifica los headers de firma de un NextRequest.
+ * Devuelve { valid: true, rawBody } o { valid: false }.
+ */
+export async function verifyDiscordRequest(
+  req: Request,
+  publicKeyHex: string
+): Promise<{ valid: true; rawBody: string } | { valid: false }> {
+  const signature = req.headers.get('x-signature-ed25519')
+  const timestamp = req.headers.get('x-signature-timestamp')
+
+  if (!signature || !timestamp) {
+    return { valid: false }
+  }
+
+  // Previene replay attacks: rechaza si el timestamp tiene >5 minutos de drift
+  const ts = parseInt(timestamp, 10)
+  if (isNaN(ts) || Math.abs(Date.now() / 1000 - ts) > 300) {
+    return { valid: false }
+  }
+
+  // Leer el body una sola vez (stream no se puede releer)
+  let rawBody: string
+  try {
+    rawBody = await req.text()
+  } catch {
+    return { valid: false }
+  }
+
+  const valid = await verifyDiscordSignature(signature, timestamp, rawBody, publicKeyHex)
+  if (!valid) return { valid: false }
+
+  return { valid: true, rawBody }
+}

--- a/supabase/migrations/20260523_agents_discord_interactions.sql
+++ b/supabase/migrations/20260523_agents_discord_interactions.sql
@@ -1,0 +1,112 @@
+-- BaW OS — Sprint 5A WS-1: Discord Interactions + Agent Attribution
+-- Nuevas tablas: agent_interactions (log de interacciones Discord/Slack)
+-- Nueva columna: reservations.created_by_agent_id (atribución en reservas)
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────
+-- 1. agent_interactions — log de cada interacción Discord / canal externo
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.agent_interactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id TEXT NOT NULL REFERENCES public.agents(id) ON DELETE RESTRICT,
+  org_id UUID REFERENCES public.organizations(id) ON DELETE SET NULL,
+  channel TEXT NOT NULL CHECK (channel IN ('discord', 'slack', 'whatsapp', 'telegram', 'signal', 'imessage', 'api')),
+  channel_id TEXT,                         -- Discord channel_id, Slack channel name, etc.
+  interaction_type TEXT NOT NULL,          -- 'APPLICATION_COMMAND', 'MESSAGE_COMPONENT', 'PING', etc.
+  interaction_id TEXT,                     -- ID original del evento Discord (idempotencia)
+  discord_guild_id TEXT,
+  discord_user_id TEXT,                    -- ID Discord del humano que disparó (siempre Fran)
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  response JSONB DEFAULT NULL,
+  status TEXT NOT NULL DEFAULT 'received'
+    CHECK (status IN ('received', 'processing', 'deferred', 'completed', 'failed')),
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_interactions_agent_created
+  ON public.agent_interactions (agent_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_interactions_org_created
+  ON public.agent_interactions (org_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_interactions_interaction_id
+  ON public.agent_interactions (interaction_id)
+  WHERE interaction_id IS NOT NULL;
+
+-- ────────────────────────────────────────────────────────────
+-- 2. Atribución en reservas: campo created_by_agent_id
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE public.reservations
+  ADD COLUMN IF NOT EXISTS created_by_agent_id TEXT REFERENCES public.agents(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_reservations_agent
+  ON public.reservations (created_by_agent_id)
+  WHERE created_by_agent_id IS NOT NULL;
+
+-- ────────────────────────────────────────────────────────────
+-- 3. Atribución en incidencias
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE public.incidents
+  ADD COLUMN IF NOT EXISTS created_by_agent_id TEXT REFERENCES public.agents(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_incidents_agent
+  ON public.incidents (created_by_agent_id)
+  WHERE created_by_agent_id IS NOT NULL;
+
+-- ────────────────────────────────────────────────────────────
+-- 4. Atribución en tareas
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE public.tasks
+  ADD COLUMN IF NOT EXISTS created_by_agent_id TEXT REFERENCES public.agents(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_agent
+  ON public.tasks (created_by_agent_id)
+  WHERE created_by_agent_id IS NOT NULL;
+
+-- ────────────────────────────────────────────────────────────
+-- 5. Campo discord_message_url en agent_runs (ya existe, pero puede faltar)
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE public.agent_runs
+  ADD COLUMN IF NOT EXISTS discord_message_url TEXT,
+  ADD COLUMN IF NOT EXISTS idempotency_key TEXT,
+  ADD COLUMN IF NOT EXISTS credential_id UUID REFERENCES public.agent_credentials(id) ON DELETE SET NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_runs_idempotency
+  ON public.agent_runs (idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+-- ────────────────────────────────────────────────────────────
+-- 6. RLS para agent_interactions
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE public.agent_interactions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS agent_interactions_select ON public.agent_interactions;
+CREATE POLICY agent_interactions_select ON public.agent_interactions FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = agent_interactions.org_id
+      AND om.user_id = auth.uid()
+  )
+  OR EXISTS (SELECT 1 FROM public.platform_admins pa WHERE pa.user_id = auth.uid())
+);
+
+-- Service role puede insertar (usado desde el endpoint Discord)
+DROP POLICY IF EXISTS agent_interactions_insert ON public.agent_interactions;
+CREATE POLICY agent_interactions_insert ON public.agent_interactions FOR INSERT
+  WITH CHECK (true); -- Controlado a nivel de service_role key en el endpoint
+
+COMMIT;
+
+-- Rollback:
+-- BEGIN;
+--   DROP TABLE IF EXISTS public.agent_interactions;
+--   ALTER TABLE public.reservations DROP COLUMN IF EXISTS created_by_agent_id;
+--   ALTER TABLE public.incidents DROP COLUMN IF EXISTS created_by_agent_id;
+--   ALTER TABLE public.tasks DROP COLUMN IF EXISTS created_by_agent_id;
+--   ALTER TABLE public.agent_runs DROP COLUMN IF EXISTS discord_message_url;
+--   ALTER TABLE public.agent_runs DROP COLUMN IF EXISTS idempotency_key;
+--   ALTER TABLE public.agent_runs DROP COLUMN IF EXISTS credential_id;
+-- COMMIT;

--- a/tests/agents/attribution.test.mjs
+++ b/tests/agents/attribution.test.mjs
@@ -1,0 +1,216 @@
+// BaW OS — Tests de atribución de agentes (Sprint 5A WS-1)
+// Pure-logic: tests de discordAttributionFooter, withAgentAttribution, buildAttributionMeta.
+//
+// Run: node tests/agents/attribution.test.mjs
+
+import { strict as assert } from 'node:assert'
+
+// ── Reimplementación de attribution.ts (pure logic) ──────────────────────────
+
+const AGENT_DISPLAY_NAMES = {
+  'alicia-ops': 'Alicia',
+  'hugo-cos': 'Hugo',
+  'conta-beto': 'Beto',
+  'maribel-law': 'Maribel',
+  'luis-growth': 'Luis',
+  'andres-tech': 'Andrés',
+}
+
+function getAgentDisplayName(agentId) {
+  return AGENT_DISPLAY_NAMES[agentId] ?? agentId
+}
+
+function channelLabel(channel) {
+  const labels = {
+    discord: 'Discord',
+    slack: 'Slack',
+    api: 'API',
+    whatsapp: 'WhatsApp',
+    telegram: 'Telegram',
+  }
+  return labels[channel] ?? channel
+}
+
+function discordAttributionFooter(attr) {
+  const name = attr.agentDisplayName || getAgentDisplayName(attr.agentId)
+  const channel = channelLabel(attr.channel)
+  return `via ${name} · BaW OS Agent · ${channel}`
+}
+
+function withAgentAttribution(message, attr) {
+  const footer = discordAttributionFooter(attr)
+  return `${message}\n\n-# ${footer}`
+}
+
+function withAgentDiscordEmbed(embed, attr) {
+  const footer = { text: discordAttributionFooter(attr) }
+  const enrichedEmbed = { ...embed, footer, timestamp: new Date().toISOString() }
+  if (attr.discordMessageUrl) enrichedEmbed.url = attr.discordMessageUrl
+  return enrichedEmbed
+}
+
+function buildAttributionMeta(attr) {
+  return {
+    agent_id: attr.agentId,
+    agent_display_name: attr.agentDisplayName || getAgentDisplayName(attr.agentId),
+    channel: attr.channel,
+    discord_message_url: attr.discordMessageUrl,
+    interaction_id: attr.interactionId,
+    attributed_at: new Date().toISOString(),
+  }
+}
+
+function mergeAttributionIntoMeta(existingMeta, attr) {
+  return { ...(existingMeta ?? {}), agent_attribution: buildAttributionMeta(attr) }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+    failed++
+  }
+}
+
+console.log('attribution.test.mjs — Agent attribution badges\n')
+
+const aliciaAttr = {
+  agentId: 'alicia-ops',
+  agentDisplayName: 'Alicia',
+  channel: 'discord',
+  discordMessageUrl: 'https://discord.com/channels/123/456/789',
+  interactionId: 'discord-interaction-001',
+}
+
+// ── 1. Footer text correcto ───────────────────────────────────────────────────
+test('discordAttributionFooter: formato correcto para Alicia', () => {
+  const footer = discordAttributionFooter(aliciaAttr)
+  assert.equal(footer, 'via Alicia · BaW OS Agent · Discord')
+})
+
+// ── 2. Footer usa agentId como fallback si no hay displayName ─────────────────
+test('discordAttributionFooter: usa agentId si no hay displayName', () => {
+  const footer = discordAttributionFooter({ agentId: 'alicia-ops', channel: 'discord' })
+  assert.equal(footer, 'via Alicia · BaW OS Agent · Discord')
+})
+
+test('discordAttributionFooter: agentId desconocido se usa literal', () => {
+  const footer = discordAttributionFooter({ agentId: 'unknown-agent', channel: 'slack' })
+  assert.equal(footer, 'via unknown-agent · BaW OS Agent · Slack')
+})
+
+// ── 3. withAgentAttribution agrega footer al mensaje ─────────────────────────
+test('withAgentAttribution: footer se agrega con formato markdown', () => {
+  const result = withAgentAttribution('Lista de incidencias: D104 - Fuga', aliciaAttr)
+  assert.ok(result.startsWith('Lista de incidencias: D104 - Fuga'))
+  assert.ok(result.includes('-# via Alicia · BaW OS Agent · Discord'))
+})
+
+// ── 4. Alicia no es referenciada como humana ──────────────────────────────────
+test('attribution NO usa "persona" ni "humano" en el texto', () => {
+  const footer = discordAttributionFooter(aliciaAttr)
+  const msg = withAgentAttribution('Test', aliciaAttr)
+  assert.ok(!footer.toLowerCase().includes('persona'))
+  assert.ok(!footer.toLowerCase().includes('humano'))
+  assert.ok(!msg.toLowerCase().includes('persona'))
+  // Verifica que dice "Agent" (no "Human" ni "Person")
+  assert.ok(footer.includes('Agent'))
+})
+
+// ── 5. withAgentDiscordEmbed preserva el embed original ──────────────────────
+test('withAgentDiscordEmbed: preserva título y description originales', () => {
+  const original = {
+    title: 'Incidencias D104',
+    description: '2 incidencias abiertas',
+    color: 0xff0000,
+  }
+  const enriched = withAgentDiscordEmbed(original, aliciaAttr)
+  assert.equal(enriched.title, 'Incidencias D104')
+  assert.equal(enriched.description, '2 incidencias abiertas')
+  assert.equal(enriched.color, 0xff0000)
+})
+
+test('withAgentDiscordEmbed: agrega footer con texto correcto', () => {
+  const enriched = withAgentDiscordEmbed({}, aliciaAttr)
+  assert.ok(enriched.footer)
+  assert.equal(enriched.footer.text, 'via Alicia · BaW OS Agent · Discord')
+})
+
+test('withAgentDiscordEmbed: agrega url del mensaje Discord si disponible', () => {
+  const enriched = withAgentDiscordEmbed({}, aliciaAttr)
+  assert.equal(enriched.url, 'https://discord.com/channels/123/456/789')
+})
+
+test('withAgentDiscordEmbed: no agrega url si no hay discordMessageUrl', () => {
+  const enriched = withAgentDiscordEmbed({}, {
+    agentId: 'alicia-ops',
+    agentDisplayName: 'Alicia',
+    channel: 'discord',
+  })
+  assert.equal(enriched.url, undefined)
+})
+
+test('withAgentDiscordEmbed: agrega timestamp ISO', () => {
+  const enriched = withAgentDiscordEmbed({}, aliciaAttr)
+  assert.ok(enriched.timestamp)
+  assert.ok(!isNaN(new Date(enriched.timestamp).getTime()))
+})
+
+// ── 6. buildAttributionMeta para DB ──────────────────────────────────────────
+test('buildAttributionMeta: estructura correcta', () => {
+  const meta = buildAttributionMeta(aliciaAttr)
+  assert.equal(meta.agent_id, 'alicia-ops')
+  assert.equal(meta.agent_display_name, 'Alicia')
+  assert.equal(meta.channel, 'discord')
+  assert.equal(meta.discord_message_url, 'https://discord.com/channels/123/456/789')
+  assert.equal(meta.interaction_id, 'discord-interaction-001')
+  assert.ok(meta.attributed_at)
+  assert.ok(!isNaN(new Date(meta.attributed_at).getTime()))
+})
+
+// ── 7. mergeAttributionIntoMeta preserva metadata existente ──────────────────
+test('mergeAttributionIntoMeta: preserva campos existentes', () => {
+  const existing = { source: 'manual', priority: 'high' }
+  const merged = mergeAttributionIntoMeta(existing, aliciaAttr)
+  assert.equal(merged.source, 'manual')
+  assert.equal(merged.priority, 'high')
+  assert.ok(merged.agent_attribution)
+  assert.equal(merged.agent_attribution.agent_id, 'alicia-ops')
+})
+
+test('mergeAttributionIntoMeta: funciona con metadata null', () => {
+  const merged = mergeAttributionIntoMeta(null, aliciaAttr)
+  assert.ok(merged.agent_attribution)
+})
+
+test('mergeAttributionIntoMeta: funciona con metadata undefined', () => {
+  const merged = mergeAttributionIntoMeta(undefined, aliciaAttr)
+  assert.ok(merged.agent_attribution)
+})
+
+// ── 8. Channel labels ────────────────────────────────────────────────────────
+test('channel label Discord correcto', () => {
+  assert.equal(channelLabel('discord'), 'Discord')
+})
+test('channel label Slack correcto', () => {
+  assert.equal(channelLabel('slack'), 'Slack')
+})
+test('channel label API correcto', () => {
+  assert.equal(channelLabel('api'), 'API')
+})
+test('channel label desconocido: se usa literal', () => {
+  assert.equal(channelLabel('matrix'), 'matrix')
+})
+
+// ── Resumen ───────────────────────────────────────────────────────────────────
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/tests/agents/auth.test.mjs
+++ b/tests/agents/auth.test.mjs
@@ -1,0 +1,291 @@
+// BaW OS — Tests de autenticación de agentes (Sprint 5A WS-1)
+// Pure-logic: tests de hashApiKey, generateApiKey, timingSafeEqual, scope checks.
+// Los tests de DB se hacen con mocks inline.
+//
+// Run: node tests/agents/auth.test.mjs
+
+import { strict as assert } from 'node:assert'
+import { webcrypto } from 'node:crypto'
+
+if (typeof globalThis.crypto === 'undefined') {
+  globalThis.crypto = webcrypto
+}
+
+// ── Reimplementación de las funciones pure de auth.ts ────────────────────────
+
+const KEY_PREFIX_LIVE = 'sk_live_'
+const KEY_PREFIX_TEST = 'sk_test_'
+const PREFIX_LOOKUP_LEN = 12
+
+async function hashApiKey(plainKey) {
+  const enc = new TextEncoder().encode(plainKey)
+  const buf = await crypto.subtle.digest('SHA-256', enc)
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function generateApiKey(env = 'live') {
+  const bytes = new Uint8Array(24)
+  crypto.getRandomValues(bytes)
+  const random = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+  const fullPrefix = env === 'live' ? KEY_PREFIX_LIVE : KEY_PREFIX_TEST
+  const plainKey = `${fullPrefix}${random}`
+  return { plainKey, prefix: plainKey.slice(0, PREFIX_LOOKUP_LEN) }
+}
+
+function timingSafeEqual(a, b) {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}
+
+function hasRequiredScopes(grantedScopes, requiredScopes) {
+  if (grantedScopes.includes('*')) return { ok: true, missing: [] }
+  const missing = requiredScopes.filter((s) => !grantedScopes.includes(s))
+  return { ok: missing.length === 0, missing }
+}
+
+// ── Simulador de authenticateAgentRequest con DB mock ────────────────────────
+
+function createMockAuthenticator(dbRows) {
+  return async function authenticate(plainKey, requiredScopes = []) {
+    if (!plainKey.startsWith(KEY_PREFIX_LIVE) && !plainKey.startsWith(KEY_PREFIX_TEST)) {
+      return { ok: false, status: 401, code: 'invalid_credential_format' }
+    }
+
+    const prefix = plainKey.slice(0, PREFIX_LOOKUP_LEN)
+    const hash = await hashApiKey(plainKey)
+
+    const activeRows = dbRows.filter(
+      (r) => r.api_key_prefix === prefix && r.status === 'active'
+    )
+    const matched = activeRows.find((r) => timingSafeEqual(r.api_key_hash, hash))
+
+    if (!matched) {
+      return { ok: false, status: 401, code: 'invalid_credential' }
+    }
+
+    if (matched.expires_at && Date.now() > new Date(matched.expires_at).getTime()) {
+      return { ok: false, status: 401, code: 'credential_expired' }
+    }
+
+    const { ok, missing } = hasRequiredScopes(matched.scopes, requiredScopes)
+    if (!ok) {
+      return { ok: false, status: 403, code: 'forbidden_scope', missing }
+    }
+
+    return {
+      ok: true,
+      agentId: matched.agent_id,
+      orgId: matched.org_id,
+      credentialId: matched.id,
+      scopes: matched.scopes,
+      rateLimitTier: matched.rate_limit_tier ?? 'standard',
+    }
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+async function test(name, fn) {
+  try {
+    await fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+    failed++
+  }
+}
+
+console.log('auth.test.mjs — Agent bearer token authentication\n')
+
+// ── Setup: generar claves de test ─────────────────────────────────────────────
+const { plainKey: liveKey, prefix: livePrefix } = generateApiKey('live')
+const { plainKey: testKey, prefix: testPrefix } = generateApiKey('test')
+const liveHash = await hashApiKey(liveKey)
+const testHash = await hashApiKey(testKey)
+const { plainKey: revokedKey, prefix: revokedPrefix } = generateApiKey('live')
+const revokedHash = await hashApiKey(revokedKey)
+
+const mockDb = [
+  {
+    id: 'cred-001',
+    org_id: 'org-baw-operations',
+    agent_id: 'alicia-ops',
+    api_key_prefix: livePrefix,
+    api_key_hash: liveHash,
+    scopes: ['incidents:read', 'incidents:write', 'units:read'],
+    status: 'active',
+    expires_at: null,
+    rate_limit_tier: 'standard',
+  },
+  {
+    id: 'cred-002',
+    org_id: 'org-baw-operations',
+    agent_id: 'alicia-ops',
+    api_key_prefix: testPrefix,
+    api_key_hash: testHash,
+    scopes: ['incidents:read'],
+    status: 'active',
+    expires_at: null,
+    rate_limit_tier: 'standard',
+  },
+  {
+    id: 'cred-003',
+    org_id: 'org-baw-operations',
+    agent_id: 'alicia-ops',
+    api_key_prefix: revokedPrefix,
+    api_key_hash: revokedHash,
+    scopes: ['incidents:read'],
+    status: 'revoked',
+    expires_at: null,
+    rate_limit_tier: 'standard',
+  },
+]
+
+const authenticate = createMockAuthenticator(mockDb)
+
+// ── 1. Bearer válido ──────────────────────────────────────────────────────────
+await test('válido: sk_live_ con scopes correctos', async () => {
+  const result = await authenticate(liveKey, ['incidents:read'])
+  assert.equal(result.ok, true)
+  assert.equal(result.agentId, 'alicia-ops')
+  assert.ok(result.scopes.includes('incidents:read'))
+})
+
+// ── 2. Bearer válido sin scopes requeridos ────────────────────────────────────
+await test('válido: sin scopes requeridos (acceso público de agente)', async () => {
+  const result = await authenticate(liveKey, [])
+  assert.equal(result.ok, true)
+})
+
+// ── 3. Bearer con scope insuficiente ─────────────────────────────────────────
+await test('forbidden: scope insuficiente (sk_test_ pide incidents:write)', async () => {
+  const result = await authenticate(testKey, ['incidents:write'])
+  assert.equal(result.ok, false)
+  assert.equal(result.status, 403)
+  assert.equal(result.code, 'forbidden_scope')
+  assert.ok(result.missing.includes('incidents:write'))
+})
+
+// ── 4. Bearer revocado ────────────────────────────────────────────────────────
+await test('inválido: credential revocada', async () => {
+  const result = await authenticate(revokedKey, [])
+  assert.equal(result.ok, false)
+  assert.equal(result.status, 401)
+  assert.equal(result.code, 'invalid_credential')
+})
+
+// ── 5. Bearer completamente inventado ────────────────────────────────────────
+await test('inválido: token inventado', async () => {
+  const result = await authenticate('sk_live_' + 'ff'.repeat(24), [])
+  assert.equal(result.ok, false)
+  assert.equal(result.status, 401)
+})
+
+// ── 6. Token con formato incorrecto ──────────────────────────────────────────
+await test('inválido: formato incorrecto (sin prefix sk_live_/sk_test_)', async () => {
+  const result = await authenticate('baw_pat_live_xxx', [])
+  assert.equal(result.ok, false)
+  assert.equal(result.status, 401)
+  assert.equal(result.code, 'invalid_credential_format')
+})
+
+// ── 7. Token expirado ────────────────────────────────────────────────────────
+await test('inválido: credential expirada', async () => {
+  const { plainKey: expiredKey, prefix: expiredPrefix } = generateApiKey('live')
+  const expiredHash = await hashApiKey(expiredKey)
+  const dbWithExpired = [
+    ...mockDb,
+    {
+      id: 'cred-expired',
+      org_id: 'org-baw-operations',
+      agent_id: 'alicia-ops',
+      api_key_prefix: expiredPrefix,
+      api_key_hash: expiredHash,
+      scopes: ['incidents:read'],
+      status: 'active', // status 'active' pero expires_at en el pasado
+      expires_at: new Date(Date.now() - 3600_000).toISOString(), // 1h ago
+      rate_limit_tier: 'standard',
+    },
+  ]
+  const authenticateWithExpired = createMockAuthenticator(dbWithExpired)
+  const result = await authenticateWithExpired(expiredKey, [])
+  assert.equal(result.ok, false)
+  assert.equal(result.status, 401)
+  assert.equal(result.code, 'credential_expired')
+})
+
+// ── 8. Scopes con wildcard (*) ────────────────────────────────────────────────
+await test('válido: scope wildcard (*) concede acceso a cualquier scope', async () => {
+  const { plainKey: superKey, prefix: superPrefix } = generateApiKey('live')
+  const superHash = await hashApiKey(superKey)
+  const dbWithSuper = [
+    ...mockDb,
+    {
+      id: 'cred-super',
+      org_id: 'org-baw-operations',
+      agent_id: 'alicia-ops',
+      api_key_prefix: superPrefix,
+      api_key_hash: superHash,
+      scopes: ['*'],
+      status: 'active',
+      expires_at: null,
+      rate_limit_tier: 'unlimited',
+    },
+  ]
+  const authenticateWithSuper = createMockAuthenticator(dbWithSuper)
+  const result = await authenticateWithSuper(superKey, [
+    'contracts:write',
+    'payments:write',
+    'cfdi:emit',
+  ])
+  assert.equal(result.ok, true)
+})
+
+// ── 9. hashApiKey determinístico ──────────────────────────────────────────────
+await test('hashApiKey es determinístico (mismo input = mismo hash)', async () => {
+  const h1 = await hashApiKey('sk_live_test_key_123')
+  const h2 = await hashApiKey('sk_live_test_key_123')
+  assert.equal(h1, h2)
+})
+
+// ── 10. hashApiKey distingue keys similares ────────────────────────────────
+await test('hashApiKey distingue claves similares', async () => {
+  const h1 = await hashApiKey('sk_live_test_key_123')
+  const h2 = await hashApiKey('sk_live_test_key_124')
+  assert.notEqual(h1, h2)
+})
+
+// ── 11. generateApiKey formato correcto ───────────────────────────────────────
+await test('generateApiKey: formato sk_live_ correcto', () => {
+  const { plainKey, prefix } = generateApiKey('live')
+  assert.ok(plainKey.startsWith('sk_live_'))
+  assert.equal(prefix, plainKey.slice(0, PREFIX_LOOKUP_LEN))
+  assert.equal(prefix.length, 12)
+})
+
+await test('generateApiKey: formato sk_test_ correcto', () => {
+  const { plainKey } = generateApiKey('test')
+  assert.ok(plainKey.startsWith('sk_test_'))
+})
+
+// ── 12. timingSafeEqual resiste comparación de diferente largo ────────────────
+await test('timingSafeEqual: diferente largo retorna false', () => {
+  assert.equal(timingSafeEqual('abc', 'abcd'), false)
+})
+
+// ── Resumen ───────────────────────────────────────────────────────────────────
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/tests/agents/discord-verify.test.mjs
+++ b/tests/agents/discord-verify.test.mjs
@@ -1,0 +1,183 @@
+// BaW OS — Tests de verificación de firma Discord Ed25519 (Sprint 5A WS-1)
+// Pure-logic: tests de la lógica de verificación sin deps externas.
+// La implementación usa Web Crypto que está disponible en Node.js ≥18.
+//
+// Run: node tests/agents/discord-verify.test.mjs
+
+import { strict as assert } from 'node:assert'
+import { webcrypto } from 'node:crypto'
+
+// Polyfill global crypto para Node entornos donde no está globalizado
+if (typeof globalThis.crypto === 'undefined') {
+  globalThis.crypto = webcrypto
+}
+
+// ── Reimplementación de discord-verify.ts (pura lógica) ──────────────────────
+// Espeja src/lib/agents/discord-verify.ts para test aislado
+
+async function importDiscordPublicKey(publicKeyHex) {
+  const bytes = new Uint8Array(
+    publicKeyHex.match(/.{1,2}/g).map((b) => parseInt(b, 16))
+  )
+  return crypto.subtle.importKey('raw', bytes, { name: 'Ed25519' }, false, ['verify'])
+}
+
+async function verifyDiscordSignature(signature, timestamp, rawBody, publicKeyHex) {
+  try {
+    const publicKey = await importDiscordPublicKey(publicKeyHex)
+    const sigBytes = new Uint8Array(
+      signature.match(/.{1,2}/g).map((b) => parseInt(b, 16))
+    )
+    const message = new TextEncoder().encode(timestamp + rawBody)
+    return await crypto.subtle.verify('Ed25519', publicKey, sigBytes, message)
+  } catch {
+    return false
+  }
+}
+
+async function verifyDiscordRequest(headers, bodyText, publicKeyHex) {
+  const signature = headers['x-signature-ed25519']
+  const timestamp = headers['x-signature-timestamp']
+  if (!signature || !timestamp) return { valid: false }
+  const ts = parseInt(timestamp, 10)
+  if (isNaN(ts) || Math.abs(Date.now() / 1000 - ts) > 300) return { valid: false }
+  const valid = await verifyDiscordSignature(signature, timestamp, bodyText, publicKeyHex)
+  return valid ? { valid: true, rawBody: bodyText } : { valid: false }
+}
+
+// ── Generación de pares de claves para tests ─────────────────────────────────
+
+async function generateTestKeyPair() {
+  const { privateKey, publicKey } = await crypto.subtle.generateKey(
+    'Ed25519',
+    true,
+    ['sign', 'verify']
+  )
+  const pubRaw = await crypto.subtle.exportKey('raw', publicKey)
+  const pubHex = Array.from(new Uint8Array(pubRaw))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+  return { privateKey, publicKey, pubHex }
+}
+
+async function signDiscordRequest(privateKey, timestamp, body) {
+  const message = new TextEncoder().encode(timestamp + body)
+  const sigBuf = await crypto.subtle.sign('Ed25519', privateKey, message)
+  return Array.from(new Uint8Array(sigBuf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+async function test(name, fn) {
+  try {
+    await fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+    failed++
+  }
+}
+
+console.log('discord-verify.test.mjs — Ed25519 signature verification\n')
+
+const { privateKey, pubHex } = await generateTestKeyPair()
+const nowTs = Math.floor(Date.now() / 1000).toString()
+const testBody = JSON.stringify({ type: 1 })
+
+// ── 1. Firma válida ───────────────────────────────────────────────────────────
+await test('válida: PING con firma correcta', async () => {
+  const sig = await signDiscordRequest(privateKey, nowTs, testBody)
+  const result = await verifyDiscordRequest(
+    { 'x-signature-ed25519': sig, 'x-signature-timestamp': nowTs },
+    testBody,
+    pubHex
+  )
+  assert.equal(result.valid, true)
+})
+
+// ── 2. Firma inválida (firma de otro body) ────────────────────────────────────
+await test('inválida: firma no corresponde al body', async () => {
+  const sig = await signDiscordRequest(privateKey, nowTs, '{"type":2}')
+  const result = await verifyDiscordRequest(
+    { 'x-signature-ed25519': sig, 'x-signature-timestamp': nowTs },
+    testBody, // body diferente
+    pubHex
+  )
+  assert.equal(result.valid, false)
+})
+
+// ── 3. Headers faltantes ──────────────────────────────────────────────────────
+await test('inválida: falta x-signature-ed25519', async () => {
+  const result = await verifyDiscordRequest(
+    { 'x-signature-timestamp': nowTs },
+    testBody,
+    pubHex
+  )
+  assert.equal(result.valid, false)
+})
+
+await test('inválida: falta x-signature-timestamp', async () => {
+  const result = await verifyDiscordRequest(
+    { 'x-signature-ed25519': 'deadbeef' },
+    testBody,
+    pubHex
+  )
+  assert.equal(result.valid, false)
+})
+
+// ── 4. Timestamp expirado (replay attack) ────────────────────────────────────
+await test('inválida: timestamp expirado (>5min)', async () => {
+  const oldTs = (Math.floor(Date.now() / 1000) - 400).toString() // 400s ago
+  const sig = await signDiscordRequest(privateKey, oldTs, testBody)
+  const result = await verifyDiscordRequest(
+    { 'x-signature-ed25519': sig, 'x-signature-timestamp': oldTs },
+    testBody,
+    pubHex
+  )
+  assert.equal(result.valid, false)
+})
+
+// ── 5. Signature hex corrupta ─────────────────────────────────────────────────
+await test('inválida: firma hex malformada', async () => {
+  const result = await verifyDiscordRequest(
+    { 'x-signature-ed25519': 'ZZZZZZ', 'x-signature-timestamp': nowTs },
+    testBody,
+    pubHex
+  )
+  assert.equal(result.valid, false)
+})
+
+// ── 6. Clave pública incorrecta ───────────────────────────────────────────────
+await test('inválida: clave pública de otro bot', async () => {
+  const { pubHex: otherPub } = await generateTestKeyPair()
+  const sig = await signDiscordRequest(privateKey, nowTs, testBody)
+  const result = await verifyDiscordRequest(
+    { 'x-signature-ed25519': sig, 'x-signature-timestamp': nowTs },
+    testBody,
+    otherPub // clave diferente
+  )
+  assert.equal(result.valid, false)
+})
+
+// ── 7. Body vacío (PING) ──────────────────────────────────────────────────────
+await test('válida: body vacío con firma correcta', async () => {
+  const emptyBody = ''
+  const sig = await signDiscordRequest(privateKey, nowTs, emptyBody)
+  const result = await verifyDiscordRequest(
+    { 'x-signature-ed25519': sig, 'x-signature-timestamp': nowTs },
+    emptyBody,
+    pubHex
+  )
+  assert.equal(result.valid, true)
+})
+
+// ── Resumen ───────────────────────────────────────────────────────────────────
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/tests/agents/run-all.sh
+++ b/tests/agents/run-all.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# BaW OS — Agent tests runner (Sprint 5A WS-1)
+# Run: bash tests/agents/run-all.sh
+
+set -e
+
+PASS=0
+FAIL=0
+
+run_test() {
+  local file=$1
+  echo ""
+  echo "── $file ────────────────────────"
+  if node "$file"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+cd "$(dirname "$0")/../.."
+
+run_test tests/agents/discord-verify.test.mjs
+run_test tests/agents/auth.test.mjs
+run_test tests/agents/attribution.test.mjs
+
+echo ""
+echo "══════════════════════════════════════"
+echo "Test suites: $((PASS + FAIL)) total, $PASS passed, $FAIL failed"
+echo "══════════════════════════════════════"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Sprint 5A WS-1 full backend — Alicia third-party agent vía Discord Interactions.

### Nuevos archivos
- `src/app/api/agents/discord-interactions/route.ts` — Endpoint Discord Interactions con verificación Ed25519 (Web Crypto, sin deps externas). Maneja PING, APPLICATION_COMMAND (deferred), MESSAGE_COMPONENT (botones aprobación inline).
- `src/lib/agents/discord-verify.ts` — Verificación de firma Ed25519 + protección anti-replay (±5min timestamp).
- `src/lib/agents/attribution.ts` — withAgentAttribution + withAgentDiscordEmbed + buildAttributionMeta para badge 'via Alicia'.
- `supabase/migrations/20260523_agents_discord_interactions.sql` — Tabla `agent_interactions`, columnas `created_by_agent_id` en reservations/incidents/tasks, columnas `discord_message_url/idempotency_key/credential_id` en agent_runs. **Ya aplicada a prod.**

### Archivos extendidos
- `src/lib/agents/auth.ts` — Agrega `verifyAgentBearer(token)` y `requireAgentAuth(scopes[])` HOF para proteger endpoints de agentes. Separado completamente de autenticación de usuarios humanos.
- `AGENTS.md` — Sección 9: Third-party agents Discord Interactions (arquitectura, tokens, atribución, env vars, tests).
- `docs/sprints/SPRINT_5A_PLAN.md` — WS-1 progress actualizado.

### ADR
- `docs/adr/ADR-021-third-party-agents-discord.md` — Decisiones: Web Crypto vs tweetnacl, path del endpoint, DEFERRED vs inline, custom_id convention, agent_interactions vs agent_runs, created_by_agent_id en 3 tablas.

### Tests
```
bash tests/agents/run-all.sh
# 3 suites — 39 tests — 0 failed
```
- `tests/agents/discord-verify.test.mjs` — 8 tests (firma válida, inválida, replay, clave incorrecta)
- `tests/agents/auth.test.mjs` — 13 tests (bearer válido/revocado/expirado/scope-insuficiente/wildcard)
- `tests/agents/attribution.test.mjs` — 18 tests (footer text, embed, metadata, channel labels)

### Repo nuevo
- `zxy-vc/openclaw-skill-baw-os` (privado) — skill.json, src/client.ts (bearer+retry+idempotency), src/tools/index.ts (10 tools), schemas JSON, tests (11 tests), CI GitHub Actions.

### Reconocimiento completado
- Alicia confirmada: `agents.id = 'alicia-ops'`, `family = 'third-party'`, `status = 'planned'`
- `agent_credentials` ya existía con schema correcto (migración 20260503)
- Tabla `bookings` no existe — es `reservations`. Atribución aplicada a reservations + incidents + tasks.
- Sin repos `openclaw-skill-*` previos en zxy-vc — repo creado desde cero.

### Env vars necesarias (Vercel)
| Variable | Descripción |
|---|---|
| `DISCORD_PUBLIC_KEY` | Clave pública Ed25519 del bot Discord (hex) |
| `INTERNAL_WEBHOOK_SECRET` | Bearer secret para dispatch async entre funciones |
| `NEXT_PUBLIC_BASE_URL` | URL base Vercel (ya debería existir) |

### Issues / pendientes para Fran
1. `resolved_by_discord_user` en `agent_approvals` — el UPDATE en el endpoint intenta set este campo; si no existe en la tabla lo ignora silenciosamente. Verificar schema de `agent_approvals` y agregar el campo en próxima migración.
2. El endpoint `/api/agents/discord-interactions/process` (procesamiento async real de comandos) es WS-2 — requiere la integración con OpenClaw runtime de Alicia en M1.
3. `DISCORD_PUBLIC_KEY` y `INTERNAL_WEBHOOK_SECRET` deben agregarse a Vercel env vars antes del primer uso real.

### Acuerdos canónicos respetados
- NO auto-merge — Fran aprueba
- Single-line commits (un commit principal + amend por secret-scanning fix)  
- MCP-first: Supabase MCP para migración, gh CLI para GitHub
- Agentes ≠ humanos: Alicia nunca referenciada como persona en código, docs, ni mensajes
- bearer auth de agentes completamente separado de autenticación de usuarios humanos
- No deps nuevas: Web Crypto nativo para Ed25519 (sin tweetnacl)