### PR TITLE
hotfix(ci): combined fix — YAML secrets expression + ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "plugins": ["@typescript-eslint"],
+  "ignorePatterns": [
+    "node_modules/",
+    ".next/",
+    "out/",
+    "build/",
+    "dist/",
+    "coverage/",
+    "design/baw-design/",
+    "supabase/migrations/",
+    "*.config.js",
+    "*.config.mjs",
+    "*.config.ts"
+  ],
+  "rules": {
+    "@next/next/no-img-element": "warn",
+    "@next/next/no-html-link-for-pages": "warn",
+    "react/no-unescaped-entities": "off",
+    "react-hooks/exhaustive-deps": "warn",
+    "@typescript-eslint/no-explicit-any": "off"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,21 +106,36 @@ jobs:
     name: smoke-supabase
     needs: lint-and-typecheck
     runs-on: ubuntu-latest
-    if: ${{ secrets.SUPABASE_STAGING_URL != '' }}
     steps:
+      - name: Check if secret is configured
+        id: check_secret
+        env:
+          SUPABASE_STAGING_URL: ${{ secrets.SUPABASE_STAGING_URL }}
+        run: |
+          if [ -z "$SUPABASE_STAGING_URL" ]; then
+            echo "configured=false" >> $GITHUB_OUTPUT
+            echo "SUPABASE_STAGING_URL not configured — skipping smoke test"
+          else
+            echo "configured=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
+        if: steps.check_secret.outputs.configured == 'true'
         uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Supabase health check
+        if: steps.check_secret.outputs.configured == 'true'
+        env:
+          SUPABASE_STAGING_URL: ${{ secrets.SUPABASE_STAGING_URL }}
+          SUPABASE_STAGING_ANON_KEY: ${{ secrets.SUPABASE_STAGING_ANON_KEY }}
         run: |
-          echo "Running Supabase smoke test against staging..."
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            "${{ secrets.SUPABASE_STAGING_URL }}/rest/v1/" \
-            -H "apikey: ${{ secrets.SUPABASE_STAGING_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_STAGING_ANON_KEY }}")
+            "$SUPABASE_STAGING_URL/rest/v1/" \
+            -H "apikey: $SUPABASE_STAGING_ANON_KEY" \
+            -H "Authorization: Bearer $SUPABASE_STAGING_ANON_KEY")
           echo "HTTP status: $STATUS"
           if [ "$STATUS" -ge 200 ] && [ "$STATUS" -lt 400 ]; then
             echo "Supabase health check passed."
@@ -137,21 +152,8 @@ jobs:
     steps:
       - name: Verify all required jobs passed
         run: |
-          if [ "${{ needs.lint-and-typecheck.result }}" != "success" ]; then
-            echo "lint-and-typecheck failed"
-            exit 1
-          fi
-          if [ "${{ needs.build.result }}" != "success" ]; then
-            echo "build failed"
-            exit 1
-          fi
-          if [ "${{ needs.tests.result }}" != "success" ]; then
-            echo "tests failed"
-            exit 1
-          fi
-          # smoke-supabase is optional — passes if skipped (secret not set) or succeeded
-          if [ "${{ needs.smoke-supabase.result }}" != "success" ] && [ "${{ needs.smoke-supabase.result }}" != "skipped" ]; then
-            echo "smoke-supabase failed"
-            exit 1
-          fi
+          if [ "${{ needs.lint-and-typecheck.result }}" != "success" ]; then echo "lint-and-typecheck failed"; exit 1; fi
+          if [ "${{ needs.build.result }}" != "success" ]; then echo "build failed"; exit 1; fi
+          if [ "${{ needs.tests.result }}" != "success" ]; then echo "tests failed"; exit 1; fi
+          if [ "${{ needs.smoke-supabase.result }}" != "success" ]; then echo "smoke-supabase failed"; exit 1; fi
           echo "All checks passed"


### PR DESCRIPTION
## Problema

PR #61 introdujo `.github/workflows/ci.yml` con dos bugs descubiertos al mergear a main:

### Bug 1
```yaml
if: ${{ secrets.SUPABASE_STAGING_URL != '' }}  # job-level
```
GitHub Actions no permite `secrets.*` en `if` job-level. Rompía parsing → todos los runs fallaban en 0s.

### Bug 2
`next lint` arrancaba interactivo porque no existía `.eslintrc.json` → exit 1.

## Fix
- **Workflow YAML**: `smoke-supabase` ahora corre siempre, con un primer step que check el secret y outputs `configured=true|false`. Steps subsecuentes gatean por ese output.
- **ESLint**: `.eslintrc.json` con preset `next/core-web-vitals` + plugin `@typescript-eslint` declarado + rules relajadas pragmáticas.

## Validación previa
- PR #67 validó typecheck/build/tests pasan después del fix YAML
- PR #68 validó 0 errors, ~18 warnings de lint

Este PR combina ambos. Después de mergear, cerrar #67 y #68.

## Reglas
Single-line commit. NO auto-merge.