### PR TITLE
hotfix(ci): add ESLint config (fixes interactive prompt in CI)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "plugins": ["@typescript-eslint"],
+  "ignorePatterns": [
+    "node_modules/",
+    ".next/",
+    "out/",
+    "build/",
+    "dist/",
+    "coverage/",
+    "design/baw-design/",
+    "supabase/migrations/",
+    "*.config.js",
+    "*.config.mjs",
+    "*.config.ts"
+  ],
+  "rules": {
+    "@next/next/no-img-element": "warn",
+    "@next/next/no-html-link-for-pages": "warn",
+    "react/no-unescaped-entities": "off",
+    "react-hooks/exhaustive-deps": "warn",
+    "@typescript-eslint/no-explicit-any": "off"
+  }
+}


### PR DESCRIPTION
## Problema

El step `Lint` del job `lint-and-typecheck` fallaba porque `next lint` no encontraba configuración de ESLint y arrancaba en modo interactivo:

```
? How would you like to configure ESLint?
❯  Strict (recommended)
   Base
   Cancel
##[error]Process completed with exit code 1.
```

## Solución

Se agrega `.eslintrc.json` en la raíz del repo con:
- **extends**: `next/core-web-vitals` — preset oficial de Next.js
- **plugins**: `@typescript-eslint` — necesario para que ESLint reconozca los comentarios `eslint-disable @typescript-eslint/*` existentes en el código sin error de "rule not found"
- **ignorePatterns**: excluye node_modules, .next, build artifacts, design assets, migrations, y config files

## Rules relajadas (pragmáticas)

| Rule | Nivel | Razón |
|------|-------|-------|
| `react/no-unescaped-entities` | off | El proyecto tiene copy en español con apóstrofes/comillas; genera ruido sin valor |
| `react-hooks/exhaustive-deps` | warn | Muchas dependencias estables en hooks; no bloquea builds |
| `@next/next/no-img-element` | warn | Varios `<img>` intencionales; no bloquea CI |
| `@next/next/no-html-link-for-pages` | warn | Reducir bloqueos en CI, mejora incremental |
| `@typescript-eslint/no-explicit-any` | off | El plugin se carga solo para reconocer disable-comments; no activamos la regla |

## Resultado local

- `npm run lint`: **0 errores, ~18 warnings** (todos react-hooks/exhaustive-deps y @next/next/no-img-element)
- `npx tsc --noEmit`: ✅ sin errores
- `npm run build`: ✅ build completo
- `tests/public-booking/run-all.sh`: ✅ todos los tests pasan
- `tests/v1/run-all.sh`: ✅ todos los tests pasan

## Archivos modificados

- `.eslintrc.json` (nuevo) — única modificación; no se tocaron `package.json` ni `package-lock.json` porque `eslint` y `eslint-config-next` ya estaban en devDependencies

## Issues pendientes (fuera del scope de este PR)

- Existen ~15+ unused vars/imports en el codebase que `@typescript-eslint/recommended` reportaría como errores. Se pueden abordar gradualmente. Issue recomendado: "Clean up unused imports and variables flagged by @typescript-eslint/no-unused-vars"
- `src/components/public-booking/LocationMap.tsx` usa `@ts-ignore` en lugar de `@ts-expect-error`