### PR TITLE
hotfix(ci): fix invalid secrets expression in smoke-supabase job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,21 +106,37 @@ jobs:
     name: smoke-supabase
     needs: lint-and-typecheck
     runs-on: ubuntu-latest
-    if: ${{ secrets.SUPABASE_STAGING_URL != '' }}
     steps:
+      - name: Check if secret is configured
+        id: check_secret
+        env:
+          SUPABASE_STAGING_URL: ${{ secrets.SUPABASE_STAGING_URL }}
+        run: |
+          if [ -z "$SUPABASE_STAGING_URL" ]; then
+            echo "configured=false" >> $GITHUB_OUTPUT
+            echo "SUPABASE_STAGING_URL not configured — skipping smoke test"
+          else
+            echo "configured=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
+        if: steps.check_secret.outputs.configured == 'true'
         uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Supabase health check
+        if: steps.check_secret.outputs.configured == 'true'
+        env:
+          SUPABASE_STAGING_URL: ${{ secrets.SUPABASE_STAGING_URL }}
+          SUPABASE_STAGING_ANON_KEY: ${{ secrets.SUPABASE_STAGING_ANON_KEY }}
         run: |
           echo "Running Supabase smoke test against staging..."
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            "${{ secrets.SUPABASE_STAGING_URL }}/rest/v1/" \
-            -H "apikey: ${{ secrets.SUPABASE_STAGING_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_STAGING_ANON_KEY }}")
+            "$SUPABASE_STAGING_URL/rest/v1/" \
+            -H "apikey: $SUPABASE_STAGING_ANON_KEY" \
+            -H "Authorization: Bearer $SUPABASE_STAGING_ANON_KEY")
           echo "HTTP status: $STATUS"
           if [ "$STATUS" -ge 200 ] && [ "$STATUS" -lt 400 ]; then
             echo "Supabase health check passed."
@@ -138,20 +154,16 @@ jobs:
       - name: Verify all required jobs passed
         run: |
           if [ "${{ needs.lint-and-typecheck.result }}" != "success" ]; then
-            echo "lint-and-typecheck failed"
-            exit 1
+            echo "lint-and-typecheck failed"; exit 1
           fi
           if [ "${{ needs.build.result }}" != "success" ]; then
-            echo "build failed"
-            exit 1
+            echo "build failed"; exit 1
           fi
           if [ "${{ needs.tests.result }}" != "success" ]; then
-            echo "tests failed"
-            exit 1
+            echo "tests failed"; exit 1
           fi
-          # smoke-supabase is optional — passes if skipped (secret not set) or succeeded
-          if [ "${{ needs.smoke-supabase.result }}" != "success" ] && [ "${{ needs.smoke-supabase.result }}" != "skipped" ]; then
-            echo "smoke-supabase failed"
-            exit 1
+          # smoke-supabase success means: either the smoke test passed OR the secret wasn't set (job ran but internal step skipped)
+          if [ "${{ needs.smoke-supabase.result }}" != "success" ]; then
+            echo "smoke-supabase failed (job-level)"; exit 1
           fi
           echo "All checks passed"


### PR DESCRIPTION
## Problem

PR #61 introduced the `smoke-supabase` job with an invalid `if` condition:

```yaml
if: ${{ secrets.SUPABASE_STAGING_URL != '' }}
```

GitHub Actions does **not** allow accessing `secrets.*` directly in job-level `if` expressions. This caused a workflow parse error, making **all** jobs fail instantly in 0 seconds with "This run likely failed because of a workflow file issue."

## Fix

Replaced the invalid job-level `if` with the standard pattern: a first step that checks the secret via an env var, sets a step output (`configured=true/false`), and all subsequent steps use `if: steps.check_secret.outputs.configured == 'true'` to conditionally skip.

Also updated `all-checks-pass` to require `smoke-supabase` to be `success` (not `skipped`), since the new pattern always runs the job — it just skips internal steps when the secret is absent.

## Verification

- **YAML syntax**: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo YAML OK` ✅
- **Typecheck** (`npx tsc --noEmit`): ✅ passed (no output = no errors)
- **Build** (`npm run build` with placeholder env vars): ✅ passed
- **Tests public-booking** (`bash tests/public-booking/run-all.sh`): ✅ 43 tests passed (14 + 7 + 13 + 9)
- **Tests v1** (`bash tests/v1/run-all.sh`): ✅ 28 tests passed (14 + 8 + 6)

## Files changed

Only `.github/workflows/ci.yml` — no other files touched.