### PR TITLE
Sprint 5A MVP: Alicia + Hugo third-party agents, Discord approvals, async interactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,8 @@ const embed = withAgentDiscordEmbed({ title: 'Nueva incidencia', ... }, attr)
 | `DISCORD_PUBLIC_KEY` | Clave pública Ed25519 del bot Discord (hex). Del portal de Discord. |
 | `INTERNAL_WEBHOOK_SECRET` | Bearer secret para dispatch async entre funciones Vercel. |
 | `NEXT_PUBLIC_BASE_URL` | URL base de Vercel (ej. `https://baw-os.vercel.app`). |
+| `ALICIA_WEBHOOK_URL` | URL push al runtime de Alicia (tunnel Cloudflare, ej. `https://alicia.zxy.vc/incoming/baw-os`). Si falta o el push falla, la interacción queda `deferred` y la recoge el long-poll del skill. |
+| `DISCORD_DEFAULT_ORG_ID` | Org UUID al que se atribuyen interacciones Discord (MVP: org `BaW Operations`). Mapeo guild→org multi-tenant es follow-up. |
 
 ### Tests de agentes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,8 @@ Enum legacy `member_role` está en proceso de eliminación (issue [#23](https://
 
 Definido en tabla `agents` (S4-3, PR #18). Framework: capability `L0-L4` (autonomy) + feedback `F0-F5` (maturity).
 
+**Presentación UI (Sprint 5A MVP):** la página `/agents` muestra **solo la familia third-party**. El catálogo completo permanece intacto en la tabla `agents` — los nativos están ocultos de la UI, no eliminados. El runner de cobranza sigue operando como automatización interna vía `/api/cron/cobranza` (diario), sin presentarse como agente. Los únicos third-party activos del MVP son **Alicia** (operadora Mateos 809P) y **Hugo** (supervisor read-only de Alicia); el resto se muestra "Diferido".
+
 ### 2.8 — Features mergeadas y funcionales
 **No eliminar** features que ya están en main funcionando, sin issue previo que justifique la eliminación. Ejemplos vigentes:
 
@@ -224,10 +226,10 @@ Mejor un PR pausado 1 hora que un PR mergeado con regresión.
 
 ---
 
-## 9 · Third-party agents — Discord Interactions (Sprint 5A WS-1)
+## 9 · Third-party agents — Discord Interactions (Sprint 5A MVP)
 
-> Agente conectado actualmente: **Alicia** (`id = alicia-ops`, `family = third-party`).
-> Único humano en el sistema: Fran. Los agentes NUNCA son referenciados como personas.
+> Agentes del MVP: **Alicia** (`id = alicia-ops`, operadora Mateos 809P) y **Hugo** (`id = hugo-cos`, supervisor de Alicia, **solo lectura**: `runs:read`, `approvals:read`, `insights:read` — nunca writes ni `approvals:resolve`; ver `docs/runbooks/hugo-cos-connect.md`).
+> Único humano en el sistema: Fran. Los agentes NUNCA son referenciados como personas. Las aprobaciones las resuelve solo Fran.
 
 ### Arquitectura del flujo Discord → BaW OS
 
@@ -242,10 +244,24 @@ Fran (Discord) → Discord API → POST /api/agents/discord-interactions
                                     │
                          dispatch async → /api/agents/discord-interactions/process
                                     │
-                         Alicia ejecuta → /api/v1/* endpoints
-                                    │
-                         Discord followup webhook → respuesta con badge
+                    push a ALICIA_WEBHOOK_URL (timeout 5s)
+                         │                        │
+                    push OK                  push falla
+                         │                        │
+              Alicia procesa            status='deferred' + aviso Discord
+                         │                        │
+                         │              skill long-poll GET /v1/interactions
+                         │                        │
+                         └────────┬───────────────┘
+                                  │
+                    Alicia ejecuta → /api/v1/* endpoints
+                                  │
+                    Discord followup webhook (skill) → respuesta con badge
+                                  │
+                    PATCH /v1/interactions/:id → completed|failed
 ```
+
+**custom_id canónico** (botones/selects): `baw:<agent_id>:<action>:<entity_id>`. Aprobaciones: `baw:<agent_id>:approval:<grant|deny>:<approval_id>` (el server acepta el legacy `baw:approval:<grant|deny>:<id>`). El botón "Aprobar" ejecuta la acción vía `dispatchApprovedAction()` — mismo contrato que `POST /v1/approvals/:id/grant`.
 
 ### Bearer tokens de agentes
 
@@ -299,27 +315,32 @@ const embed = withAgentDiscordEmbed({ title: 'Nueva incidencia', ... }, attr)
 ### Tests de agentes
 
 ```bash
-bash tests/agents/run-all.sh   # 3 suites, 39 tests
+bash tests/agents/run-all.sh   # 4 suites
 ```
 
 O individualmente:
 ```bash
-node tests/agents/discord-verify.test.mjs  # 8 tests (firma Ed25519)
-node tests/agents/auth.test.mjs            # 13 tests (bearer tokens + scopes)
-node tests/agents/attribution.test.mjs     # 18 tests (badges de atribución)
+node tests/agents/discord-verify.test.mjs    # firma Ed25519
+node tests/agents/auth.test.mjs              # bearer tokens + scopes
+node tests/agents/attribution.test.mjs       # badges de atribución
+node tests/agents/discord-custom-id.test.mjs # parser custom_id aprobaciones
 ```
 
 ### Archivos clave de la integración Discord
 
 | Archivo | Propósito |
 |---|---|
-| `src/app/api/agents/discord-interactions/route.ts` | Endpoint principal Discord |
+| `src/app/api/agents/discord-interactions/route.ts` | Endpoint principal Discord (PING, deferred, botones de aprobación) |
+| `src/app/api/agents/discord-interactions/process/route.ts` | Procesamiento async: push al runtime o deferred |
+| `src/app/api/v1/interactions/route.ts` + `[id]/route.ts` | Long-poll safety net del skill (GET + PATCH) |
 | `src/lib/agents/discord-verify.ts` | Verificación firma Ed25519 |
 | `src/lib/agents/auth.ts` | verifyAgentBearer + requireAgentAuth HOF |
-| `src/lib/agents/attribution.ts` | Badge "via Alicia" en mensajes y DB |
+| `src/lib/agents/attribution.ts` | Badge "via Alicia" / "via Hugo" en mensajes y DB |
 | `supabase/migrations/20260523_agents_discord_interactions.sql` | agent_interactions + attribution columns |
+| `supabase/migrations/20260611_agent_approvals_discord_resolver.sql` | resolved_by_discord_user (ADR-021 D8) |
 | `docs/adr/ADR-021-third-party-agents-discord.md` | Decisiones arquitecturales |
+| `docs/runbooks/hugo-cos-connect.md` | Conexión de Hugo (supervisor read-only) |
 
 ---
 
-**Última actualización:** 2026-05-23 · Sprint 5A WS-1 — Discord Interactions + Alicia bearer auth
+**Última actualización:** 2026-06-11 · Sprint 5A MVP — Alicia + Hugo third-party, nativos ocultos de UI, pipeline async completo

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,29 +1,35 @@
 # PROJECT_STATE.md — Estado vivo de BaW OS
 
 > **Este archivo cambia seguido.** Cualquier agente que vaya a tocar el repo debe leerlo después de `AGENTS.md` y antes de empezar.
-> **Última actualización:** 2026-05-03 (Sprint 5A iniciado: Conversational Agent Runtime, Alicia third-party).
+> **Última actualización:** 2026-06-11 (Sprint 5A simplificado a MVP: Alicia + Hugo third-party, nativos fuera de UI).
 
 ---
 
 ## 1 · Sprint en curso
 
-**Sprint 5A — Conversational Agent Runtime · EN CURSO desde 2026-05-03.**
+**Sprint 5A MVP — Producto mínimo utilizable con agentes third-party · simplificado el 2026-06-11.**
 
-**Goal:** conectar Alicia (único agente third party de Sprint 5A) vía OpenClaw skill + Discord para que opere BaW OS en lenguaje natural en producción.
+**Goal:** Fran + Alicia + Hugo operando Mateos 809P vía Discord sobre las features que ya existen. Producto mínimo, no plataforma completa.
+
+**Decisiones de simplificación (2026-06-11, Fran):**
+- **Agentes nativos fuera del alcance**: la UI `/agents` muestra solo la familia third-party. Nada se borra de DB. El runner de cobranza sigue vivo como cron interno (`/api/cron/cobranza`, diario, dry-run default) sin presentarse como agente.
+- **Alicia** (`alicia-ops`) = operadora de Mateos 809P. Scopes: `incidents:rw, tasks:rw, units:r, contracts:r, payments:r, approvals:r, interactions:rw`.
+- **Hugo** (`hugo-cos`) = supervisor de Alicia, **solo lectura + reportes** (`runs:read, approvals:read, insights:read`). NO aprueba acciones (solo Fran), NO dispara a Alicia. Runbook: `docs/runbooks/hugo-cos-connect.md`.
+- **División de trabajo**: Claude (Fable 5) → repo `baw-os`; Codex → repo `openclaw-skill-baw-os` (skill con persona dual Alicia+Hugo). El contrato de interfaz está en AGENTS.md §9.
+- Siguen vigentes de ADR-016: webhooks-first + long-poll safety net, repo separado para el skill, CFDI/Stripe writes en Fase 6, in-app chat en 5B.
+
+**Estado server-side (2026-06-11):** pipeline Discord completo (endpoint principal + `/process` + `/v1/interactions` GET/PATCH), botones de aprobación reparados y ejecutando vía dispatcher, `GET /v1/runs` reparado, UI `/agents` solo third-party con badges de conexión, cron cobranza, webhooks issue #22 migrados, guard de submodule en prebuild. Pendiente: Codex (skill), migraciones SQL en Supabase prod, env vars en Vercel, credenciales de Alicia/Hugo (Fran).
+
+**Bugs encontrados y corregidos en main (patrón "columnas fantasma en selects"):**
+- `GET /v1/runs` seleccionaba `completed_at, created_at` — columnas inexistentes en `agent_runs` (son `started_at, finished_at`). Todo GET devolvía 500.
+- Botones Discord de aprobación: status `'approved'` (el CHECK admite `'granted'`), columna `resolved_by_discord_user` inexistente (migración `20260611` la agrega), y el grant nunca ejecutaba la acción.
+- Lección: al escribir selects/updates de Supabase, verificar columnas contra `supabase/migrations/`, no contra memoria.
 
 Docs canon:
 - [ADR-016 Third-Party Agent Integration](./adr/ADR-016-third-party-agent-integration.md)
-- [Sprint 5A Plan](./sprints/SPRINT_5A_PLAN.md)
-- Runbooks: `docs/runbooks/setup-discord-channel.md`, `setup-cloudflare-tunnel.md`, `alicia-skill-install.md`
-
-Decisiones canonizadas hoy:
-- **Solo Alicia conectada** (no los 7 ZXY agents). Andrés NO conectar (tech lead, no operador).
-- **Webhooks-first + polling safety net** (Cloudflare Tunnel `alicia.zxy.vc` + long-poll 30s).
-- **Repo separado** `openclaw-skill-baw-os` (no monorepo).
-- **Fase 5 original (CFDI/Stripe writes) movida a Fase 6**.
-- **Discord-first, in-app chat en Sprint 5B**.
-
-WS-1 (BaW OS server-side) arranca primero. WS-2 (skill OpenClaw) en paralelo. WS-3 runbooks listos para Fran ejecutar.
+- [ADR-021 Third-Party Agents Discord](./adr/ADR-021-third-party-agents-discord.md) (D8 cerrado)
+- [Sprint 5A Plan](./sprints/SPRINT_5A_PLAN.md) (alcance recortado a MVP — ver nota al inicio)
+- Runbooks: `setup-discord-channel.md`, `setup-cloudflare-tunnel.md`, `alicia-skill-install.md`, `hugo-cos-connect.md`
 
 ---
 

--- a/docs/adr/ADR-021-third-party-agents-discord.md
+++ b/docs/adr/ADR-021-third-party-agents-discord.md
@@ -95,11 +95,13 @@ Ejemplos:
 - Con unique constraint en DB, un segundo request con el mismo key falla a nivel DB antes de ejecutar la acción.
 - Complementa el middleware de idempotency que ya existe (`idempotency_keys` table) con tracking en el run level.
 
-### D8 — `resolved_by_discord_user` en agent_approvals (campo nuevo sin migración separada)
+### D8 — `resolved_by_discord_user` en agent_approvals ✅ CERRADO (2026-06-11)
 
-**Decisión**: Usar `UPDATE agent_approvals SET status='approved', resolved_at=now(), resolved_by_discord_user=:discord_user_id` al procesar botones.
+**Decisión**: Usar `UPDATE agent_approvals SET status='granted', resolved_at=now(), resolved_by_discord_user=:discord_user_id` al procesar botones grant.
 
-**Nota**: Si `resolved_by_discord_user` no existe en `agent_approvals`, el UPDATE ignorará el campo silenciosamente en Supabase. En la migración `20260523_agents_discord_interactions.sql` NO se agrega este campo porque no tenemos el schema exacto de `agent_approvals`. **Acción pendiente**: verificar schema de `agent_approvals` y agregar el campo si falta en la próxima migración.
+**Resolución (Sprint 5A MVP)**: el schema de `agent_approvals` se verificó — el campo no existía y PostgREST falla (no ignora) columnas desconocidas, lo que rompía los botones. La migración `20260611_agent_approvals_discord_resolver.sql` agrega `resolved_by_discord_user TEXT`. Además se corrigió el status a `'granted'` (el CHECK de la tabla no admite `'approved'`) y el grant ahora ejecuta la acción vía `dispatchApprovedAction()` con el mismo contrato que `POST /v1/approvals/:id/grant`.
+
+**custom_id (actualiza D4)**: el formato canónico para botones de aprobación es `baw:<agent_id>:approval:<grant|deny>:<approval_id>`; el servidor acepta el formato legacy `baw:approval:<grant|deny>:<approval_id>` durante la transición.
 
 ---
 
@@ -113,7 +115,7 @@ Ejemplos:
 
 ### Negativas / Pendientes
 - El endpoint `/api/agents/discord-interactions/process` (procesamiento async para followup Discord) no se construye en WS-1 — requiere la integración con la skill OpenClaw de Alicia (WS-2).
-- El campo `resolved_by_discord_user` en `agent_approvals` requiere verificación de schema antes de aplicar.
+- ~~El campo `resolved_by_discord_user` en `agent_approvals` requiere verificación de schema antes de aplicar.~~ Resuelto: migración `20260611_agent_approvals_discord_resolver.sql`.
 
 ### Decisiones futuras que este ADR deja abiertas
 - Rate limiting por agente en el endpoint Discord (Sprint 5B).

--- a/docs/runbooks/hugo-cos-connect.md
+++ b/docs/runbooks/hugo-cos-connect.md
@@ -1,0 +1,81 @@
+# Runbook — Conectar a Hugo (hugo-cos) como supervisor read-only
+
+**Audience**: Fran
+**Estimated time**: 15 min
+**Sprint**: 5A MVP
+**Prerequisite**:
+- Alicia conectada y operando (runbooks `alicia-skill-install.md` + `setup-discord-channel.md` completos)
+- Fix de `GET /v1/runs` deployado (Sprint 5A MVP)
+- Skill `openclaw-skill-baw-os` con soporte de persona Hugo (lado Codex)
+
+## Rol de Hugo en el MVP
+
+Hugo (`hugo-cos`) es el **supervisor de Alicia**: ve sus runs, sus aprobaciones
+y las métricas de la org, y publica resúmenes/digests en Discord. En el MVP:
+
+- **Solo lectura.** Hugo NUNCA recibe scopes `*:write`, `approvals:resolve` ni `agents:run`.
+- **No aprueba acciones.** Las aprobaciones REQUIRE_APPROVAL las resuelve solo Fran
+  (botones Discord o UI).
+- **No dispara a Alicia.** La delegación supervisor→worker queda para un sprint posterior.
+
+## Steps
+
+### 1. Emitir la credencial de Hugo
+
+1. Entra a `https://baw-os.vercel.app/agents/hugo-cos/credentials` (sesión owner/admin).
+2. Crea una credencial con label `prod` y **exactamente** estos scopes:
+   - `runs:read`
+   - `approvals:read`
+   - `insights:read`
+3. Copia la key `sk_live_...` — **se muestra una sola vez**.
+
+### 2. Configurar el skill (lado Hugo)
+
+En el `.env` del skill en la máquina donde corre Hugo:
+
+```env
+BAW_OS_API_URL=https://baw-os.vercel.app
+BAW_OS_HUGO_API_KEY=sk_live_...   # la key del paso 1
+```
+
+### 3. Smoke tests (verificación positiva)
+
+Con la credencial de Hugo, los tres endpoints read-only deben responder 200:
+
+```bash
+KEY="sk_live_..."
+BASE="https://baw-os.vercel.app"
+
+curl -s -H "Authorization: Bearer $KEY" "$BASE/api/v1/runs?agent_id=alicia-ops&limit=5"
+curl -s -H "Authorization: Bearer $KEY" "$BASE/api/v1/approvals?status=all&agent_id=alicia-ops"
+curl -s -H "Authorization: Bearer $KEY" "$BASE/api/v1/insights/summary"
+```
+
+### 4. Verificación negativa (obligatoria)
+
+La misma credencial debe recibir **403 `forbidden_scope`** en cualquier write:
+
+```bash
+# Debe fallar con 403:
+curl -s -X POST -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"title":"test"}' "$BASE/api/v1/incidents"
+
+# Debe fallar con 403:
+curl -s -X POST -H "Authorization: Bearer $KEY" \
+  "$BASE/api/v1/approvals/00000000-0000-0000-0000-000000000000/grant"
+```
+
+Si alguno de estos devuelve algo distinto de 403, **revoca la credencial
+inmediatamente** en `/agents/hugo-cos/credentials` y revisa los scopes.
+
+### 5. Digest en Discord
+
+El digest lo compone y publica el **skill** (no hay endpoint de digest
+server-side): el skill consulta los tres GET y arma el resumen con footer
+de atribución "via Hugo · BaW OS Agent · Discord". Frecuencia sugerida:
+1 digest diario + alerta inmediata si hay approvals pendientes >2h.
+
+## Rollback
+
+Revocar la credencial en `/agents/hugo-cos/credentials` → Hugo pierde acceso
+de inmediato. No hay nada más que limpiar (Hugo no escribe datos).

--- a/docs/sprints/SPRINT_5A_PLAN.md
+++ b/docs/sprints/SPRINT_5A_PLAN.md
@@ -1,8 +1,10 @@
 # Sprint 5A — Conversational Agent Runtime (Alicia third-party)
 
-**Status**: WS-1 In Progress — WS-2/3/4 Planned
+> **⚠️ ALCANCE ACTUALIZADO (2026-06-11) — Sprint 5A MVP.** Fran simplificó el plan: el MVP conecta **Alicia (operadora Mateos 809P) + Hugo (supervisor solo-lectura de Alicia)** y la UI `/agents` muestra únicamente third-party (los nativos quedan en DB, ocultos; cobranza pasa a cron interno). El non-goal "no Hugo" de abajo queda superado — Hugo SÍ se conecta, pero solo con `runs:read, approvals:read, insights:read` (ver `docs/runbooks/hugo-cos-connect.md`). División: Claude Fable 5 → repo `baw-os` (server-side completado 2026-06-11); Codex → `openclaw-skill-baw-os`. Estado vivo en `docs/PROJECT_STATE.md` §1.
+
+**Status**: WS-1 ✅ Complete (servidor, 2026-06-11) — WS-2 (Codex) In Progress — WS-3/4 Pending Fran
 **Start**: 2026-05-03
-**Target end**: 2026-05-07 (4 days)
+**Target end**: 2026-05-07 (4 days) → re-planificado 2026-06-11
 **Owner**: Computer (this AI), supervised by Fran
 **Related ADR**: [ADR-016](../adr/ADR-016-third-party-agent-integration.md)
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/check-design-tokens.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -1,0 +1,32 @@
+// BaW OS — Pre-build guard: verifica que el submodule design/baw-design esté
+// inicializado antes de compilar. Sin esto, un submodule faltante muere con un
+// error CSS críptico en `@import "../../design/baw-design/tokens/index.css"`.
+// Corre automáticamente vía `prebuild` en package.json (local y Vercel).
+
+import { statSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const tokensPath = resolve(process.cwd(), 'design/baw-design/tokens/index.css')
+
+let ok = false
+try {
+  ok = statSync(tokensPath).size > 0
+} catch {
+  ok = false
+}
+
+if (!ok) {
+  console.error('')
+  console.error('✗ design/baw-design/tokens/index.css no existe o está vacío.')
+  console.error('')
+  console.error('  El submodule `design/baw-design` no está inicializado. Corre:')
+  console.error('')
+  console.error('    git submodule update --init --recursive')
+  console.error('')
+  console.error('  En Vercel: verifica que el deploy tenga acceso al repo')
+  console.error('  zxy-vc/baw-design y que installCommand incluya el submodule init.')
+  console.error('')
+  process.exit(1)
+}
+
+console.log('✓ design tokens OK (submodule baw-design inicializado)')

--- a/src/app/agents/[id]/credentials/CredentialsManager.tsx
+++ b/src/app/agents/[id]/credentials/CredentialsManager.tsx
@@ -45,6 +45,10 @@ const COMMON_SCOPES = [
   'insights:read',
   'messages:send',
   'messages:read',
+  'approvals:read',
+  'agents:read',
+  'interactions:read',
+  'interactions:write',
 ]
 
 export default function CredentialsManager({

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -46,17 +46,31 @@ async function loadData() {
     orgId = null
   }
 
+  // MVP Sprint 5A: la UI muestra solo agentes third-party. Los agentes
+  // nativos (baw-coord, ops-core, experiencia, inteligencia) permanecen en
+  // DB y el runner de cobranza sigue corriendo como automatización interna,
+  // pero no se presentan como agentes en el catálogo. 'zxy-shared' es alias
+  // legacy de third-party.
   const { data: agentsData } = await supabase
     .from('agents')
     .select('*')
+    .in('family', ['third-party', 'zxy-shared'])
     .order('family')
     .order('display_name')
 
   let runs: AgentRunRow[] = []
   let approvals: import('./ApprovalQueueClient').ApprovalRow[] = []
   let policies: { agent_id: string; autonomy_level: number; active: boolean }[] = []
+  let connectedIds = new Set<string>()
 
   if (orgId) {
+    const { data: credsData } = await supabase
+      .from('agent_credentials')
+      .select('agent_id')
+      .eq('org_id', orgId)
+      .eq('status', 'active')
+    connectedIds = new Set((credsData || []).map((c) => c.agent_id as string))
+
     const [runsRes, approvalsRes, policiesRes] = await Promise.all([
       supabase
         .from('agent_runs')
@@ -93,7 +107,7 @@ async function loadData() {
     autonomy_level: policyMap.get(a.id)?.autonomy_level ?? 1,
   }))
 
-  return { agents, runs, approvals, orgId }
+  return { agents, runs, approvals, orgId, connectedIds }
 }
 
 // Modelo de agentes según Roster v0.2 (Notion canónico):
@@ -124,6 +138,59 @@ const FAMILY_DESC: Record<string, string> = {
 }
 
 const FAMILY_ORDER = ['baw-coord', 'ops-core', 'experiencia', 'inteligencia', 'third-party', 'pm-ops', 'zxy-shared']
+
+// MVP Sprint 5A: agentes third-party activos y su rol operativo.
+// Los demás third-party quedan diferidos (Sprint 5B+).
+const MVP_AGENT_ROLES: Record<string, string> = {
+  'alicia-ops': 'Operadora · Mateos 809P',
+  'hugo-cos': 'Supervisor de Alicia · solo lectura',
+}
+
+function ConnectionBadge({
+  connected,
+  isMvpAgent,
+}: {
+  connected: boolean
+  isMvpAgent: boolean
+}) {
+  if (connected) {
+    return (
+      <span
+        className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full"
+        style={{
+          backgroundColor: 'var(--baw-success-bg-soft)',
+          color: 'var(--baw-success-fg)',
+        }}
+      >
+        Conectado
+      </span>
+    )
+  }
+  if (isMvpAgent) {
+    return (
+      <span
+        className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full"
+        style={{
+          backgroundColor: 'var(--baw-warning-bg-soft)',
+          color: 'var(--baw-warning-fg)',
+        }}
+      >
+        Por conectar
+      </span>
+    )
+  }
+  return (
+    <span
+      className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full"
+      style={{
+        backgroundColor: 'var(--baw-neutral-bg-soft)',
+        color: 'var(--baw-neutral-fg)',
+      }}
+    >
+      Diferido
+    </span>
+  )
+}
 
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, { bg: string; fg: string }> = {
@@ -164,7 +231,7 @@ function RunStatusBadge({ status }: { status: string }) {
 }
 
 export default async function AgentsPage() {
-  const { agents, runs, approvals, orgId } = await loadData()
+  const { agents, runs, approvals, orgId, connectedIds } = await loadData()
   // approvals usado solo en Modo Agent; lo declaramos aquí para tipado.
   void approvals
   const implemented = new Set<string>(listImplementedAgents())
@@ -201,7 +268,7 @@ export default async function AgentsPage() {
           className="text-[11px] uppercase tracking-wider"
           style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
         >
-          BaW + 10 especialistas en 3 escuadrones · Operaciones Core · Experiencia · Inteligencia · Third Party · Roster v0.2 · v1: Cobranza dunning
+          Agentes third-party conectados a BaW OS · Alicia opera Mateos 809P · Hugo supervisa · Sprint 5A MVP
         </p>
         <div className="mt-3">
           <ViewModeSwitch initialMode={viewMode} />
@@ -228,13 +295,17 @@ export default async function AgentsPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
             {list.map((a) => {
               const isImpl = implemented.has(a.id)
+              const isMvpAgent = a.id in MVP_AGENT_ROLES
+              const connected = connectedIds.has(a.id)
               return (
                 <div
                   key={a.id}
                   className="rounded-lg p-4 flex flex-col gap-3"
                   style={{
                     backgroundColor: 'var(--baw-surface)',
-                    border: '1px solid var(--baw-border)',
+                    border: isMvpAgent
+                      ? '1px solid var(--baw-accent)'
+                      : '1px solid var(--baw-border)',
                   }}
                 >
                   <div className="flex items-start justify-between gap-2">
@@ -249,10 +320,13 @@ export default async function AgentsPage() {
                         className="text-[11px] mt-0.5"
                         style={{ color: 'var(--baw-muted)' }}
                       >
-                        {a.domain} · L{a.capability_level} · F{a.feedback_level}
+                        {MVP_AGENT_ROLES[a.id] ?? a.domain} · L{a.capability_level} · F{a.feedback_level}
                       </div>
                     </div>
-                    <StatusBadge status={a.status} />
+                    <div className="flex flex-col items-end gap-1">
+                      <ConnectionBadge connected={connected} isMvpAgent={isMvpAgent} />
+                      <StatusBadge status={a.status} />
+                    </div>
                   </div>
                   {a.description && (
                     <p
@@ -264,12 +338,20 @@ export default async function AgentsPage() {
                   )}
                   {isImpl && orgId ? (
                     <AgentRunButton agentId={a.id} agentName={a.display_name} />
+                  ) : orgId && isMvpAgent ? (
+                    <Link
+                      href={`/agents/${a.id}/credentials`}
+                      className="text-[11px] underline"
+                      style={{ color: 'var(--baw-accent)' }}
+                    >
+                      {connected ? 'Gestionar credenciales →' : 'Conectar (emitir credencial) →'}
+                    </Link>
                   ) : (
                     <div
                       className="text-[11px] italic"
                       style={{ color: 'var(--baw-muted)' }}
                     >
-                      {!orgId ? 'requiere sesión activa' : 'pendiente de implementación'}
+                      {!orgId ? 'requiere sesión activa' : 'diferido · se conecta en un sprint posterior'}
                     </div>
                   )}
                 </div>

--- a/src/app/api/agents/discord-interactions/process/route.ts
+++ b/src/app/api/agents/discord-interactions/process/route.ts
@@ -1,0 +1,175 @@
+/**
+ * BaW OS — Procesamiento async de interacciones Discord (Sprint 5A MVP)
+ * POST /api/agents/discord-interactions/process
+ *
+ * Lo invoca el endpoint principal de Discord Interactions vía dispatchAsync()
+ * (fire-and-forget, autenticado con INTERNAL_WEBHOOK_SECRET). Flujo:
+ *  1. Valida el bearer interno (timing-safe).
+ *  2. Marca la interacción como 'processing' y backfillea org_id.
+ *  3. Push webhooks-first al runtime del agente (ALICIA_WEBHOOK_URL, tunnel
+ *     Cloudflare). El runtime procesa y responde a Discord vía followup.
+ *  4. Si el push falla (runtime dormido/inaccesible), deja la interacción en
+ *     'deferred' — la recoge el long-poll del skill (GET /v1/interactions) —
+ *     y avisa en Discord que la solicitud quedó en cola.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { withAgentAttribution, getAgentDisplayName } from '@/lib/agents/attribution'
+import type { AgentId } from '@/lib/agents/types'
+
+export const runtime = 'nodejs'
+
+const AGENT_PUSH_TIMEOUT_MS = 5_000
+
+interface ProcessBody {
+  interaction_id?: string
+  interaction_token?: string
+  agent_id?: string
+  raw_interaction?: Record<string, unknown>
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}
+
+function isAuthorized(req: NextRequest): boolean {
+  const secret = process.env.INTERNAL_WEBHOOK_SECRET
+  if (!secret) return false
+  const auth = req.headers.get('authorization') ?? ''
+  if (!auth.startsWith('Bearer ')) return false
+  return timingSafeEqual(auth.slice('Bearer '.length), secret)
+}
+
+/**
+ * Followup a Discord usando el token de la interacción (válido 15 min).
+ * Best-effort: un fallo aquí no debe romper el pipeline.
+ */
+async function discordFollowup(
+  applicationId: string,
+  interactionToken: string,
+  content: string
+): Promise<void> {
+  try {
+    await fetch(
+      `https://discord.com/api/v10/webhooks/${applicationId}/${interactionToken}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+        signal: AbortSignal.timeout(5_000),
+      }
+    )
+  } catch (err) {
+    console.error('discord followup failed:', err)
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: ProcessBody
+  try {
+    body = (await req.json()) as ProcessBody
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { interaction_id: interactionId, interaction_token: interactionToken } = body
+  const agentId = body.agent_id ?? 'alicia-ops'
+  const rawInteraction = body.raw_interaction ?? {}
+
+  if (!interactionId || !interactionToken) {
+    return NextResponse.json(
+      { error: 'interaction_id and interaction_token are required' },
+      { status: 400 }
+    )
+  }
+
+  const supabase = createServiceClient()
+
+  // ── 2. Backfill org_id + marcar processing ────────────────
+  // logInteraction() inserta con org_id null; aquí lo resolvemos. MVP: una
+  // sola org Discord-conectada (BaW Operations) vía env. El mapeo
+  // guild_id → org queda como follow-up multi-tenant.
+  const defaultOrgId = process.env.DISCORD_DEFAULT_ORG_ID ?? null
+
+  const { data: interaction } = await supabase
+    .from('agent_interactions')
+    .update({
+      status: 'processing',
+      ...(defaultOrgId ? { org_id: defaultOrgId } : {}),
+    })
+    .eq('interaction_id', interactionId)
+    .select('id, org_id, agent_id, payload')
+    .maybeSingle()
+
+  if (!interaction) {
+    return NextResponse.json(
+      { error: `interaction ${interactionId} not found` },
+      { status: 404 }
+    )
+  }
+
+  // ── 3. Push webhooks-first al runtime del agente ──────────
+  const agentWebhookUrl = process.env.ALICIA_WEBHOOK_URL ?? ''
+  let pushed = false
+
+  if (agentWebhookUrl) {
+    try {
+      const res = await fetch(agentWebhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          interaction_id: interactionId,
+          interaction_token: interactionToken,
+          agent_id: agentId,
+          raw_interaction: rawInteraction,
+        }),
+        signal: AbortSignal.timeout(AGENT_PUSH_TIMEOUT_MS),
+      })
+      pushed = res.ok
+    } catch {
+      pushed = false
+    }
+  }
+
+  if (pushed) {
+    // El runtime confirmó recepción; él hace el followup a Discord y luego
+    // cierra la interacción vía PATCH /v1/interactions/:id.
+    return NextResponse.json({ ok: true, delivery: 'push' })
+  }
+
+  // ── 4. Fallback: deferred + aviso en Discord ──────────────
+  await supabase
+    .from('agent_interactions')
+    .update({ status: 'deferred' })
+    .eq('id', interaction.id as string)
+
+  const applicationId =
+    typeof rawInteraction.application_id === 'string'
+      ? rawInteraction.application_id
+      : null
+  if (applicationId) {
+    const displayName = getAgentDisplayName(agentId as AgentId)
+    const content = withAgentAttribution(
+      `⏳ ${displayName} está fuera de línea en este momento. Tu solicitud quedó en cola y se procesará en cuanto se reconecte.`,
+      {
+        agentId: agentId as AgentId,
+        agentDisplayName: displayName,
+        channel: 'discord',
+        interactionId,
+      }
+    )
+    await discordFollowup(applicationId, interactionToken, content)
+  }
+
+  return NextResponse.json({ ok: true, delivery: 'deferred' })
+}

--- a/src/app/api/agents/discord-interactions/route.ts
+++ b/src/app/api/agents/discord-interactions/route.ts
@@ -18,6 +18,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createServiceClient } from '@/lib/supabase'
 import { verifyDiscordRequest } from '@/lib/agents/discord-verify'
 import { getAgentDisplayName } from '@/lib/agents/attribution'
+import { dispatchApprovedAction } from '@/lib/agents/v1/dispatcher'
 
 export const runtime = 'nodejs'
 
@@ -71,14 +72,53 @@ interface DiscordInteraction {
 function resolveAgentId(interaction: DiscordInteraction): string {
   const customId = interaction.data?.custom_id ?? ''
 
-  // Formato custom_id: "baw:<agent_id>:<action>:<payload...>"
+  // Formato canónico: "baw:<agent_id>:<action>:<payload...>" (ADR-021 D4)
+  // Formato legacy: "baw:approval:<grant|deny>:<id>" — sin agent_id, no confundir
   if (customId.startsWith('baw:')) {
     const parts = customId.split(':')
-    if (parts[1]) return parts[1]
+    if (parts[1] && parts[1] !== 'approval') return parts[1]
   }
 
   // Default: alicia-ops (única agente third-party conectada en Sprint 5A)
   return 'alicia-ops'
+}
+
+interface ApprovalCustomId {
+  action: 'grant' | 'deny'
+  approvalId: string
+}
+
+/**
+ * Parsea el custom_id de botones de aprobación.
+ * Canónico: baw:<agent_id>:approval:<grant|deny>:<approval_id>
+ * Legacy:   baw:approval:<grant|deny>:<approval_id>
+ */
+function parseApprovalCustomId(customId: string): ApprovalCustomId | null {
+  if (!customId.startsWith('baw:')) return null
+  const parts = customId.split(':')
+
+  let action: string | undefined
+  let approvalId: string | undefined
+  if (parts[1] === 'approval') {
+    action = parts[2]
+    approvalId = parts[3]
+  } else if (parts[2] === 'approval') {
+    action = parts[3]
+    approvalId = parts[4]
+  } else {
+    return null
+  }
+
+  if (!approvalId || (action !== 'grant' && action !== 'deny')) return null
+  return { action, approvalId }
+}
+
+/** Respuesta efímera (solo visible para quien hizo click). */
+function ephemeralMessage(content: string): NextResponse {
+  return NextResponse.json({
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: { content, flags: 64 },
+  })
 }
 
 /**
@@ -221,63 +261,144 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       JSON.parse(rawBody) as Record<string, unknown>
     )
 
-    // Procesamos aprobaciones inline (grant/deny son idempotentes y rápidos)
-    if (customId.startsWith('baw:approval:')) {
-      // Formato: baw:approval:grant:<approval_id> | baw:approval:deny:<approval_id>
-      const parts = customId.split(':')
-      const action = parts[2] as 'grant' | 'deny'
-      const approvalId = parts[3]
-
-      if (!approvalId || !['grant', 'deny'].includes(action)) {
-        return NextResponse.json(
-          {
-            type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-            data: {
-              content: '⚠️ ID de aprobación inválido.',
-              flags: 64, // ephemeral
-            },
-          }
-        )
+    // Procesamos aprobaciones inline (mismo contrato que /v1/approvals/:id/grant|deny)
+    const isApprovalComponent =
+      customId.startsWith('baw:approval:') || customId.split(':')[2] === 'approval'
+    if (isApprovalComponent) {
+      const parsed = parseApprovalCustomId(customId)
+      if (!parsed) {
+        return ephemeralMessage('⚠️ ID de aprobación inválido.')
       }
+      const { action, approvalId } = parsed
 
-      // Ejecutar grant/deny en agent_approvals
       try {
         const supabase = createServiceClient()
-        const newStatus = action === 'grant' ? 'approved' : 'denied'
         const discordUserId =
           interaction.member?.user?.id ?? interaction.user?.id ?? 'unknown'
+        const nowIso = new Date().toISOString()
 
-        const { error } = await supabase
+        const { data: approval, error: loadError } = await supabase
+          .from('agent_approvals')
+          .select('id, org_id, agent_id, action_type, payload, status, expires_at')
+          .eq('id', approvalId)
+          .maybeSingle()
+
+        if (loadError) throw loadError
+        if (!approval) {
+          return ephemeralMessage('⚠️ Aprobación no encontrada.')
+        }
+        if (approval.status !== 'pending') {
+          return ephemeralMessage(
+            `⚠️ Esta solicitud ya fue resuelta (estado: ${approval.status}).`
+          )
+        }
+        if (new Date(approval.expires_at as string).getTime() < Date.now()) {
+          await supabase
+            .from('agent_approvals')
+            .update({ status: 'expired', resolved_at: nowIso })
+            .eq('id', approvalId)
+            .eq('status', 'pending')
+          return ephemeralMessage('⚠️ La solicitud expiró antes de resolverse.')
+        }
+
+        if (action === 'deny') {
+          const { error } = await supabase
+            .from('agent_approvals')
+            .update({
+              status: 'denied',
+              resolved_at: nowIso,
+              resolved_by_discord_user: discordUserId,
+            })
+            .eq('id', approvalId)
+            .eq('status', 'pending') // Solo pendientes — previene doble-click
+          if (error) throw error
+
+          return NextResponse.json({
+            type: InteractionResponseType.UPDATE_MESSAGE,
+            data: {
+              content: '❌ Solicitud **denegada**.',
+              components: [], // Elimina los botones del mensaje original
+            },
+          })
+        }
+
+        // grant: ejecutar la acción aprobada vía dispatcher
+        const dispatch = await dispatchApprovedAction({
+          approvalId,
+          orgId: approval.org_id as string,
+          agentId: approval.agent_id as string,
+          actionType: approval.action_type as string,
+          payload: (approval.payload as Record<string, unknown>) || {},
+          resolvedBy: `discord:${discordUserId}`,
+        })
+
+        // Persistir resolución (si dispatch falla, mantenemos pending para retry)
+        await supabase
           .from('agent_approvals')
           .update({
-            status: newStatus,
-            resolved_at: new Date().toISOString(),
-            resolved_by_discord_user: discordUserId,
+            status: dispatch.ok ? 'granted' : 'pending',
+            resolved_at: dispatch.ok ? nowIso : null,
+            resolved_by_discord_user: dispatch.ok ? discordUserId : null,
+            result: dispatch.ok
+              ? (dispatch.result as object)
+              : ({ error: dispatch.error } as object),
           })
           .eq('id', approvalId)
-          .eq('status', 'pending') // Solo pendientes — previene doble-click
+          .eq('status', 'pending')
 
-        if (error) throw error
+        // Audit como agent_run + agent_action (mismo patrón que /v1 grant)
+        const { data: run } = await supabase
+          .from('agent_runs')
+          .insert({
+            org_id: approval.org_id,
+            agent_id: approval.agent_id,
+            triggered_by: 'agent',
+            status: dispatch.ok ? 'succeeded' : 'failed',
+            input: {
+              approval_id: approvalId,
+              action_type: approval.action_type,
+              resolved_via: 'discord',
+            } as object,
+            output: dispatch.ok
+              ? ((dispatch.result || {}) as object)
+              : ({ error: dispatch.error } as object),
+            finished_at: nowIso,
+            error: dispatch.ok ? null : dispatch.error,
+          })
+          .select('id')
+          .single()
 
-        const emoji = action === 'grant' ? '✅' : '❌'
-        const label = action === 'grant' ? 'aprobado' : 'denegado'
+        if (run) {
+          await supabase.from('agent_actions').insert({
+            run_id: run.id as string,
+            org_id: approval.org_id,
+            agent_id: approval.agent_id,
+            action_type: approval.action_type,
+            entity_type: dispatch.entityType ?? null,
+            entity_id: dispatch.entityId ?? null,
+            status: dispatch.ok ? 'ok' : 'failed',
+            payload: (approval.payload || {}) as object,
+            result: (dispatch.result || {}) as object,
+            error: dispatch.error ?? null,
+          })
+        }
+
+        if (!dispatch.ok) {
+          return ephemeralMessage(
+            `⚠️ Aprobación recibida pero la ejecución falló: ${dispatch.error}. La solicitud sigue pendiente.`
+          )
+        }
 
         return NextResponse.json({
           type: InteractionResponseType.UPDATE_MESSAGE,
           data: {
-            content: `${emoji} Solicitud **${label}**.`,
+            content: '✅ Solicitud **aprobada** y ejecutada.',
             components: [], // Elimina los botones del mensaje original
           },
         })
       } catch (err) {
         console.error('approval resolution failed:', err)
-        return NextResponse.json({
-          type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-          data: {
-            content: '⚠️ Error al procesar la aprobación. Intenta de nuevo.',
-            flags: 64,
-          },
-        })
+        return ephemeralMessage('⚠️ Error al procesar la aprobación. Intenta de nuevo.')
       }
     }
 

--- a/src/app/api/cron/cobranza/route.ts
+++ b/src/app/api/cron/cobranza/route.ts
@@ -1,0 +1,52 @@
+// BaW OS — GET /api/cron/cobranza · automatización interna de mora
+// Sprint 5A MVP: el runner de cobranza ya no se invoca desde la UI de agentes
+// (catálogo muestra solo third-party); este cron diario lo mantiene operando
+// como automatización del sistema. Dry-run por defecto (v1 del runner);
+// ejecutar con ?dry_run=false para escalar mora de verdad.
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { cobranzaRunner } from '@/lib/agents/cobranza'
+import { executeAgentRun } from '@/lib/agents/runner'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization')
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const url = new URL(request.url)
+  const dryRun = url.searchParams.get('dry_run') !== 'false'
+
+  const supabase = createServiceClient()
+  const { data: orgs, error } = await supabase.from('organizations').select('id')
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!orgs || orgs.length === 0) {
+    return NextResponse.json({ message: 'No organizations', runs: [] })
+  }
+
+  const runs: Array<{ org_id: string; run_id?: string; status: string; error?: string }> = []
+  for (const org of orgs) {
+    const orgId = org.id as string
+    try {
+      const result = await executeAgentRun(cobranzaRunner, {
+        orgId,
+        agentId: 'cobranza',
+        triggeredBy: 'cron',
+        input: { dry_run: dryRun },
+      })
+      runs.push({ org_id: orgId, run_id: result.runId, status: result.status })
+    } catch (e) {
+      runs.push({
+        org_id: orgId,
+        status: 'failed',
+        error: e instanceof Error ? e.message : 'run_failed',
+      })
+    }
+  }
+
+  return NextResponse.json({ message: 'OK', dry_run: dryRun, runs })
+}

--- a/src/app/api/owner/[token]/route.ts
+++ b/src/app/api/owner/[token]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-import { getOrgIdAsync } from '@/lib/api-auth'
+import { resolveOrgIdForWebhook } from '@/lib/org-context'
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ||
@@ -25,7 +25,7 @@ function createPortalClient() {
 }
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { token: string } }
 ) {
   if (!LEGACY_ENABLED) {
@@ -46,7 +46,15 @@ export async function GET(
   }
 
   const supabase = createPortalClient()
-  const ORG_ID = await getOrgIdAsync()
+  // issue #22: org explícita vía header/`?org=<slug>`, no el shim "primera org".
+  // Endpoint legacy flag-gated; quien reactive el flag debe pasar la org.
+  const ORG_ID = await resolveOrgIdForWebhook(request)
+  if (!ORG_ID) {
+    return NextResponse.json(
+      { error: 'org requerida', message: 'Agrega ?org=<slug> a la URL.' },
+      { status: 400 },
+    )
+  }
   const now = new Date()
   const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split('T')[0]
   const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().split('T')[0]

--- a/src/app/api/portal/[token]/incident/route.ts
+++ b/src/app/api/portal/[token]/incident/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createServiceClient, getOrgId } from '@/lib/api-auth'
+import { createServiceClient } from '@/lib/api-auth'
 
 export async function POST(
   request: NextRequest,
@@ -11,7 +11,7 @@ export async function POST(
   // Validate token and get contract
   const { data: contract, error: contractError } = await supabase
     .from('contracts')
-    .select('id, unit_id')
+    .select('id, unit_id, org_id')
     .eq('portal_token', token)
     .eq('portal_enabled', true)
     .single()
@@ -36,7 +36,9 @@ export async function POST(
   const { data, error } = await supabase
     .from('incidents')
     .insert({
-      org_id: getOrgId(),
+      // issue #22: el token ya identifica al contract → su org_id es la fuente
+      // correcta, no el shim legacy de "primera org"
+      org_id: contract.org_id,
       unit_id: contract.unit_id,
       title: category,
       description,

--- a/src/app/api/tenant/[token]/incident/route.ts
+++ b/src/app/api/tenant/[token]/incident/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createServiceClient, getOrgId } from '@/lib/api-auth'
+import { createServiceClient } from '@/lib/api-auth'
 
 export async function POST(
   request: NextRequest,
@@ -11,7 +11,7 @@ export async function POST(
   // Validate token and get contract
   const { data: contract, error: contractError } = await supabase
     .from('contracts')
-    .select('id, unit_id')
+    .select('id, unit_id, org_id')
     .eq('portal_token', token)
     .eq('portal_enabled', true)
     .single()
@@ -36,7 +36,9 @@ export async function POST(
   const { data, error } = await supabase
     .from('incidents')
     .insert({
-      org_id: getOrgId(),
+      // issue #22: el token ya identifica al contract → su org_id es la fuente
+      // correcta, no el shim legacy de "primera org"
+      org_id: contract.org_id,
       unit_id: contract.unit_id,
       title: category,
       description,

--- a/src/app/api/v1/interactions/[id]/route.ts
+++ b/src/app/api/v1/interactions/[id]/route.ts
@@ -1,0 +1,64 @@
+// BaW OS v1 — PATCH /v1/interactions/:id
+// El skill del agente cierra una interacción que procesó vía long-poll o push:
+// status 'completed' (con response) o 'failed' (con error). Telemetría del
+// pipeline Discord — no pasa por classifier/approvals (no es acción de negocio).
+import { NextRequest, NextResponse } from 'next/server'
+import { authenticateAgentRequest, agentAuthErrorResponse } from '@/lib/agents/auth'
+import { v1Ok, v1Error } from '@/lib/agents/v1/responses'
+import { createServiceClient } from '@/lib/supabase'
+
+function extractId(req: NextRequest): string | null {
+  const m = req.nextUrl.pathname.match(/\/v1\/interactions\/([^/]+)/)
+  return m?.[1] ?? null
+}
+
+interface PatchBody {
+  status?: string
+  response?: Record<string, unknown>
+  error?: string
+}
+
+export async function PATCH(req: NextRequest): Promise<NextResponse> {
+  const auth = await authenticateAgentRequest(req, ['interactions:write'])
+  if (!auth.ok) return agentAuthErrorResponse(auth)
+
+  const id = extractId(req)
+  if (!id) return v1Error('invalid_path', 'interaction id missing', 400)
+
+  let body: PatchBody
+  try {
+    body = (await req.json()) as PatchBody
+  } catch {
+    return v1Error('invalid_json', 'body must be valid JSON', 400)
+  }
+
+  if (body.status !== 'completed' && body.status !== 'failed') {
+    return v1Error('invalid_status', "status must be 'completed' or 'failed'", 400)
+  }
+
+  const supabase = createServiceClient()
+  const { data, error } = await supabase
+    .from('agent_interactions')
+    .update({
+      status: body.status,
+      response: body.response ?? null,
+      error: body.status === 'failed' ? (body.error ?? 'unknown error') : null,
+      completed_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('agent_id', auth.agentId) // cada agente solo cierra sus propias interacciones
+    .in('status', ['received', 'processing', 'deferred']) // no reabrir cerradas
+    .select('id, agent_id, status, completed_at')
+    .maybeSingle()
+
+  if (error) return v1Error('query_error', error.message, 500)
+  if (!data) {
+    return v1Error(
+      'not_found',
+      `interaction ${id} not found, not yours, or already closed`,
+      404
+    )
+  }
+
+  return v1Ok(data)
+}

--- a/src/app/api/v1/interactions/route.ts
+++ b/src/app/api/v1/interactions/route.ts
@@ -1,0 +1,58 @@
+// BaW OS v1 — GET /v1/interactions
+// Safety net de long-poll para el skill del agente: lista interacciones Discord
+// pendientes de procesar (deferred/processing) del propio agente. El payload
+// completo incluye application_id + token para que el skill haga el followup.
+// Filtros: status (CSV, default 'deferred,processing'), limit/cursor estándar.
+import { v1Read } from '@/lib/agents/v1/handler'
+import { v1Ok, v1Error } from '@/lib/agents/v1/responses'
+import { parsePagination, makeCursor } from '@/lib/agents/v1/pagination'
+import { createServiceClient } from '@/lib/supabase'
+
+const VALID_STATUSES = ['received', 'processing', 'deferred', 'completed', 'failed']
+
+export const GET = v1Read({
+  scopes: ['interactions:read'],
+  handler: async ({ auth, req }) => {
+    const { limit, afterTs } = parsePagination(req)
+    const statusParam = req.nextUrl.searchParams.get('status') || 'deferred,processing'
+    const statuses = statusParam
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => VALID_STATUSES.includes(s))
+    if (statuses.length === 0) {
+      return v1Error(
+        'invalid_status',
+        `status must be CSV of: ${VALID_STATUSES.join(', ')}`,
+        400
+      )
+    }
+
+    const supabase = createServiceClient()
+    let q = supabase
+      .from('agent_interactions')
+      .select(
+        'id, agent_id, org_id, channel, channel_id, interaction_type, interaction_id, discord_guild_id, discord_user_id, payload, status, error, created_at, completed_at'
+      )
+      .eq('agent_id', auth.agentId) // cada agente solo ve sus propias interacciones
+      .in('status', statuses)
+      .order('created_at', { ascending: true }) // FIFO: procesar lo más viejo primero
+      .order('id', { ascending: true })
+      .limit(limit + 1)
+
+    if (afterTs) q = q.gt('created_at', afterTs)
+
+    const { data, error } = await q
+    if (error) return v1Error('query_error', error.message, 500)
+
+    const rows = data || []
+    const hasMore = rows.length > limit
+    const trimmed = hasMore ? rows.slice(0, limit) : rows
+    const last = trimmed[trimmed.length - 1]
+    const next_cursor =
+      hasMore && last
+        ? makeCursor({ id: last.id as string, created_at: last.created_at as string })
+        : null
+
+    return v1Ok(trimmed, { next_cursor, limit })
+  },
+})

--- a/src/app/api/v1/runs/route.ts
+++ b/src/app/api/v1/runs/route.ts
@@ -14,15 +14,17 @@ export const GET = v1Read({
 
     let q = supabase
       .from('agent_runs')
-      .select('id, org_id, agent_id, status, input, output, started_at, completed_at, created_at')
+      .select(
+        'id, org_id, agent_id, status, triggered_by, input, output, started_at, finished_at, duration_ms, metrics, error'
+      )
       .eq('org_id', auth.orgId)
-      .order('created_at', { ascending: false })
+      .order('started_at', { ascending: false })
       .order('id', { ascending: false })
       .limit(limit + 1)
 
     if (agentId) q = q.eq('agent_id', agentId)
     if (status) q = q.eq('status', status)
-    if (afterTs) q = q.lt('created_at', afterTs)
+    if (afterTs) q = q.lt('started_at', afterTs)
 
     const { data, error } = await q
     if (error) return v1Error('query_error', error.message, 500)
@@ -31,7 +33,10 @@ export const GET = v1Read({
     const hasMore = rows.length > limit
     const trimmed = hasMore ? rows.slice(0, limit) : rows
     const last = trimmed[trimmed.length - 1]
-    const next_cursor = hasMore && last ? makeCursor(last) : null
+    const next_cursor =
+      hasMore && last
+        ? makeCursor({ id: last.id as string, created_at: last.started_at as string })
+        : null
 
     return v1Ok(trimmed, { next_cursor, limit })
   },

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -1,6 +1,7 @@
 // BaW OS — WhatsApp Webhook (Meta Cloud API)
 import { NextRequest, NextResponse } from 'next/server'
-import { createServiceClient, getOrgId } from '@/lib/api-auth'
+import { createServiceClient } from '@/lib/api-auth'
+import { resolveOrgIdForWebhook } from '@/lib/org-context'
 
 const FAQS: Record<string, string> = {
   FAQ: 'Hola 👋 Soy el asistente de BaW. Para pagos usa la referencia de tu contrato. Para reportar una incidencia responde INCIDENCIA. Para hablar con un asesor responde ASESOR.',
@@ -45,12 +46,21 @@ export async function POST(request: NextRequest) {
     const body: string = message.text?.body ?? ''
     const messageId: string = message.id
 
+    // issue #22: derivar org del request (header/slug/query `?org=`), no del
+    // shim legacy "primera org". La URL del webhook en Meta se configura con
+    // `?org=<slug>`. Sin org no procesamos, pero respondemos 200 para no
+    // romper el handshake de Meta (que reintenta en 4xx/5xx).
+    const orgId = await resolveOrgIdForWebhook(request, payload)
+    if (!orgId) {
+      console.error('[whatsapp] org no resuelta — configura ?org=<slug> en la URL del webhook')
+      return NextResponse.json({ status: 'ok' })
+    }
+
     // Classify with Groq LLM
     const classification = await classifyMessage(body)
 
     // Audit log
     const supabase = createServiceClient()
-    const orgId = getOrgId()
 
     await supabase.from('audit_log').insert({
       org_id: orgId,

--- a/supabase/migrations/20260611_agent_approvals_discord_resolver.sql
+++ b/supabase/migrations/20260611_agent_approvals_discord_resolver.sql
@@ -1,0 +1,13 @@
+-- BaW OS — Sprint 5A MVP: resolver de aprobaciones desde Discord
+-- Cierra el pendiente de ADR-021 D8: persistir quién resolvió una aprobación
+-- desde un botón Discord (los Discord user IDs no son auth.users UUIDs,
+-- por eso es una columna TEXT separada de resolved_by).
+--
+-- Aditiva e idempotente. Rollback:
+--   ALTER TABLE public.agent_approvals DROP COLUMN IF EXISTS resolved_by_discord_user;
+
+ALTER TABLE public.agent_approvals
+  ADD COLUMN IF NOT EXISTS resolved_by_discord_user TEXT;
+
+COMMENT ON COLUMN public.agent_approvals.resolved_by_discord_user IS
+  'Discord user ID (snowflake) de quien resolvió la aprobación vía botón Discord. NULL si se resolvió por UI/API.';

--- a/supabase/migrations/20260611_agents_alicia_hugo_beta.sql
+++ b/supabase/migrations/20260611_agents_alicia_hugo_beta.sql
@@ -1,0 +1,12 @@
+-- BaW OS — Sprint 5A MVP: Alicia y Hugo pasan de 'planned' a 'beta'
+-- Son los dos únicos agentes third-party del MVP: Alicia opera Mateos 809P,
+-- Hugo la supervisa en modo solo-lectura. El resto del catálogo (nativos y
+-- otros ZXY) permanece 'planned' y oculto de la UI.
+--
+-- Aditiva e idempotente. Rollback:
+--   UPDATE public.agents SET status = 'planned' WHERE id IN ('alicia-ops','hugo-cos');
+
+UPDATE public.agents
+SET status = 'beta'
+WHERE id IN ('alicia-ops', 'hugo-cos')
+  AND status = 'planned';

--- a/tests/agents/discord-custom-id.test.mjs
+++ b/tests/agents/discord-custom-id.test.mjs
@@ -1,0 +1,107 @@
+// BaW OS — Tests del parser de custom_id de aprobaciones Discord (Sprint 5A MVP)
+// Pure-logic: espejo de parseApprovalCustomId/resolveAgentId en
+// src/app/api/agents/discord-interactions/route.ts — mantener en sync.
+//
+// Run: node tests/agents/discord-custom-id.test.mjs
+
+import { strict as assert } from 'node:assert'
+
+// ── Reimplementación (pure logic) ─────────────────────────────────────────────
+
+function parseApprovalCustomId(customId) {
+  if (!customId.startsWith('baw:')) return null
+  const parts = customId.split(':')
+
+  let action
+  let approvalId
+  if (parts[1] === 'approval') {
+    action = parts[2]
+    approvalId = parts[3]
+  } else if (parts[2] === 'approval') {
+    action = parts[3]
+    approvalId = parts[4]
+  } else {
+    return null
+  }
+
+  if (!approvalId || (action !== 'grant' && action !== 'deny')) return null
+  return { action, approvalId }
+}
+
+function resolveAgentId(customId) {
+  if (customId.startsWith('baw:')) {
+    const parts = customId.split(':')
+    if (parts[1] && parts[1] !== 'approval') return parts[1]
+  }
+  return 'alicia-ops'
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    passed += 1
+    console.log(`  ✓ ${name}`)
+  } catch (err) {
+    failed += 1
+    console.error(`  ✗ ${name}`)
+    console.error(`    ${err.message}`)
+  }
+}
+
+const APPROVAL_ID = 'a1b2c3d4-0000-0000-0000-000000000000'
+
+test('canónico grant: baw:<agent_id>:approval:grant:<id>', () => {
+  const r = parseApprovalCustomId(`baw:alicia-ops:approval:grant:${APPROVAL_ID}`)
+  assert.deepEqual(r, { action: 'grant', approvalId: APPROVAL_ID })
+})
+
+test('canónico deny: baw:<agent_id>:approval:deny:<id>', () => {
+  const r = parseApprovalCustomId(`baw:alicia-ops:approval:deny:${APPROVAL_ID}`)
+  assert.deepEqual(r, { action: 'deny', approvalId: APPROVAL_ID })
+})
+
+test('legacy grant: baw:approval:grant:<id>', () => {
+  const r = parseApprovalCustomId(`baw:approval:grant:${APPROVAL_ID}`)
+  assert.deepEqual(r, { action: 'grant', approvalId: APPROVAL_ID })
+})
+
+test('legacy deny: baw:approval:deny:<id>', () => {
+  const r = parseApprovalCustomId(`baw:approval:deny:${APPROVAL_ID}`)
+  assert.deepEqual(r, { action: 'deny', approvalId: APPROVAL_ID })
+})
+
+test('acción inválida → null', () => {
+  assert.equal(parseApprovalCustomId(`baw:alicia-ops:approval:explode:${APPROVAL_ID}`), null)
+  assert.equal(parseApprovalCustomId(`baw:approval:explode:${APPROVAL_ID}`), null)
+})
+
+test('sin approval_id → null', () => {
+  assert.equal(parseApprovalCustomId('baw:approval:grant'), null)
+  assert.equal(parseApprovalCustomId('baw:alicia-ops:approval:grant'), null)
+})
+
+test('custom_id no-approval → null', () => {
+  assert.equal(parseApprovalCustomId('baw:alicia-ops:task:view:123'), null)
+  assert.equal(parseApprovalCustomId('otracosa:approval:grant:123'), null)
+})
+
+test('resolveAgentId: canónico devuelve el agent_id', () => {
+  assert.equal(resolveAgentId(`baw:hugo-cos:approval:grant:${APPROVAL_ID}`), 'hugo-cos')
+})
+
+test('resolveAgentId: legacy NO devuelve "approval" como agent_id', () => {
+  assert.equal(resolveAgentId(`baw:approval:grant:${APPROVAL_ID}`), 'alicia-ops')
+})
+
+test('resolveAgentId: custom_id vacío → default alicia-ops', () => {
+  assert.equal(resolveAgentId(''), 'alicia-ops')
+})
+
+console.log('')
+console.log(`${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/tests/agents/run-all.sh
+++ b/tests/agents/run-all.sh
@@ -23,6 +23,7 @@ cd "$(dirname "$0")/../.."
 run_test tests/agents/discord-verify.test.mjs
 run_test tests/agents/auth.test.mjs
 run_test tests/agents/attribution.test.mjs
+run_test tests/agents/discord-custom-id.test.mjs
 
 echo ""
 echo "══════════════════════════════════════"

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/payments",
       "schedule": "0 6 1 * *"
+    },
+    {
+      "path": "/api/cron/cobranza",
+      "schedule": "0 13 * * *"
     }
   ],
   "installCommand": "git submodule update --init --recursive && npm install"


### PR DESCRIPTION
## Summary

Implements Sprint 5A MVP: connects Alicia (operadora Mateos 809P) and Hugo (supervisor, read-only) as third-party agents via Discord. Adds approval resolution from Discord buttons with full audit trail, async interaction processing with fallback to long-poll, and hides native agents from UI while keeping them operational via internal cron.

**Key deliverables:**
- Discord approval buttons (canonical + legacy format) with grant/deny resolution via `dispatchApprovedAction`
- Async interaction processing (`/api/agents/discord-interactions/process`) with webhooks-first push + deferred fallback
- Agent credentials scopes: Hugo locked to `runs:read`, `approvals:read`, `insights:read` (no writes)
- `/agents` UI shows only third-party family; native agents hidden but cobranza runner stays alive via `/api/cron/cobranza`
- Full audit: `agent_runs` + `agent_actions` + `resolved_by_discord_user` tracking

---

## Pre-flight checklist

- [x] `git fetch origin && git log origin/main --oneline -10` — verified main state
- [x] `gh pr list --state all --limit 10` — no duplicate PRs
- [x] `git log --oneline -5 -- <modified files>` — reviewed recent history
- [x] Branch based on updated `origin/main`
- [x] Single objective: Sprint 5A MVP scope (third-party agents + Discord approvals)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes (with `prebuild` design tokens check)

---

## Invariants (AGENTS.md §2)

- [x] No Inter typography changes in `src/app/layout.tsx`
- [x] No parallel token sets — uses `var(--baw-*)` from `design/baw-design/tokens/`
- [x] No `SIDEBAR_SECTIONS` modifications in `src/lib/navigation.ts`
- [x] No bypass of `isPlatformAdmin()` or `resolveOrgId()`
- [x] No legacy `member_role` enum references
- [x] Agents remain in 10+1 catalog (Alicia + Hugo marked 'beta', others 'planned' but not deleted)
- [x] No deletion of merged functional features

---

## Canonical Agreements Affected

- [x] **Schema DB / Migration SQL**: 
  - `20260611_agent_approvals_discord_resolver.sql` — adds `resolved_by_discord_user` column
  - `20260611_agents_alicia_hugo_beta.sql` — marks Alicia + Hugo as 'beta'
- [x] **Catálogo de agentes**: UI now filters to `family IN ('third-party', 'zxy-shared')` only; native agents hidden
- [x] **API pública**: New endpoints `/v1/interactions` (GET), `/v1/interactions/:id` (PATCH); approval resolution via Discord buttons
- [x] **ADR-021 (Third-party agents Discord)**: Implements D4 (canonical custom_id format), D8 (resolved_by_discord_user persistence)

---

## Changes Overview

### Core Approval Resolution (Discord Buttons)
- **`src/app/api/agents/discord-interactions/route.ts`**:
  - `parseApprovalCustomId()`: parses canonical (`baw:<agent_id>:approval:<grant|deny>:<id>`) and legacy (`baw:approval:<grant|deny>:<id>`) formats
  - Approval grant flow: load approval → validate status/expiry → call `dispatchApprovedAction()` → persist result + audit trail
  - Approval deny flow: update status → remove buttons from Discord message
  - Idempotent via `eq('status', 'pending')` constraint on updates
  - Full audit: creates `agent_runs` + `agent_actions` records with `resolved_via: 'discord'`

### Async Interaction Processing
- **`

https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U