### PR TITLE
Cobranza viva + ciclo de vida del contrato + endurecimiento de seguridad

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ STRIPE_WEBHOOK_SECRET=
 WHATSAPP_ACCESS_TOKEN=
 WHATSAPP_PHONE_NUMBER_ID=
 WHATSAPP_VERIFY_TOKEN=baw-os-webhook-2026
+# Gate maestro del envío automático de cobranza por WhatsApp. Mientras esté
+# vacío/false, el cron de cobranza corre en dry-run (registra, NO envía).
+# Ponlo en 'true' cuando las credenciales de arriba estén listas y quieras
+# que los recordatorios y avisos de mora se envíen de verdad a los inquilinos.
+COBRANZA_WHATSAPP_ENABLED=false
 
 # -----------------------------------------------------------------------------
 # Channex — channel manager (corto plazo / STR). Opcional para Mateos LTR puro.

--- a/src/app/agents/[id]/credentials/page.tsx
+++ b/src/app/agents/[id]/credentials/page.tsx
@@ -7,6 +7,7 @@ import { createServiceClient } from '@/lib/supabase'
 import { resolveOrgId, OrgContextError } from '@/lib/org-context'
 import { createSupabaseServer } from '@/lib/supabase-server'
 import CredentialsManager from './CredentialsManager'
+import { ORG_ADMIN_ROLES } from '@/lib/admin-auth'
 
 export const dynamic = 'force-dynamic'
 
@@ -74,7 +75,7 @@ async function requireAdminOfActiveOrg(): Promise<{
       .eq('user_id', user.id)
       .eq('org_id', orgId)
       .maybeSingle()
-    if (!membership || !['owner', 'admin'].includes(membership.role as string)) {
+    if (!membership || !ORG_ADMIN_ROLES.includes(membership.role as string)) {
       return null
     }
   }

--- a/src/app/api/admin/agents/[id]/credentials/route.ts
+++ b/src/app/api/admin/agents/[id]/credentials/route.ts
@@ -12,6 +12,7 @@ import { resolveOrgId, OrgContextError } from '@/lib/org-context'
 import { createSupabaseServer } from '@/lib/supabase-server'
 import { generateApiKey, hashApiKey } from '@/lib/agents/auth'
 import type { AgentId } from '@/lib/agents/types'
+import { ORG_ADMIN_ROLES } from '@/lib/admin-auth'
 
 interface RouteContext {
   params: Promise<{ id: string }>
@@ -55,7 +56,7 @@ async function requireAdminCaller(): Promise<
       .eq('user_id', user.id)
       .eq('org_id', orgId)
       .maybeSingle()
-    if (!membership || !['owner', 'admin'].includes(membership.role as string)) {
+    if (!membership || !ORG_ADMIN_ROLES.includes(membership.role as string)) {
       return { ok: false, status: 403, message: 'Owner or admin role required' }
     }
   }

--- a/src/app/api/auth/sync-session/route.ts
+++ b/src/app/api/auth/sync-session/route.ts
@@ -11,6 +11,23 @@ import { cookies } from 'next/headers'
 export const dynamic = 'force-dynamic'
 
 export async function POST(request: Request) {
+  // Audit 2026-06-12: mitigación CSRF — solo aceptamos POSTs same-origin.
+  // (Los browsers mandan Origin en POSTs cross-site; si difiere del host,
+  // rechazamos. Requests sin Origin (curl, SSR interno) pasan.)
+  const origin = request.headers.get('origin')
+  if (origin) {
+    const host = request.headers.get('host')
+    let originHost: string | null = null
+    try {
+      originHost = new URL(origin).host
+    } catch {
+      originHost = null
+    }
+    if (!host || originHost !== host) {
+      return NextResponse.json({ error: 'Cross-origin not allowed' }, { status: 403 })
+    }
+  }
+
   const { access_token, refresh_token } = await request
     .json()
     .catch(() => ({}))

--- a/src/app/api/channex/sync/route.ts
+++ b/src/app/api/channex/sync/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { channexFetch } from '@/lib/channex'
 import { createServiceClient } from '@/lib/api-auth'
 import { resolveOrgIdForWebhook, listAllOrgIds } from '@/lib/org-context'
+import { createSupabaseServer } from '@/lib/supabase-server'
 
 export const dynamic = 'force-dynamic'
 
@@ -51,6 +52,23 @@ function mapStatus(status: string | undefined): string {
 
 export async function POST(request: NextRequest) {
   try {
+    // Audit 2026-06-12: era público. Ahora: cron (CRON_SECRET) o sesión.
+    const authHeader = request.headers.get('authorization')
+    const isCron =
+      !!process.env.CRON_SECRET && authHeader === `Bearer ${process.env.CRON_SECRET}`
+    if (!isCron) {
+      const supabase = createSupabaseServer()
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) {
+        return NextResponse.json(
+          { success: false, error: 'Unauthorized' },
+          { status: 401 },
+        )
+      }
+    }
+
     let orgId = await resolveOrgIdForWebhook(request, null)
     if (!orgId) {
       const allOrgs = await listAllOrgIds()

--- a/src/app/api/channex/webhook/route.ts
+++ b/src/app/api/channex/webhook/route.ts
@@ -20,6 +20,27 @@ function mapChannel(source: string | undefined): string {
 
 export async function POST(request: NextRequest) {
   try {
+    // Audit 2026-06-12: el webhook era público — cualquiera podía inyectar o
+    // cancelar reservas con ?org=<slug>. Channex no firma webhooks, así que
+    // exigimos un token compartido en la URL: configurar en Channex la URL
+    // `/api/channex/webhook?org=<slug>&token=<CHANNEX_WEBHOOK_SECRET>`.
+    const secret = process.env.CHANNEX_WEBHOOK_SECRET
+    if (!secret) {
+      return NextResponse.json(
+        { success: false, error: 'CHANNEX_WEBHOOK_SECRET not configured' },
+        { status: 503 },
+      )
+    }
+    const token =
+      request.nextUrl.searchParams.get('token') ??
+      request.headers.get('x-channex-token')
+    if (token !== secret) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 },
+      )
+    }
+
     const body = await request.json()
     const event = body.event || body.type
     const payload = body.payload || body.data || body

--- a/src/app/api/cron/cobranza/route.ts
+++ b/src/app/api/cron/cobranza/route.ts
@@ -1,12 +1,14 @@
-// BaW OS — GET /api/cron/cobranza · automatización interna de mora
-// Sprint 5A MVP: el runner de cobranza ya no se invoca desde la UI de agentes
-// (catálogo muestra solo third-party); este cron diario lo mantiene operando
-// como automatización del sistema. Dry-run por defecto (v1 del runner);
-// ejecutar con ?dry_run=false para escalar mora de verdad.
+// BaW OS — GET /api/cron/cobranza · automatización de cobranza (recordatorios + mora)
+// El cron diario manda recordatorios preventivos y avisos de mora por WhatsApp.
+// Modo real vs dry-run lo controla COBRANZA_WHATSAPP_ENABLED:
+//   - flag 'true'  → el cron envía WhatsApp real (a menos que se fuerce ?dry_run=true)
+//   - flag ausente → dry-run (solo registra en audit, no envía)
+// Override manual disponible con ?dry_run=true|false.
 import { NextResponse } from 'next/server'
 import { createServiceClient } from '@/lib/supabase'
 import { cobranzaRunner } from '@/lib/agents/cobranza'
 import { executeAgentRun } from '@/lib/agents/runner'
+import { cobranzaWhatsAppEnabled } from '@/lib/whatsapp'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +19,9 @@ export async function GET(request: Request) {
   }
 
   const url = new URL(request.url)
-  const dryRun = url.searchParams.get('dry_run') !== 'false'
+  const override = url.searchParams.get('dry_run')
+  // Default: real si el flag está encendido; dry-run si no. Override con query.
+  const dryRun = override !== null ? override !== 'false' : !cobranzaWhatsAppEnabled()
 
   const supabase = createServiceClient()
   const { data: orgs, error } = await supabase.from('organizations').select('id')

--- a/src/app/api/cron/payments/route.ts
+++ b/src/app/api/cron/payments/route.ts
@@ -31,11 +31,13 @@ export async function GET(request: Request) {
 
   const supabase = getSupabase()
 
-  // Get all active and en_renovacion contracts
+  // Get all active and en_renovacion contracts.
+  // STR (renta corta) se cobra por reserva, no por mes → se excluye de la renta mensual.
   const { data: contracts } = await supabase
     .from('contracts')
-    .select('id, monthly_amount, payment_day, org_id')
+    .select('id, monthly_amount, payment_day, org_id, rent_type')
     .in('status', ['active', 'en_renovacion'])
+    .neq('rent_type', 'STR')
 
   if (!contracts || contracts.length === 0) {
     return NextResponse.json({ message: 'No active contracts', generated: 0 })

--- a/src/app/api/cron/renovaciones/route.ts
+++ b/src/app/api/cron/renovaciones/route.ts
@@ -1,0 +1,51 @@
+// BaW OS — GET /api/cron/renovaciones · ciclo de vida del contrato.
+// El cron diario detecta contratos por vencer (≤30 días) o ya vencidos sin renovar
+// y los pasa a 'en_renovacion' sin cortar la facturación, avisando al inquilino.
+// Modo real vs dry-run lo controla COBRANZA_WHATSAPP_ENABLED (mismo gate que cobranza):
+//   - flag 'true'  → flip de estado + WhatsApp real (salvo ?dry_run=true)
+//   - flag ausente → dry-run (solo registra en audit, no muta ni envía)
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { renovacionesRunner } from '@/lib/agents/renovaciones'
+import { executeAgentRun } from '@/lib/agents/runner'
+import { cobranzaWhatsAppEnabled } from '@/lib/whatsapp'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization')
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const url = new URL(request.url)
+  const override = url.searchParams.get('dry_run')
+  const dryRun = override !== null ? override !== 'false' : !cobranzaWhatsAppEnabled()
+
+  const supabase = createServiceClient()
+  const { data: orgs, error } = await supabase.from('organizations').select('id')
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  if (!orgs || orgs.length === 0) {
+    return NextResponse.json({ message: 'No organizations', runs: [] })
+  }
+
+  const runs: Array<{ org_id: string; run_id?: string; status: string; error?: string }> = []
+  for (const org of orgs) {
+    const orgId = org.id as string
+    try {
+      const result = await executeAgentRun(renovacionesRunner, {
+        orgId,
+        agentId: 'renovaciones',
+        triggeredBy: 'cron',
+        input: { dry_run: dryRun },
+      })
+      runs.push({ org_id: orgId, run_id: result.runId, status: result.status })
+    } catch (e) {
+      runs.push({ org_id: orgId, status: 'failed', error: e instanceof Error ? e.message : 'run_failed' })
+    }
+  }
+
+  return NextResponse.json({ message: 'OK', dry_run: dryRun, runs })
+}

--- a/src/app/api/me/view-mode/route.ts
+++ b/src/app/api/me/view-mode/route.ts
@@ -3,6 +3,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { getViewMode, setViewMode, type ViewMode } from '@/lib/agents/view-mode'
+import { createSupabaseServer } from '@/lib/supabase-server'
 
 export async function GET() {
   const mode = await getViewMode()
@@ -10,6 +11,17 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json(
+      { success: false, error: 'Unauthorized' },
+      { status: 401 }
+    )
+  }
+
   let body: { mode?: ViewMode }
   try {
     body = await req.json()

--- a/src/app/api/mora/notify/route.ts
+++ b/src/app/api/mora/notify/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { getMoraLevel } from '@/lib/mora-engine'
-import { resolveOrgIdForWebhook, listAllOrgIds } from '@/lib/org-context'
+import { resolveOrgId, resolveOrgIdForWebhook, listAllOrgIds } from '@/lib/org-context'
+import { createSupabaseServer } from '@/lib/supabase-server'
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ||
@@ -73,13 +74,35 @@ async function notifyForOrg(
 
 export async function POST(request: NextRequest) {
   try {
+    // Audit 2026-06-12: era público — cualquiera podía iterar todos los
+    // tenants y envenenar el audit log. Ahora: cron (CRON_SECRET) puede
+    // procesar todas las orgs; un usuario con sesión solo SU org activa.
+    const authHeader = request.headers.get('authorization')
+    const isCron =
+      !!process.env.CRON_SECRET && authHeader === `Bearer ${process.env.CRON_SECRET}`
+
+    let sessionOrgId: string | null = null
+    if (!isCron) {
+      const supabase = createSupabaseServer()
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) {
+        return NextResponse.json(
+          { success: false, error: 'Unauthorized' },
+          { status: 401 },
+        )
+      }
+      sessionOrgId = await resolveOrgId()
+    }
+
     const body = await request.json().catch(() => ({}))
     const { contractIds } = body as { contractIds?: string[] }
 
     const baseUrl = request.nextUrl.origin
 
-    // Resolver target orgs: explicit > all
-    const explicitOrg = await resolveOrgIdForWebhook(request, body)
+    // Resolver target orgs: sesión → su org; cron → explicit > all
+    const explicitOrg = sessionOrgId ?? (await resolveOrgIdForWebhook(request, body))
     const targetOrgs = explicitOrg ? [explicitOrg] : await listAllOrgIds()
 
     if (targetOrgs.length === 0) {

--- a/src/app/api/mora/route.ts
+++ b/src/app/api/mora/route.ts
@@ -21,12 +21,23 @@ export async function GET(request: NextRequest) {
   // Fase 1 transition: aceptamos credenciales sk_live_/sk_test_ (nueva) o
   // BAWOS_API_KEY global (legacy). El legacy se elimina en Fase 2.
   const auth = await authenticateAgentRequest(request, ['mora:read'])
+  let legacyCaller = false
   if (!auth.ok) {
     if (validateLegacyApiKey(request)) {
       // Legacy path: aceptado pero sin identidad de agente.
+      legacyCaller = true
     } else {
       return agentAuthErrorResponse(auth)
     }
+  }
+
+  // Audit 2026-06-12: el caller legacy (key global, sin identidad ni org)
+  // debe declarar org_id explícito — sin esto devolvía mora cross-tenant.
+  if (legacyCaller && !request.nextUrl.searchParams.get('org_id')) {
+    return NextResponse.json(
+      { success: false, error: 'org_id query param is required with legacy API key' },
+      { status: 400 },
+    )
   }
 
   try {

--- a/src/app/api/notifications/whatsapp/route.ts
+++ b/src/app/api/notifications/whatsapp/route.ts
@@ -25,6 +25,7 @@ export async function POST(request: NextRequest) {
     .from('occupants')
     .select('name, phone')
     .eq('id', occupant_id)
+    .eq('org_id', orgId) // audit 2026-06-12: sin esto, cross-tenant lookup
     .single()
 
   if (occErr || !occupant) return apiError('Occupant not found', 404)

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -3,7 +3,8 @@
 // en un único request. Usa service-role para bypass de RLS y se hace best-effort de rollback.
 
 import { NextRequest } from 'next/server'
-import { createServiceClient, apiOk, apiError, setActiveOrgId } from '@/lib/api-auth'
+import { createServiceClient, apiOk, apiError, setActiveOrgId, unauthorized } from '@/lib/api-auth'
+import { createSupabaseServer } from '@/lib/supabase-server'
 
 interface UnitInput {
   number: string
@@ -39,7 +40,18 @@ interface OnboardingV2Body {
 export async function POST(request: NextRequest) {
   let createdOrgId: string | null = null
   try {
+    // Audit 2026-06-12: este endpoint era público y aceptaba cualquier
+    // user_id en el body — cualquiera podía crear orgs a nombre de otro y
+    // envenenar el cache de org activa. Ahora exige sesión y fuerza que la
+    // org se cree para el usuario autenticado.
+    const authClient = createSupabaseServer()
+    const {
+      data: { user },
+    } = await authClient.auth.getUser()
+    if (!user) return unauthorized('Sesión requerida para onboarding')
+
     const body = (await request.json()) as OnboardingV2Body
+    body.user_id = user.id
 
     // Validaciones mínimas
     if (!body.user_id) return apiError('user_id es obligatorio', 400)

--- a/src/app/api/payments/[id]/receipt/route.ts
+++ b/src/app/api/payments/[id]/receipt/route.ts
@@ -1,0 +1,25 @@
+// BaW OS — POST /api/payments/[id]/receipt
+// Envía el comprobante de pago por WhatsApp. Lo llama el flujo manual de /cobros
+// tras registrar un pago. Requiere sesión (humano) o API key legacy.
+import { NextRequest, NextResponse } from 'next/server'
+import { validateApiKey } from '@/lib/api-auth'
+import { createSupabaseServer } from '@/lib/supabase-server'
+import { sendPaymentReceipt } from '@/lib/payment-receipt'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  if (!validateApiKey(request)) {
+    const supabase = createSupabaseServer()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const result = await sendPaymentReceipt(params.id)
+  return NextResponse.json({ success: result.ok, reason: result.reason })
+}

--- a/src/app/api/v1/payments/route.ts
+++ b/src/app/api/v1/payments/route.ts
@@ -3,6 +3,7 @@ import { v1Read, v1Write } from '@/lib/agents/v1/handler'
 import { v1Ok, v1Error } from '@/lib/agents/v1/responses'
 import { parsePagination, makeCursor } from '@/lib/agents/v1/pagination'
 import { createServiceClient } from '@/lib/supabase'
+import { sendPaymentReceipt } from '@/lib/payment-receipt'
 
 export const GET = v1Read({
   scopes: ['payments:read'],
@@ -110,6 +111,9 @@ export const POST = v1Write<PaymentRecordBody>({
       result: { id: data.id },
       status: 'ok',
     })
+
+    // Comprobante por WhatsApp (fire-and-forget; gateado por el flag de cobranza)
+    void sendPaymentReceipt(data.id as string)
 
     return v1Ok(data)
   },

--- a/src/app/api/v1/units/route.ts
+++ b/src/app/api/v1/units/route.ts
@@ -1,8 +1,11 @@
-// BaW OS v1 — GET /v1/units
-import { v1Read } from '@/lib/agents/v1/handler'
+// BaW OS v1 — GET + POST /v1/units
+import { v1Read, v1Write } from '@/lib/agents/v1/handler'
 import { v1Ok, v1Error } from '@/lib/agents/v1/responses'
 import { parsePagination, makeCursor } from '@/lib/agents/v1/pagination'
 import { createServiceClient } from '@/lib/supabase'
+
+const UNIT_TYPES = ['STR', 'MTR', 'LTR', 'OFFICE', 'COMMON']
+const UNIT_STATUSES = ['available', 'occupied', 'maintenance', 'reserved', 'inactive']
 
 export const GET = v1Read({
   scopes: ['units:read'],
@@ -34,5 +37,88 @@ export const GET = v1Read({
     const next_cursor = hasMore && last ? makeCursor(last) : null
 
     return v1Ok(trimmed, { next_cursor, limit })
+  },
+})
+
+interface UnitCreateBody {
+  number: string
+  type?: string
+  floor?: number
+  status?: string
+  area_m2?: number
+  bedrooms?: number
+  bathrooms?: number
+  amenities?: string[]
+  notes?: string
+}
+
+// POST /v1/units — dar de alta una unidad. action_type 'unit.create'.
+export const POST = v1Write<UnitCreateBody>({
+  scopes: ['units:write'],
+  actionType: 'unit.create',
+  endpoint: '/v1/units',
+  validate: (raw) => {
+    if (typeof raw !== 'object' || raw === null) throw new Error('body must be object')
+    const b = raw as Record<string, unknown>
+    if (typeof b.number !== 'string' || b.number.trim().length === 0) {
+      throw new Error('number is required')
+    }
+    if (b.type !== undefined && !UNIT_TYPES.includes(b.type as string)) {
+      throw new Error(`type must be one of: ${UNIT_TYPES.join(', ')}`)
+    }
+    if (b.status !== undefined && !UNIT_STATUSES.includes(b.status as string)) {
+      throw new Error(`status must be one of: ${UNIT_STATUSES.join(', ')}`)
+    }
+    return {
+      number: b.number.trim(),
+      type: typeof b.type === 'string' ? b.type : 'LTR',
+      floor: typeof b.floor === 'number' ? b.floor : undefined,
+      status: typeof b.status === 'string' ? b.status : 'available',
+      area_m2: typeof b.area_m2 === 'number' ? b.area_m2 : undefined,
+      bedrooms: typeof b.bedrooms === 'number' ? b.bedrooms : undefined,
+      bathrooms: typeof b.bathrooms === 'number' ? b.bathrooms : undefined,
+      amenities: Array.isArray(b.amenities) ? (b.amenities as string[]) : undefined,
+      notes: typeof b.notes === 'string' ? b.notes : undefined,
+    }
+  },
+  handler: async ({ auth, body, recordAction }) => {
+    const supabase = createServiceClient()
+    const { data, error } = await supabase
+      .from('units')
+      .insert({
+        org_id: auth.orgId,
+        number: body.number,
+        type: body.type ?? 'LTR',
+        floor: body.floor ?? null,
+        status: body.status ?? 'available',
+        area_m2: body.area_m2 ?? null,
+        bedrooms: body.bedrooms ?? null,
+        bathrooms: body.bathrooms ?? null,
+        amenities: body.amenities ?? null,
+        notes: body.notes ?? null,
+      })
+      .select('id, org_id, number, floor, type, status, created_at')
+      .single()
+
+    if (error || !data) {
+      // 23505 = unique_violation (org_id, number) — la unidad ya existe
+      const dup = (error as { code?: string } | null)?.code === '23505'
+      return v1Error(
+        dup ? 'duplicate' : 'insert_error',
+        dup ? `unit ${body.number} already exists` : error?.message || 'failed to create unit',
+        dup ? 409 : 500,
+      )
+    }
+
+    await recordAction({
+      actionType: 'unit.create',
+      entityType: 'unit',
+      entityId: data.id as string,
+      payload: body as unknown as Record<string, unknown>,
+      result: { id: data.id },
+      status: 'ok',
+    })
+
+    return v1Ok(data)
   },
 })

--- a/src/app/api/whatsapp/notify/route.ts
+++ b/src/app/api/whatsapp/notify/route.ts
@@ -1,6 +1,7 @@
 // BaW OS — WhatsApp Notification API
 import { NextRequest } from 'next/server'
 import { validateApiKey, unauthorized, apiError, apiOk, createServiceClient, getOrgId } from '@/lib/api-auth'
+import { createSupabaseServer } from '@/lib/supabase-server'
 
 type NotifyType = 'mora_day1' | 'mora_day5' | 'mora_day10' | 'checkin' | 'contract_expiring'
 
@@ -29,7 +30,16 @@ function buildMessage(body: NotifyBody): string {
 }
 
 export async function POST(request: NextRequest) {
-  if (!validateApiKey(request)) return unauthorized()
+  // Audit 2026-06-12: la UI mandaba un API key hardcodeado en el JS del
+  // cliente (comprometido — rotar BAWOS_API_KEY). Ahora una sesión válida
+  // también autoriza, y la UI ya no embebe secretos.
+  if (!validateApiKey(request)) {
+    const supabase = createSupabaseServer()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return unauthorized()
+  }
 
   const accessToken = process.env.WHATSAPP_ACCESS_TOKEN
   const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID

--- a/src/app/api/whatsapp/send/route.ts
+++ b/src/app/api/whatsapp/send/route.ts
@@ -1,6 +1,7 @@
 // BaW OS — WhatsApp Send Message API
 import { NextRequest } from 'next/server'
 import { validateApiKey, unauthorized, apiError, apiOk, createServiceClient, getOrgId } from '@/lib/api-auth'
+import { createSupabaseServer } from '@/lib/supabase-server'
 
 interface SendBody {
   to: string
@@ -10,7 +11,16 @@ interface SendBody {
 }
 
 export async function POST(request: NextRequest) {
-  if (!validateApiKey(request)) return unauthorized()
+  // Audit 2026-06-12: la UI mandaba un API key hardcodeado en el JS del
+  // cliente (comprometido — rotar BAWOS_API_KEY). Ahora una sesión válida
+  // también autoriza, y la UI ya no embebe secretos.
+  if (!validateApiKey(request)) {
+    const supabase = createSupabaseServer()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return unauthorized()
+  }
 
   const accessToken = process.env.WHATSAPP_ACCESS_TOKEN
   const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID

--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -207,6 +207,11 @@ export default function CobrosPage() {
       payment_method: payForm.method.toLowerCase() === 'transferencia' ? 'transferencia' : payForm.method.toLowerCase() === 'efectivo' ? 'efectivo' : 'otro',
     }).select().single()
 
+    // Comprobante por WhatsApp (fire-and-forget; gateado por el flag de cobranza)
+    if (paymentData && !error) {
+      fetch(`/api/payments/${paymentData.id}/receipt`, { method: 'POST' }).catch(() => {})
+    }
+
     // Also create ledger entry
     if (paymentData && !error) {
       await supabase.from('payment_ledger').insert({

--- a/src/app/contracts/new/page.tsx
+++ b/src/app/contracts/new/page.tsx
@@ -24,6 +24,7 @@ export default function NewContractPage() {
     deposit_amount: '',
     deposit_paid: false,
     payment_day: '1',
+    rent_type: 'LTR' as 'LTR' | 'MTR' | 'STR',
     notes: '',
     drive_folder_url: '',
   })
@@ -79,6 +80,7 @@ export default function NewContractPage() {
       deposit_amount: form.deposit_amount ? Number(form.deposit_amount) : null,
       deposit_paid: form.deposit_paid,
       payment_day: Number(form.payment_day),
+      rent_type: form.rent_type,
       status: 'active',
       notes: form.notes || null,
       drive_folder_url: form.drive_folder_url || null,
@@ -117,7 +119,11 @@ export default function NewContractPage() {
           <select
             required
             value={form.unit_id}
-            onChange={(e) => setForm({ ...form, unit_id: e.target.value })}
+            onChange={(e) => {
+              const unit = units.find((u) => u.id === e.target.value)
+              const inferred = unit && ['LTR', 'MTR', 'STR'].includes(unit.type) ? (unit.type as 'LTR' | 'MTR' | 'STR') : form.rent_type
+              setForm({ ...form, unit_id: e.target.value, rent_type: inferred })
+            }}
             className="input-field"
           >
             <option value="">Seleccionar unidad...</option>
@@ -127,6 +133,22 @@ export default function NewContractPage() {
               </option>
             ))}
           </select>
+        </div>
+
+        <div>
+          <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Tipo de renta</label>
+          <select
+            value={form.rent_type}
+            onChange={(e) => setForm({ ...form, rent_type: e.target.value as 'LTR' | 'MTR' | 'STR' })}
+            className="input-field"
+          >
+            <option value="LTR">Larga (LTR) — renta mensual</option>
+            <option value="MTR">Media (MTR) — renta mensual</option>
+            <option value="STR">Corta (STR) — se cobra por reserva</option>
+          </select>
+          {form.rent_type === 'STR' && (
+            <p className="text-xs text-amber-500 mt-1">La renta corta no genera cobro mensual automático; se factura por reserva.</p>
+          )}
         </div>
 
         <div>

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -21,6 +21,7 @@ export default function ContractsPage() {
     monthly_amount: 0,
     payment_day: 1,
     status: 'active' as ContractStatus,
+    rent_type: 'LTR' as 'LTR' | 'MTR' | 'STR',
     notes: '',
     end_date: '',
     drive_link: '',
@@ -72,6 +73,7 @@ export default function ContractsPage() {
       monthly_amount: contract.monthly_amount,
       payment_day: contract.payment_day,
       status: contract.status,
+      rent_type: (contract.rent_type as 'LTR' | 'MTR' | 'STR') || 'LTR',
       notes: contract.notes?.replace(/\n?📎 https?:\/\/\S+/, '').trim() || '',
       end_date: contract.end_date || '',
       drive_link: existingLink,
@@ -94,6 +96,7 @@ export default function ContractsPage() {
         monthly_amount: editForm.monthly_amount,
         payment_day: editForm.payment_day,
         status: editForm.status,
+        rent_type: editForm.rent_type,
         notes: notesValue || null,
         end_date: editForm.end_date || null,
         aval: editForm.aval || null,
@@ -472,6 +475,18 @@ export default function ContractsPage() {
                   {Object.entries(statusLabels).map(([key, label]) => (
                     <option key={key} value={key}>{label}</option>
                   ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Tipo de renta</label>
+                <select
+                  value={editForm.rent_type}
+                  onChange={(e) => setEditForm({ ...editForm, rent_type: e.target.value as 'LTR' | 'MTR' | 'STR' })}
+                  className="input-field w-full"
+                >
+                  <option value="LTR">Larga (LTR)</option>
+                  <option value="MTR">Media (MTR)</option>
+                  <option value="STR">Corta (STR) — sin cobro mensual</option>
                 </select>
               </div>
               <div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,7 +6,7 @@ import { supabase } from '@/lib/supabase'
 import { useOrgContext } from '@/hooks/useOrgContext'
 import type { MemberRole, OrgMember, Organization, UserProfile } from '@/types'
 
-const roleOptions: MemberRole[] = ['owner', 'admin', 'operator', 'viewer', 'agent']
+const roleOptions: MemberRole[] = ['pm_owner', 'pm_admin', 'pm_operator', 'pm_viewer']
 
 export default function SettingsPage() {
   const [tab, setTab] = useState<'profile' | 'organization' | 'access'>('profile')

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,9 +4,11 @@ import { useEffect, useMemo, useState } from 'react'
 import { Building2, Save, Settings2, Shield, User } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { useOrgContext } from '@/hooks/useOrgContext'
+import { ORG_ADMIN_ROLES } from '@/lib/navigation'
 import type { MemberRole, OrgMember, Organization, UserProfile } from '@/types'
 
 const roleOptions: MemberRole[] = ['pm_owner', 'pm_admin', 'pm_operator', 'pm_viewer']
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 export default function SettingsPage() {
   const [tab, setTab] = useState<'profile' | 'organization' | 'access'>('profile')
@@ -16,10 +18,11 @@ export default function SettingsPage() {
   const [profile, setProfile] = useState<Partial<UserProfile>>({})
   const [organization, setOrganization] = useState<Partial<Organization>>({})
   const [members, setMembers] = useState<OrgMember[]>([])
-  const [newMember, setNewMember] = useState({ invited_email: '', role: 'operator' as MemberRole })
+  const [newMember, setNewMember] = useState({ invited_email: '', role: 'pm_operator' as MemberRole })
   const [message, setMessage] = useState<string | null>(null)
 
-  const { orgId, loading: orgLoading } = useOrgContext()
+  const { orgId, role, loading: orgLoading } = useOrgContext()
+  const isOrgAdmin = !!role && ORG_ADMIN_ROLES.includes(role)
 
   async function load(activeOrgId: string) {
     setLoading(true)
@@ -124,32 +127,47 @@ export default function SettingsPage() {
   }
 
   async function addMemberPlaceholder() {
-    if (!newMember.invited_email.trim() || !orgId) return
+    const email = newMember.invited_email.trim()
+    if (!orgId) return
+    if (!EMAIL_RE.test(email)) {
+      setMessage('Ingresa un email válido para invitar.')
+      return
+    }
     setSaving(true)
     setMessage(null)
     const payload = {
       org_id: orgId,
       user_id: crypto.randomUUID(),
-      invited_email: newMember.invited_email.trim(),
+      invited_email: email,
       role: newMember.role,
       is_active: true,
     }
     const { data, error } = await supabase.from('org_members').insert(payload).select('*').single()
     if (!error && data) {
       setMembers((current) => [...current, data as OrgMember])
-      setNewMember({ invited_email: '', role: 'operator' })
-      setMessage('Acceso agregado como placeholder. Falta ligar auth real después.')
+      setNewMember({ invited_email: '', role: 'pm_operator' })
+      setMessage('Acceso pre-registrado. El usuario quedará activo al iniciar sesión con ese email (invitación por correo: pendiente).')
     } else {
       setMessage(error ? `Error: ${error.message}` : 'No se pudo agregar miembro')
     }
     setSaving(false)
   }
 
-  const tabs = useMemo(() => ([
-    { key: 'profile', label: 'Perfil', icon: User },
-    { key: 'organization', label: 'Organización', icon: Building2 },
-    { key: 'access', label: 'Accesos', icon: Shield },
-  ] as const), [])
+  // Operadores/viewers solo ven su perfil; la config de organización y los
+  // accesos son de admins. (La RLS también lo bloquea a nivel de datos.)
+  const tabs = useMemo(() => {
+    const base = [{ key: 'profile', label: 'Perfil', icon: User }] as const
+    const adminTabs = [
+      { key: 'organization', label: 'Organización', icon: Building2 },
+      { key: 'access', label: 'Accesos', icon: Shield },
+    ] as const
+    return isOrgAdmin ? [...base, ...adminTabs] : base
+  }, [isOrgAdmin])
+
+  // Si un no-admin tenía seleccionada una pestaña restringida, regrésalo a Perfil.
+  useEffect(() => {
+    if (!isOrgAdmin && tab !== 'profile') setTab('profile')
+  }, [isOrgAdmin, tab])
 
   if (orgLoading || loading) return <div className="text-sm page-subtitle">Cargando configuración…</div>
   if (!orgId) {

--- a/src/app/whatsapp/page.tsx
+++ b/src/app/whatsapp/page.tsx
@@ -103,7 +103,6 @@ export default function WhatsAppPage() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-api-key': 'baw-secret-2026',
         },
         body: JSON.stringify({
           type: notifyType,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -20,9 +20,12 @@ import { cn } from '@/lib/utils'
 import WorkspaceSwitcher from '@/components/WorkspaceSwitcher'
 import BawMark from '@/components/BawMark'
 import ViewModeSwitch from '@/components/ViewModeSwitch'
+import { useOrgContext } from '@/hooks/useOrgContext'
 import {
   SIDEBAR_SECTIONS,
+  ORG_ADMIN_ROLES,
   isSectionActive,
+  filterSectionsByRole,
 } from '@/lib/navigation'
 
 const COLLAPSED_WIDTH = 56
@@ -41,10 +44,13 @@ const ICON_MAP = {
 
 export default function Sidebar() {
   const pathname = usePathname()
+  const { role } = useOrgContext()
   const [mobileOpen, setMobileOpen] = useState(false)
   const [hovering, setHovering] = useState(false)
   const [pinned, setPinned] = useState(false)
   const [unreadCount, setUnreadCount] = useState(0)
+
+  const isOrgAdmin = !!role && ORG_ADMIN_ROLES.includes(role)
 
   const expanded = pinned || hovering || mobileOpen
 
@@ -94,8 +100,18 @@ export default function Sidebar() {
     root.style.setProperty('--sidebar-rendered-width', `${width}px`)
   }, [pinned, width])
 
-  const sections = useMemo(() => SIDEBAR_SECTIONS.filter((s) => s.placement === 'top'), [])
-  const footerSections = useMemo(() => SIDEBAR_SECTIONS.filter((s) => s.placement === 'footer'), [])
+  const visibleSections = useMemo(
+    () => filterSectionsByRole(SIDEBAR_SECTIONS, role),
+    [role],
+  )
+  const sections = useMemo(
+    () => visibleSections.filter((s) => s.placement === 'top'),
+    [visibleSections],
+  )
+  const footerSections = useMemo(
+    () => visibleSections.filter((s) => s.placement === 'footer'),
+    [visibleSections],
+  )
 
   function renderEntry(section: (typeof SIDEBAR_SECTIONS)[number]) {
     const Icon = ICON_MAP[section.icon as keyof typeof ICON_MAP]
@@ -258,8 +274,9 @@ export default function Sidebar() {
           {footerSections.map((s) => renderEntry(s))}
         </div>
 
-        {/* View mode switch (Human / Agent) — global */}
-        {expanded && (
+        {/* View mode switch (Human / Agent) — solo admins de la cuenta.
+            Operadores/viewers no gestionan agentes, así que no ven el toggle. */}
+        {expanded && isOrgAdmin && (
           <div
             className="shrink-0 px-3 py-2"
             style={{ borderTop: '1px solid var(--baw-sidebar-border)' }}

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -19,6 +19,10 @@ export interface AdminCallerErr {
   message: string
 }
 
+// Roles con permisos de admin de tenant (L1). Los valores canónicos son pm_*;
+// owner/admin son legacy tolerados durante la migración del enum (issue #23).
+export const ORG_ADMIN_ROLES = ['pm_owner', 'pm_admin', 'owner', 'admin']
+
 export async function requireAdminCaller(): Promise<AdminCallerOk | AdminCallerErr> {
   const supabase = createSupabaseServer()
   const {
@@ -56,7 +60,7 @@ export async function requireAdminCaller(): Promise<AdminCallerOk | AdminCallerE
       .maybeSingle()
     if (
       !membership ||
-      !['owner', 'admin'].includes(membership.role as string)
+      !ORG_ADMIN_ROLES.includes(membership.role as string)
     ) {
       return { ok: false, status: 403, message: 'Owner or admin role required' }
     }

--- a/src/lib/agents/cobranza.ts
+++ b/src/lib/agents/cobranza.ts
@@ -37,6 +37,14 @@ interface ContractRow {
   unit_id: string | null
   occupant_id: string | null
   org_id: string
+  portal_token: string | null
+  portal_enabled: boolean | null
+}
+
+function portalUrlFor(contract: ContractRow): string | null {
+  if (!contract.portal_enabled || !contract.portal_token) return null
+  const base = process.env.NEXT_PUBLIC_BASE_URL || 'https://baw-os.vercel.app'
+  return `${base}/tenant/${contract.portal_token}`
 }
 
 function paymentAmount(p: PaymentRow): number {
@@ -55,7 +63,6 @@ export const cobranzaRunner: AgentRunner = {
     const dryRun = ctx.input.dry_run !== false // por defecto dry-run
     const canSend = !dryRun && whatsAppConfigured()
     const today = new Date()
-    const todayStr = today.toISOString().slice(0, 10)
     const horizon = new Date(today.getTime() + REMINDER_DAYS * 86_400_000)
       .toISOString()
       .slice(0, 10)
@@ -108,7 +115,7 @@ export const cobranzaRunner: AgentRunner = {
 
     const { data: cRows } = await supabase
       .from('contracts')
-      .select('id, unit_id, occupant_id, org_id')
+      .select('id, unit_id, occupant_id, org_id, portal_token, portal_enabled')
       .in('id', contractIds.length ? contractIds : ['00000000-0000-0000-0000-000000000000'])
     const contracts = (cRows || []) as ContractRow[]
 
@@ -145,6 +152,7 @@ export const cobranzaRunner: AgentRunner = {
       const unitNumber = contract.unit_id ? unitsMap.get(contract.unit_id) ?? '—' : '—'
       const name = occupant?.name ?? 'inquilino'
       const phone = occupant?.phone ?? null
+      const portalUrl = portalUrlFor(contract)
 
       const overdue = cps.filter((p) => new Date(p.due_date) <= today)
       const upcoming = cps.filter((p) => new Date(p.due_date) > today)
@@ -191,7 +199,7 @@ export const cobranzaRunner: AgentRunner = {
         }
 
         escalations[worstLevel] = (escalations[worstLevel] || 0) + 1
-        const message = buildDunningMessage({ name, unit: unitNumber, amount: totalDue, daysPastDue: maxDays, level: worstLevel })
+        const message = buildDunningMessage({ name, unit: unitNumber, amount: totalDue, daysPastDue: maxDays, level: worstLevel, portalUrl })
         await dispatch({
           ctx, supabase, kind: 'dunning', contract, name, unitNumber,
           phone, message, canSend, daysPastDue: maxDays, level: worstLevel, totalDue,
@@ -206,7 +214,7 @@ export const cobranzaRunner: AgentRunner = {
         const soonest = upcoming.reduce((acc, p) => (new Date(p.due_date) < new Date(acc.due_date) ? p : acc), upcoming[0])
         const daysUntil = -dayDiff(new Date(soonest.due_date), today)
         const amount = paymentAmount(soonest)
-        const message = buildReminderMessage({ name, unit: unitNumber, amount, daysUntil })
+        const message = buildReminderMessage({ name, unit: unitNumber, amount, daysUntil, portalUrl })
         escalations.reminder++
         await dispatch({
           ctx, supabase, kind: 'reminder', contract, name, unitNumber,

--- a/src/lib/agents/cobranza.ts
+++ b/src/lib/agents/cobranza.ts
@@ -1,10 +1,24 @@
-// BaW OS — Agente Cobranza v1 (S4-3)
-// Ejecuta dunning sobre payments overdue: detecta mora, escala niveles, registra notificaciones.
-// Reutiliza la lógica de mora-engine. v1 = dry-run + audit; v2 enviará emails/whatsapp reales.
+// BaW OS — Agente Cobranza v2 (Bloque 1: cobranza viva)
+// Dunning sobre payments: recordatorio preventivo (antes de vencer) + aviso de
+// mora escalado (después de vencer), con envío real por WhatsApp Business
+// gateado por COBRANZA_WHATSAPP_ENABLED. Si el gate está apagado o falta el
+// teléfono, registra la acción en audit sin enviar (comportamiento dry-run).
+//
+// Fix 2026-06-15: la v1 seleccionaba contracts.tenant_name y units.unit_number
+// (columnas inexistentes — son occupant_id y number), por lo que nunca resolvía
+// al inquilino y no podía notificar. Ahora resuelve vía occupants.
 
 import { createServiceClient } from '@/lib/api-auth'
 import { getMoraLevel } from '@/lib/mora-engine'
+import {
+  sendWhatsAppText,
+  whatsAppConfigured,
+  buildReminderMessage,
+  buildDunningMessage,
+} from '@/lib/whatsapp'
 import type { AgentRunContext, AgentRunResult, AgentRunner } from './types'
+
+const REMINDER_DAYS = 5 // recordatorio preventivo N días antes del vencimiento
 
 interface PaymentRow {
   id: string
@@ -21,14 +35,16 @@ interface PaymentRow {
 interface ContractRow {
   id: string
   unit_id: string | null
-  tenant_name: string | null
+  occupant_id: string | null
   org_id: string
 }
 
-interface UnitRow {
-  id: string
-  unit_number: string | null
-  building_id: string | null
+function paymentAmount(p: PaymentRow): number {
+  return Number(p.amount || Number(p.rent_amount || 0) + Number(p.water_fee || 0))
+}
+
+function dayDiff(from: Date, to: Date): number {
+  return Math.floor((to.getTime() - from.getTime()) / 86_400_000)
 }
 
 export const cobranzaRunner: AgentRunner = {
@@ -36,17 +52,24 @@ export const cobranzaRunner: AgentRunner = {
 
   async run(ctx: AgentRunContext): Promise<AgentRunResult> {
     const supabase = createServiceClient()
-    const dryRun = ctx.input.dry_run !== false // por defecto dry-run en v1
+    const dryRun = ctx.input.dry_run !== false // por defecto dry-run
+    const canSend = !dryRun && whatsAppConfigured()
     const today = new Date()
+    const todayStr = today.toISOString().slice(0, 10)
+    const horizon = new Date(today.getTime() + REMINDER_DAYS * 86_400_000)
+      .toISOString()
+      .slice(0, 10)
 
-    // 1. Cargar payments overdue (no confirmados, due_date pasado) del org actual
+    // 1. Pagos sin confirmar con vencimiento hasta REMINDER_DAYS en el futuro:
+    //    cubre tanto vencidos (mora) como próximos a vencer (recordatorio).
     const { data: payments, error: pErr } = await supabase
       .from('payments')
       .select('id, contract_id, due_date, amount, rent_amount, water_fee, status, confirmed_at, org_id')
       .eq('org_id', ctx.orgId)
       .is('confirmed_at', null)
-      .lte('due_date', today.toISOString().slice(0, 10))
-      .limit(500)
+      .neq('status', 'paid')
+      .lte('due_date', horizon)
+      .limit(1000)
 
     if (pErr) {
       await ctx.recordAction({
@@ -60,71 +83,90 @@ export const cobranzaRunner: AgentRunner = {
       }
     }
 
-    const overdue = (payments || []) as PaymentRow[]
-
-    if (overdue.length === 0) {
+    const rows = (payments || []) as PaymentRow[]
+    if (rows.length === 0) {
       await ctx.recordAction({
         action_type: 'cobranza.scan_complete',
         status: 'ok',
-        result: { overdue_count: 0 },
+        result: { pending_count: 0 },
       })
       return {
-        output: { message: 'no overdue payments', overdue_count: 0 },
+        output: { message: 'no pending payments', pending_count: 0 },
         metrics: { actions_total: 1, actions_ok: 1, actions_failed: 0 },
       }
     }
 
-    // 2. Agrupar por contract_id, calcular días de mora
+    // 2. Agrupar por contrato
     const byContract = new Map<string, PaymentRow[]>()
-    for (const p of overdue) {
+    for (const p of rows) {
       if (!p.contract_id) continue
       const arr = byContract.get(p.contract_id) || []
       arr.push(p)
       byContract.set(p.contract_id, arr)
     }
-
     const contractIds = Array.from(byContract.keys())
-    let contracts: ContractRow[] = []
-    if (contractIds.length > 0) {
-      const { data: cRows } = await supabase
-        .from('contracts')
-        .select('id, unit_id, tenant_name, org_id')
-        .in('id', contractIds)
-      contracts = (cRows || []) as ContractRow[]
-    }
 
+    const { data: cRows } = await supabase
+      .from('contracts')
+      .select('id, unit_id, occupant_id, org_id')
+      .in('id', contractIds.length ? contractIds : ['00000000-0000-0000-0000-000000000000'])
+    const contracts = (cRows || []) as ContractRow[]
+
+    // 3. Resolver inquilinos (nombre + teléfono) y unidades (número)
+    const occupantIds = contracts.map((c) => c.occupant_id).filter(Boolean) as string[]
     const unitIds = contracts.map((c) => c.unit_id).filter(Boolean) as string[]
-    let units: UnitRow[] = []
-    if (unitIds.length > 0) {
-      const { data: uRows } = await supabase
-        .from('units')
-        .select('id, unit_number, building_id')
-        .in('id', unitIds)
-      units = (uRows || []) as UnitRow[]
+
+    const occupantsMap = new Map<string, { name: string; phone: string | null }>()
+    if (occupantIds.length) {
+      const { data } = await supabase
+        .from('occupants')
+        .select('id, name, phone')
+        .in('id', occupantIds)
+      for (const o of data || []) {
+        occupantsMap.set(o.id as string, { name: (o.name as string) || 'inquilino', phone: (o.phone as string) || null })
+      }
+    }
+    const unitsMap = new Map<string, string>()
+    if (unitIds.length) {
+      const { data } = await supabase.from('units').select('id, number').in('id', unitIds)
+      for (const u of data || []) unitsMap.set(u.id as string, (u.number as string) || '—')
     }
 
     let actionsOk = 0
     let actionsFailed = 0
     let actionsSkipped = 0
-    const escalations: Record<string, number> = { grace: 0, warning: 0, critical: 0, legal: 0, abogado: 0 }
+    let sentCount = 0
+    const escalations: Record<string, number> = { reminder: 0, warning: 0, critical: 0, legal: 0, abogado: 0 }
 
     for (const contract of contracts) {
-      const contractPayments = byContract.get(contract.id) || []
-      const oldest = contractPayments.reduce((acc, p) =>
-        new Date(p.due_date) < new Date(acc.due_date) ? p : acc,
-      contractPayments[0])
+      const cps = byContract.get(contract.id) || []
+      if (cps.length === 0) continue
+      const occupant = contract.occupant_id ? occupantsMap.get(contract.occupant_id) : undefined
+      const unitNumber = contract.unit_id ? unitsMap.get(contract.unit_id) ?? '—' : '—'
+      const name = occupant?.name ?? 'inquilino'
+      const phone = occupant?.phone ?? null
 
-      const daysPastDue = Math.floor((today.getTime() - new Date(oldest.due_date).getTime()) / 86400000)
+      const oldest = cps.reduce((acc, p) => (new Date(p.due_date) < new Date(acc.due_date) ? p : acc), cps[0])
+      const daysPastDue = dayDiff(new Date(oldest.due_date), today)
+      const totalDue = cps.reduce((sum, p) => sum + paymentAmount(p), 0)
+
+      // ── Caso A: aún no vence → recordatorio preventivo ────────────────
+      if (daysPastDue < 0) {
+        const daysUntil = -daysPastDue
+        const message = buildReminderMessage({ name, unit: unitNumber, amount: totalDue, daysUntil })
+        escalations.reminder++
+        await dispatch({
+          ctx, supabase, kind: 'reminder', contract, name, unitNumber,
+          phone, message, canSend, daysPastDue, level: 'reminder', totalDue,
+          onSent: () => sentCount++,
+          onResult: (ok) => (ok ? actionsOk++ : actionsFailed++),
+        })
+        continue
+      }
+
       const level = getMoraLevel(daysPastDue)
-      escalations[level] = (escalations[level] || 0) + 1
 
-      const totalOverdue = contractPayments.reduce((sum, p) => {
-        const amount = Number(p.amount || (Number(p.rent_amount || 0) + Number(p.water_fee || 0)))
-        return sum + amount
-      }, 0)
-
-      const unit = units.find((u) => u.id === contract.unit_id)
-
+      // ── Caso B: en gracia (1-5 días) → no molestar todavía ────────────
       if (level === 'grace') {
         await ctx.recordAction({
           action_type: 'cobranza.skip_grace',
@@ -137,56 +179,25 @@ export const cobranzaRunner: AgentRunner = {
         continue
       }
 
-      // v1: registrar acción de notificación (dry-run por defecto)
-      const notifyStatus = dryRun ? 'pending_approval' : 'ok'
-      await ctx.recordAction({
-        action_type: 'cobranza.notify',
-        entity_type: 'contract',
-        entity_id: contract.id,
-        status: notifyStatus,
-        payload: {
-          dry_run: dryRun,
-          tenant_name: contract.tenant_name,
-          unit_number: unit?.unit_number,
-          days_past_due: daysPastDue,
-          level,
-          total_overdue: totalOverdue,
-          payments_count: contractPayments.length,
-        },
-        result: dryRun
-          ? { message: 'dry-run: notificación NO enviada, requiere aprobación humana' }
-          : { message: 'notificación registrada en audit' },
+      // ── Caso C: mora (warning+) → aviso escalado ──────────────────────
+      escalations[level] = (escalations[level] || 0) + 1
+      const message = buildDunningMessage({ name, unit: unitNumber, amount: totalDue, daysPastDue, level })
+      await dispatch({
+        ctx, supabase, kind: 'dunning', contract, name, unitNumber,
+        phone, message, canSend, daysPastDue, level, totalDue,
+        onSent: () => sentCount++,
+        onResult: (ok) => (ok ? actionsOk++ : actionsFailed++),
       })
-
-      // En no-dry-run, además escribimos a audit_log para backward-compat con /api/mora/notify
-      if (!dryRun) {
-        await supabase.from('audit_log').insert({
-          org_id: ctx.orgId,
-          actor_type: 'agent',
-          actor_id: 'cobranza',
-          action: 'mora.notificacion_enviada',
-          entity_type: 'contract',
-          entity_id: contract.id,
-          metadata: {
-            unit_number: unit?.unit_number,
-            tenant_name: contract.tenant_name,
-            days_past_due: daysPastDue,
-            total_overdue: totalOverdue,
-            level,
-            run_id: ctx.runId,
-          },
-        })
-      }
-
-      actionsOk++
     }
 
     return {
       output: {
-        overdue_count: overdue.length,
+        pending_count: rows.length,
         contracts_processed: contracts.length,
         escalations,
+        sent_count: sentCount,
         dry_run: dryRun,
+        whatsapp_enabled: canSend,
       },
       metrics: {
         actions_total: actionsOk + actionsFailed + actionsSkipped,
@@ -196,4 +207,74 @@ export const cobranzaRunner: AgentRunner = {
       },
     }
   },
+}
+
+// Envía (o registra en dry-run) una notificación de cobranza y la audita.
+async function dispatch(args: {
+  ctx: AgentRunContext
+  supabase: ReturnType<typeof createServiceClient>
+  kind: 'reminder' | 'dunning'
+  contract: ContractRow
+  name: string
+  unitNumber: string
+  phone: string | null
+  message: string
+  canSend: boolean
+  daysPastDue: number
+  level: string
+  totalDue: number
+  onSent: () => void
+  onResult: (ok: boolean) => void
+}): Promise<void> {
+  const { ctx, supabase, kind, contract, name, unitNumber, phone, message, canSend, daysPastDue, level, totalDue } = args
+
+  let sent = false
+  let sendError: string | undefined
+  if (canSend && phone) {
+    const res = await sendWhatsAppText(phone, message)
+    sent = res.ok
+    sendError = res.error
+    if (sent) args.onSent()
+  }
+
+  const status: 'ok' | 'skipped' | 'failed' = sent
+    ? 'ok'
+    : canSend && phone
+      ? 'failed' // intentó enviar y falló
+      : 'skipped' // dry-run o sin teléfono
+
+  await ctx.recordAction({
+    action_type: kind === 'reminder' ? 'cobranza.reminder' : 'cobranza.notify',
+    entity_type: 'contract',
+    entity_id: contract.id,
+    status,
+    payload: {
+      channel: 'whatsapp',
+      tenant_name: name,
+      unit_number: unitNumber,
+      has_phone: !!phone,
+      days_past_due: daysPastDue,
+      level,
+      total_due: totalDue,
+      sent,
+    },
+    result: sent
+      ? { message: 'WhatsApp enviado', preview: message.slice(0, 120) }
+      : { message: canSend ? (phone ? `envío falló: ${sendError}` : 'sin teléfono') : 'dry-run: no enviado', preview: message.slice(0, 120) },
+    error: status === 'failed' ? sendError : undefined,
+  })
+
+  if (sent) {
+    await supabase.from('audit_log').insert({
+      org_id: contract.org_id,
+      actor_type: 'agent',
+      actor_id: 'cobranza',
+      action: kind === 'reminder' ? 'cobranza.recordatorio_enviado' : 'mora.notificacion_enviada',
+      entity_type: 'contract',
+      entity_id: contract.id,
+      metadata: { unit_number: unitNumber, tenant_name: name, days_past_due: daysPastDue, level, total_due: totalDue, run_id: ctx.runId },
+    })
+  }
+
+  args.onResult(status !== 'failed')
 }

--- a/src/lib/agents/cobranza.ts
+++ b/src/lib/agents/cobranza.ts
@@ -9,7 +9,7 @@
 // al inquilino y no podía notificar. Ahora resuelve vía occupants.
 
 import { createServiceClient } from '@/lib/api-auth'
-import { getMoraLevel } from '@/lib/mora-engine'
+import { calcMoraSurcharge, getMoraLevelOrder, type MoraLevel } from '@/lib/mora-engine'
 import {
   sendWhatsAppText,
   whatsAppConfigured,
@@ -146,48 +146,75 @@ export const cobranzaRunner: AgentRunner = {
       const name = occupant?.name ?? 'inquilino'
       const phone = occupant?.phone ?? null
 
-      const oldest = cps.reduce((acc, p) => (new Date(p.due_date) < new Date(acc.due_date) ? p : acc), cps[0])
-      const daysPastDue = dayDiff(new Date(oldest.due_date), today)
-      const totalDue = cps.reduce((sum, p) => sum + paymentAmount(p), 0)
+      const overdue = cps.filter((p) => new Date(p.due_date) <= today)
+      const upcoming = cps.filter((p) => new Date(p.due_date) > today)
 
-      // ── Caso A: aún no vence → recordatorio preventivo ────────────────
-      if (daysPastDue < 0) {
-        const daysUntil = -daysPastDue
-        const message = buildReminderMessage({ name, unit: unitNumber, amount: totalDue, daysUntil })
-        escalations.reminder++
+      // ── Caso A: hay pagos vencidos → aplicar mora + aviso escalado ─────
+      if (overdue.length > 0) {
+        let totalDue = 0
+        let worstLevel: MoraLevel = 'grace'
+        let maxDays = 0
+
+        for (const p of overdue) {
+          const days = dayDiff(new Date(p.due_date), today)
+          const base = paymentAmount(p)
+          const { level, amount: fee } = calcMoraSurcharge(base, days)
+          // Persistir el cargo (solo en modo real; dry-run no muta saldos).
+          // Idempotente: cada corrida fija el cargo del nivel ACTUAL del pago,
+          // no lo acumula día a día.
+          if (!dryRun) {
+            await supabase
+              .from('payments')
+              .update({
+                late_fee_amount: fee,
+                late_fee_level: level,
+                late_fee_updated_at: new Date().toISOString(),
+              })
+              .eq('id', p.id)
+          }
+          totalDue += base + fee
+          if (getMoraLevelOrder(level) < getMoraLevelOrder(worstLevel)) worstLevel = level
+          if (days > maxDays) maxDays = days
+        }
+
+        // En gracia (1-5 días): no se molesta al inquilino todavía.
+        if (worstLevel === 'grace') {
+          await ctx.recordAction({
+            action_type: 'cobranza.skip_grace',
+            entity_type: 'contract',
+            entity_id: contract.id,
+            status: 'skipped',
+            payload: { days_past_due: maxDays, level: worstLevel },
+          })
+          actionsSkipped++
+          continue
+        }
+
+        escalations[worstLevel] = (escalations[worstLevel] || 0) + 1
+        const message = buildDunningMessage({ name, unit: unitNumber, amount: totalDue, daysPastDue: maxDays, level: worstLevel })
         await dispatch({
-          ctx, supabase, kind: 'reminder', contract, name, unitNumber,
-          phone, message, canSend, daysPastDue, level: 'reminder', totalDue,
+          ctx, supabase, kind: 'dunning', contract, name, unitNumber,
+          phone, message, canSend, daysPastDue: maxDays, level: worstLevel, totalDue,
           onSent: () => sentCount++,
           onResult: (ok) => (ok ? actionsOk++ : actionsFailed++),
         })
         continue
       }
 
-      const level = getMoraLevel(daysPastDue)
-
-      // ── Caso B: en gracia (1-5 días) → no molestar todavía ────────────
-      if (level === 'grace') {
-        await ctx.recordAction({
-          action_type: 'cobranza.skip_grace',
-          entity_type: 'contract',
-          entity_id: contract.id,
-          status: 'skipped',
-          payload: { days_past_due: daysPastDue, level },
+      // ── Caso B: solo pagos próximos → recordatorio preventivo ─────────
+      if (upcoming.length > 0) {
+        const soonest = upcoming.reduce((acc, p) => (new Date(p.due_date) < new Date(acc.due_date) ? p : acc), upcoming[0])
+        const daysUntil = -dayDiff(new Date(soonest.due_date), today)
+        const amount = paymentAmount(soonest)
+        const message = buildReminderMessage({ name, unit: unitNumber, amount, daysUntil })
+        escalations.reminder++
+        await dispatch({
+          ctx, supabase, kind: 'reminder', contract, name, unitNumber,
+          phone, message, canSend, daysPastDue: -daysUntil, level: 'reminder', totalDue: amount,
+          onSent: () => sentCount++,
+          onResult: (ok) => (ok ? actionsOk++ : actionsFailed++),
         })
-        actionsSkipped++
-        continue
       }
-
-      // ── Caso C: mora (warning+) → aviso escalado ──────────────────────
-      escalations[level] = (escalations[level] || 0) + 1
-      const message = buildDunningMessage({ name, unit: unitNumber, amount: totalDue, daysPastDue, level })
-      await dispatch({
-        ctx, supabase, kind: 'dunning', contract, name, unitNumber,
-        phone, message, canSend, daysPastDue, level, totalDue,
-        onSent: () => sentCount++,
-        onResult: (ok) => (ok ? actionsOk++ : actionsFailed++),
-      })
     }
 
     return {

--- a/src/lib/agents/registry.ts
+++ b/src/lib/agents/registry.ts
@@ -1,11 +1,13 @@
 // BaW OS — Registry de runners disponibles (S4-3)
-// Solo Cobranza v1 implementado. El resto se suma cuando salgan de 'planned'.
+// Implementados: Cobranza y Renovaciones. El resto se suma cuando salga de 'planned'.
 
 import { cobranzaRunner } from './cobranza'
+import { renovacionesRunner } from './renovaciones'
 import type { AgentId, AgentRunner } from './types'
 
 const REGISTRY: Partial<Record<AgentId, AgentRunner>> = {
   cobranza: cobranzaRunner,
+  renovaciones: renovacionesRunner,
 }
 
 export function getAgentRunner(agentId: AgentId): AgentRunner | null {

--- a/src/lib/agents/renovaciones.ts
+++ b/src/lib/agents/renovaciones.ts
@@ -1,0 +1,143 @@
+// BaW OS — Agente Renovaciones (Bloque 2: ciclo de vida del contrato).
+// Detecta contratos que vencen pronto o que ya vencieron sin renovar y los pasa a
+// 'en_renovacion', SIN cortar la facturación (decisión de Fran 2026-06-15: cubre la
+// tácita reconducción — el inquilino que sigue viviendo se mantiene cobrado).
+// Nunca pone 'expired' solo (eso detiene la renta mensual y es decisión humana).
+//
+// Gate: igual que cobranza. En dry-run no muta estado ni envía WhatsApp; solo
+// registra en audit lo que HARÍA. En modo real (COBRANZA_WHATSAPP_ENABLED='true')
+// hace el flip de estado y manda el aviso de renovación al inquilino.
+
+import { createServiceClient } from '@/lib/api-auth'
+import { sendWhatsAppText, whatsAppConfigured, buildRenewalMessage } from '@/lib/whatsapp'
+import type { AgentRunContext, AgentRunResult, AgentRunner } from './types'
+
+const RENEWAL_WINDOW_DAYS = 30 // marca en_renovacion desde 30 días antes del vencimiento
+
+interface ContractRow {
+  id: string
+  unit_id: string | null
+  occupant_id: string | null
+  org_id: string
+  end_date: string | null
+  status: string | null
+}
+
+function dayDiff(from: Date, to: Date): number {
+  return Math.floor((to.getTime() - from.getTime()) / 86_400_000)
+}
+
+export const renovacionesRunner: AgentRunner = {
+  agentId: 'renovaciones',
+
+  async run(ctx: AgentRunContext): Promise<AgentRunResult> {
+    const supabase = createServiceClient()
+    const dryRun = ctx.input.dry_run !== false
+    const canSend = !dryRun && whatsAppConfigured()
+    const today = new Date()
+    const horizon = new Date(today.getTime() + RENEWAL_WINDOW_DAYS * 86_400_000)
+      .toISOString()
+      .slice(0, 10)
+
+    // Contratos activos con fin de vigencia hasta el horizonte (incluye ya vencidos).
+    const { data: cRows, error } = await supabase
+      .from('contracts')
+      .select('id, unit_id, occupant_id, org_id, end_date, status')
+      .eq('org_id', ctx.orgId)
+      .eq('status', 'active')
+      .not('end_date', 'is', null)
+      .lte('end_date', horizon)
+      .limit(1000)
+
+    if (error) {
+      await ctx.recordAction({ action_type: 'renovaciones.fetch', status: 'failed', error: error.message })
+      return { output: { error: 'fetch_failed' }, metrics: { actions_total: 1, actions_ok: 0, actions_failed: 1 } }
+    }
+
+    const contracts = (cRows || []) as ContractRow[]
+    if (contracts.length === 0) {
+      await ctx.recordAction({ action_type: 'renovaciones.scan_complete', status: 'ok', result: { due_count: 0 } })
+      return { output: { message: 'no contracts due for renewal', due_count: 0 }, metrics: { actions_total: 1, actions_ok: 1, actions_failed: 0 } }
+    }
+
+    // Resolver inquilinos y unidades para el aviso.
+    const occupantIds = contracts.map((c) => c.occupant_id).filter(Boolean) as string[]
+    const unitIds = contracts.map((c) => c.unit_id).filter(Boolean) as string[]
+    const occupantsMap = new Map<string, { name: string; phone: string | null }>()
+    if (occupantIds.length) {
+      const { data } = await supabase.from('occupants').select('id, name, phone').in('id', occupantIds)
+      for (const o of data || []) {
+        occupantsMap.set(o.id as string, { name: (o.name as string) || 'inquilino', phone: (o.phone as string) || null })
+      }
+    }
+    const unitsMap = new Map<string, string>()
+    if (unitIds.length) {
+      const { data } = await supabase.from('units').select('id, number').in('id', unitIds)
+      for (const u of data || []) unitsMap.set(u.id as string, (u.number as string) || '—')
+    }
+
+    let actionsOk = 0
+    let actionsFailed = 0
+    let sentCount = 0
+    let flippedCount = 0
+
+    for (const contract of contracts) {
+      if (!contract.end_date) continue
+      const occupant = contract.occupant_id ? occupantsMap.get(contract.occupant_id) : undefined
+      const unitNumber = contract.unit_id ? unitsMap.get(contract.unit_id) ?? '—' : '—'
+      const name = occupant?.name ?? 'inquilino'
+      const phone = occupant?.phone ?? null
+      const daysUntil = -dayDiff(today, new Date(contract.end_date))
+      const expired = daysUntil < 0
+
+      // 1. Flip de estado a en_renovacion (solo en modo real). Mantiene la facturación.
+      if (!dryRun) {
+        const { error: upErr } = await supabase
+          .from('contracts')
+          .update({ status: 'en_renovacion' })
+          .eq('id', contract.id)
+        if (upErr) {
+          await ctx.recordAction({
+            action_type: 'renovaciones.flip_status',
+            entity_type: 'contract',
+            entity_id: contract.id,
+            status: 'failed',
+            error: upErr.message,
+          })
+          actionsFailed++
+          continue
+        }
+        flippedCount++
+      }
+
+      // 2. Aviso de renovación al inquilino (gated; no rompe si falta teléfono).
+      let sent = false
+      if (canSend && phone) {
+        const message = buildRenewalMessage({ name, unit: unitNumber, endDate: contract.end_date, daysUntil })
+        const res = await sendWhatsAppText(phone, message)
+        sent = res.ok
+        if (res.ok) sentCount++
+      }
+
+      await ctx.recordAction({
+        action_type: 'renovaciones.flag',
+        entity_type: 'contract',
+        entity_id: contract.id,
+        status: 'ok',
+        payload: { end_date: contract.end_date, days_until: daysUntil, expired, dry_run: dryRun },
+        result: { flipped: !dryRun, notified: sent },
+      })
+      actionsOk++
+    }
+
+    return {
+      output: {
+        message: dryRun ? 'dry-run: no se mutó estado ni se envió' : 'renovaciones procesadas',
+        due_count: contracts.length,
+        flipped: flippedCount,
+        notified: sentCount,
+      },
+      metrics: { actions_total: actionsOk + actionsFailed, actions_ok: actionsOk, actions_failed: actionsFailed },
+    }
+  },
+}

--- a/src/lib/agents/types.ts
+++ b/src/lib/agents/types.ts
@@ -3,6 +3,7 @@
 export type AgentId =
   | 'baw'
   | 'cobranza'
+  | 'renovaciones'
   | 'reservas'
   | 'mantenimiento'
   | 'huesped'

--- a/src/lib/agents/v1/dispatcher.ts
+++ b/src/lib/agents/v1/dispatcher.ts
@@ -86,6 +86,38 @@ export async function dispatchApprovedAction(ctx: DispatchContext): Promise<Disp
       return { ok: true, result: { id: data.id }, entityType: 'task', entityId: data.id as string }
     }
 
+    case 'unit.create': {
+      const p = ctx.payload as {
+        number: string
+        type?: string
+        floor?: number
+        status?: string
+        area_m2?: number
+        bedrooms?: number
+        bathrooms?: number
+        amenities?: string[]
+        notes?: string
+      }
+      const { data, error } = await supabase
+        .from('units')
+        .insert({
+          org_id: ctx.orgId,
+          number: p.number,
+          type: p.type ?? 'LTR',
+          floor: p.floor ?? null,
+          status: p.status ?? 'available',
+          area_m2: p.area_m2 ?? null,
+          bedrooms: p.bedrooms ?? null,
+          bathrooms: p.bathrooms ?? null,
+          amenities: p.amenities ?? null,
+          notes: p.notes ?? null,
+        })
+        .select('id')
+        .single()
+      if (error || !data) return { ok: false, error: error?.message || 'insert failed' }
+      return { ok: true, result: { id: data.id }, entityType: 'unit', entityId: data.id as string }
+    }
+
     case 'payment.record': {
       const p = ctx.payload as {
         contract_id: string

--- a/src/lib/mora-engine.ts
+++ b/src/lib/mora-engine.ts
@@ -22,6 +22,30 @@ export function getMoraLevel(daysPastDue: number): MoraLevel {
   return "abogado"
 }
 
+/**
+ * Recargo por mora ESCALONADO por nivel (decisión de Fran 2026-06-15).
+ * Tasa sobre el monto vencido. Ajusta estos valores si cambia la política.
+ *   gracia (1-5d): 0% · warning (6-15d): 3% · crítico (16-30d): 10%
+ *   legal (31-60d): 15% · abogado (60+d): 20%
+ */
+export function getMoraSurchargeRate(level: MoraLevel): number {
+  switch (level) {
+    case "grace": return 0
+    case "warning": return 0.03
+    case "critical": return 0.10
+    case "legal": return 0.15
+    case "abogado": return 0.20
+  }
+}
+
+/** Calcula el cargo por mora en pesos para un monto base y días de atraso. */
+export function calcMoraSurcharge(baseAmount: number, daysPastDue: number): { level: MoraLevel; rate: number; amount: number } {
+  const level = getMoraLevel(daysPastDue)
+  const rate = getMoraSurchargeRate(level)
+  const amount = Math.round(Number(baseAmount) * rate * 100) / 100
+  return { level, rate, amount }
+}
+
 export function getMoraColor(level: MoraLevel): string {
   switch (level) {
     case "grace": return "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-300 dark:border-yellow-700"

--- a/src/lib/mora-engine.ts
+++ b/src/lib/mora-engine.ts
@@ -23,18 +23,19 @@ export function getMoraLevel(daysPastDue: number): MoraLevel {
 }
 
 /**
- * Recargo por mora ESCALONADO por nivel (decisión de Fran 2026-06-15).
- * Tasa sobre el monto vencido. Ajusta estos valores si cambia la política.
- *   gracia (1-5d): 0% · warning (6-15d): 3% · crítico (16-30d): 10%
- *   legal (31-60d): 15% · abogado (60+d): 20%
+ * Recargo por mora ESCALONADO por días (política de Fran 2026-06-15).
+ * Tasa sobre el total mensual vencido. Solo dos escalones:
+ *   gracia (1-5d): 0% · 6-15 días: 5% · 16+ días: 10%
+ * Los niveles legal/abogado conservan el 10% (no suben el recargo, solo el tono
+ * del mensaje y el escalamiento operativo).
  */
 export function getMoraSurchargeRate(level: MoraLevel): number {
   switch (level) {
     case "grace": return 0
-    case "warning": return 0.03
+    case "warning": return 0.05
     case "critical": return 0.10
-    case "legal": return 0.15
-    case "abogado": return 0.20
+    case "legal": return 0.10
+    case "abogado": return 0.10
   }
 }
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -47,7 +47,18 @@ export type SidebarSection = {
   routes: string[]
   /** Horizontal sub-nav shown above content (omit if section has 1 view) */
   subNav?: SubNavItem[]
+  /**
+   * Roles de org con permiso para VER esta sección en el menú. Si se omite, la
+   * sección es visible para cualquier miembro de la org. Gating de UX (esconder
+   * lo inaccesible); la autorización real vive en cada page/endpoint.
+   */
+  visibleToRoles?: string[]
 }
+
+// Roles con permisos de admin de tenant (L1). pm_* canónicos + owner/admin
+// legacy (issue #23). Duplicado aquí a propósito: navigation.ts lo importa el
+// Sidebar (client component) y no puede depender de admin-auth (server-only).
+export const ORG_ADMIN_ROLES = ['pm_owner', 'pm_admin', 'owner', 'admin']
 
 export const SIDEBAR_SECTIONS: SidebarSection[] = [
   {
@@ -148,6 +159,8 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     icon: 'Bot',
     placement: 'footer',
     routes: ['/agents'],
+    // Conectar/configurar agentes y sus credenciales = admin de la cuenta.
+    visibleToRoles: ORG_ADMIN_ROLES,
   },
   {
     id: 'settings',
@@ -156,6 +169,9 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     icon: 'Settings2',
     placement: 'footer',
     routes: ['/settings', '/onboarding', '/api-docs'],
+    // Config de la organización y miembros = admin. El perfil personal de cada
+    // usuario vive en /me (accesible desde el menú de perfil), no aquí.
+    visibleToRoles: ORG_ADMIN_ROLES,
     subNav: [
       { href: '/settings', label: 'General' },
       { href: '/onboarding', label: 'Configurar cuenta' },
@@ -163,6 +179,22 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     ],
   },
 ]
+
+/**
+ * Filtra las secciones visibles según el rol de org del usuario.
+ * Si `role` es null/undefined (sesión aún cargando) devuelve todas para evitar
+ * parpadeo; el caller debe esperar a que el rol resuelva antes de confiar en
+ * el filtro para roles bajos.
+ */
+export function filterSectionsByRole(
+  sections: SidebarSection[],
+  role: string | null | undefined,
+): SidebarSection[] {
+  if (!role) return sections
+  return sections.filter(
+    (s) => !s.visibleToRoles || s.visibleToRoles.includes(role),
+  )
+}
 
 /** Returns the section the given pathname belongs to, or null. */
 export function findSection(pathname: string): SidebarSection | null {

--- a/src/lib/org-context.ts
+++ b/src/lib/org-context.ts
@@ -136,7 +136,29 @@ export async function resolveOrgIdFromRequest(
 ): Promise<string> {
   const headerOrgId = request.headers.get('x-org-id')
   if (headerOrgId) {
-    // Validar que la sesión efectivamente pertenece a esa org
+    // Audit 2026-06-12: el header NO se confía a ciegas — un usuario de la
+    // org A podía mandar `x-org-id: <org B>` y operar sobre datos ajenos.
+    // Validamos que la sesión actual sea miembro de esa org.
+    const supabase = createSupabaseServer()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) {
+      throw new OrgContextError('No authenticated user', 'NO_SESSION')
+    }
+    const service = createServiceClient()
+    const { data: membership } = await service
+      .from('org_members')
+      .select('org_id')
+      .eq('user_id', user.id)
+      .eq('org_id', headerOrgId)
+      .maybeSingle()
+    if (!membership) {
+      throw new OrgContextError(
+        'User is not a member of the requested org',
+        'INVALID_ORG',
+      )
+    }
     return headerOrgId
   }
   return resolveOrgId()

--- a/src/lib/payment-receipt.ts
+++ b/src/lib/payment-receipt.ts
@@ -1,0 +1,82 @@
+// BaW OS — Envío de comprobante de pago por WhatsApp (Bloque 1: cobranza).
+// Reutilizable desde varios puntos donde se registra un pago: API v1 de Alicia,
+// webhook de Stripe, y el flujo manual de /cobros (vía /api/payments/[id]/receipt).
+//
+// Gateado por las mismas condiciones que la cobranza: solo envía si las
+// credenciales de Meta están y COBRANZA_WHATSAPP_ENABLED='true'.
+
+import { createServiceClient } from '@/lib/api-auth'
+import {
+  sendWhatsAppText,
+  whatsAppConfigured,
+  cobranzaWhatsAppEnabled,
+  buildReceiptMessage,
+} from '@/lib/whatsapp'
+
+export interface ReceiptResult {
+  ok: boolean
+  reason?: string
+}
+
+/** Envía el comprobante del pago indicado. No lanza; seguro como fire-and-forget. */
+export async function sendPaymentReceipt(paymentId: string): Promise<ReceiptResult> {
+  try {
+    if (!whatsAppConfigured() || !cobranzaWhatsAppEnabled()) {
+      return { ok: false, reason: 'whatsapp_disabled' }
+    }
+    const supabase = createServiceClient()
+
+    const { data: payment } = await supabase
+      .from('payments')
+      .select('id, org_id, contract_id, amount, amount_paid, paid_date, method, reference, late_fee_amount')
+      .eq('id', paymentId)
+      .maybeSingle()
+    if (!payment || !payment.contract_id) return { ok: false, reason: 'payment_not_found' }
+
+    const { data: contract } = await supabase
+      .from('contracts')
+      .select('id, occupant_id, unit_id')
+      .eq('id', payment.contract_id as string)
+      .maybeSingle()
+    if (!contract) return { ok: false, reason: 'contract_not_found' }
+
+    const [{ data: occupant }, { data: unit }] = await Promise.all([
+      contract.occupant_id
+        ? supabase.from('occupants').select('name, phone').eq('id', contract.occupant_id as string).maybeSingle()
+        : Promise.resolve({ data: null }),
+      contract.unit_id
+        ? supabase.from('units').select('number').eq('id', contract.unit_id as string).maybeSingle()
+        : Promise.resolve({ data: null }),
+    ])
+
+    const phone = (occupant?.phone as string) || null
+    if (!phone) return { ok: false, reason: 'no_phone' }
+
+    const paidAmount = Number(payment.amount_paid ?? payment.amount ?? 0)
+    const message = buildReceiptMessage({
+      name: (occupant?.name as string) || 'inquilino',
+      unit: (unit?.number as string) || '—',
+      amount: paidAmount,
+      method: payment.method as string | null,
+      reference: payment.reference as string | null,
+      date: payment.paid_date as string | null,
+    })
+
+    const res = await sendWhatsAppText(phone, message)
+    if (!res.ok) return { ok: false, reason: res.error }
+
+    await supabase.from('audit_log').insert({
+      org_id: payment.org_id,
+      actor_type: 'agent',
+      actor_id: 'cobranza',
+      action: 'pago.comprobante_enviado',
+      entity_type: 'payment',
+      entity_id: payment.id,
+      metadata: { to: phone, amount: paidAmount },
+    })
+
+    return { ok: true }
+  } catch (e) {
+    return { ok: false, reason: e instanceof Error ? e.message : 'error' }
+  }
+}

--- a/src/lib/whatsapp.ts
+++ b/src/lib/whatsapp.ts
@@ -66,15 +66,20 @@ function fmtMoney(amount: number): string {
   return `$${Number(amount).toLocaleString('es-MX', { minimumFractionDigits: 0 })} MXN`
 }
 
+function portalLine(portalUrl?: string | null): string {
+  return portalUrl ? ` Revisa tu estado de cuenta y paga aquí: ${portalUrl}` : ' Revisa tu estado de cuenta en tu portal.'
+}
+
 /** Recordatorio preventivo: el pago vence en N días. */
 export function buildReminderMessage(o: {
   name: string
   unit: string
   amount: number
   daysUntil: number
+  portalUrl?: string | null
 }): string {
   const cuando = o.daysUntil <= 0 ? 'vence HOY' : `vence en ${o.daysUntil} día${o.daysUntil === 1 ? '' : 's'}`
-  return `Hola ${o.name} 👋 Te recordamos que la renta del depto ${o.unit} por ${fmtMoney(o.amount)} ${cuando}. Puedes pagar y revisar tu estado de cuenta desde tu portal. ¡Gracias! — BaW`
+  return `Hola ${o.name} 👋 Te recordamos que la renta del depto ${o.unit} por ${fmtMoney(o.amount)} ${cuando}.${portalLine(o.portalUrl)} ¡Gracias! — BaW`
 }
 
 /** Comprobante: confirmación de pago recibido. */
@@ -99,17 +104,19 @@ export function buildDunningMessage(o: {
   amount: number
   daysPastDue: number
   level: MoraLevel
+  portalUrl?: string | null
 }): string {
-  const base = `Hola ${o.name}, la renta del depto ${o.unit} por ${fmtMoney(o.amount)} tiene ${o.daysPastDue} día${o.daysPastDue === 1 ? '' : 's'} de atraso.`
+  const base = `Hola ${o.name}, la renta del depto ${o.unit} por ${fmtMoney(o.amount)} (incluye cargo por mora) tiene ${o.daysPastDue} día${o.daysPastDue === 1 ? '' : 's'} de atraso.`
+  const portal = portalLine(o.portalUrl)
   switch (o.level) {
     case 'warning':
-      return `${base} Te pedimos regularizar tu pago a la brevedad para evitar cargos por mora. Cualquier duda, contáctanos. — BaW Admin`
+      return `${base} Te pedimos regularizar tu pago a la brevedad.${portal} Cualquier duda, contáctanos. — BaW Admin`
     case 'critical':
-      return `${base} Se aplica un cargo por mora. Por favor regulariza con urgencia; revisa tu estado de cuenta en tu portal. — BaW Admin`
+      return `${base} Por favor regulariza con urgencia.${portal} — BaW Admin`
     case 'legal':
-      return `⚠️ ${base} Tu cuenta entró en proceso de aviso legal. Contáctanos hoy mismo para evitar acciones adicionales. — BaW Admin`
+      return `⚠️ ${base} Tu cuenta entró en proceso de aviso legal. Contáctanos hoy mismo para evitar acciones adicionales.${portal} — BaW Admin`
     case 'abogado':
-      return `🚨 ${base} Tu cuenta fue escalada a cobranza legal. Es indispensable que te comuniques de inmediato. — BaW Admin`
+      return `🚨 ${base} Tu cuenta fue escalada a cobranza legal. Es indispensable que te comuniques de inmediato.${portal} — BaW Admin`
     default:
       return base
   }

--- a/src/lib/whatsapp.ts
+++ b/src/lib/whatsapp.ts
@@ -77,6 +77,21 @@ export function buildReminderMessage(o: {
   return `Hola ${o.name} 👋 Te recordamos que la renta del depto ${o.unit} por ${fmtMoney(o.amount)} ${cuando}. Puedes pagar y revisar tu estado de cuenta desde tu portal. ¡Gracias! — BaW`
 }
 
+/** Comprobante: confirmación de pago recibido. */
+export function buildReceiptMessage(o: {
+  name: string
+  unit: string
+  amount: number
+  method?: string | null
+  reference?: string | null
+  date?: string | null
+}): string {
+  const metodo = o.method ? ` (${o.method})` : ''
+  const ref = o.reference ? ` Ref: ${o.reference}.` : ''
+  const fecha = o.date ? ` el ${o.date}` : ''
+  return `Hola ${o.name} ✅ Recibimos tu pago de ${fmtMoney(o.amount)} del depto ${o.unit}${metodo}${fecha}.${ref} ¡Gracias! Puedes ver tu estado de cuenta en tu portal. — BaW`
+}
+
 /** Aviso de mora según el nivel de escalamiento. */
 export function buildDunningMessage(o: {
   name: string

--- a/src/lib/whatsapp.ts
+++ b/src/lib/whatsapp.ts
@@ -1,0 +1,101 @@
+// BaW OS — WhatsApp Business (Meta Cloud API) — sender + plantillas de cobranza
+//
+// Helper server-side reutilizable para enviar mensajes reales. El disparo
+// automático de cobranza está detrás de COBRANZA_WHATSAPP_ENABLED para que el
+// despliegue sea seguro: nada se envía hasta que Fran lo encienda con sus
+// credenciales de Meta.
+
+import type { MoraLevel } from '@/lib/mora-engine'
+
+export interface WhatsAppSendResult {
+  ok: boolean
+  error?: string
+  messageId?: string
+}
+
+/** ¿Están las credenciales de Meta configuradas? */
+export function whatsAppConfigured(): boolean {
+  return !!(process.env.WHATSAPP_ACCESS_TOKEN && process.env.WHATSAPP_PHONE_NUMBER_ID)
+}
+
+/** Gate maestro: el envío automático de cobranza solo ocurre si esto es 'true'. */
+export function cobranzaWhatsAppEnabled(): boolean {
+  return process.env.COBRANZA_WHATSAPP_ENABLED === 'true'
+}
+
+/** Envía un mensaje de texto por WhatsApp Business. No lanza; devuelve el resultado. */
+export async function sendWhatsAppText(
+  to: string,
+  message: string,
+): Promise<WhatsAppSendResult> {
+  const accessToken = process.env.WHATSAPP_ACCESS_TOKEN
+  const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID
+  if (!accessToken || !phoneNumberId) return { ok: false, error: 'whatsapp_not_configured' }
+  if (!to) return { ok: false, error: 'missing_recipient' }
+
+  try {
+    const res = await fetch(
+      `https://graph.facebook.com/v18.0/${phoneNumberId}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          messaging_product: 'whatsapp',
+          to,
+          type: 'text',
+          text: { body: message },
+        }),
+        signal: AbortSignal.timeout(10_000),
+      },
+    )
+    const json = (await res.json().catch(() => ({}))) as {
+      error?: { message?: string }
+      messages?: Array<{ id?: string }>
+    }
+    if (!res.ok) return { ok: false, error: json?.error?.message ?? `meta_error_${res.status}` }
+    return { ok: true, messageId: json?.messages?.[0]?.id }
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'send_failed' }
+  }
+}
+
+function fmtMoney(amount: number): string {
+  return `$${Number(amount).toLocaleString('es-MX', { minimumFractionDigits: 0 })} MXN`
+}
+
+/** Recordatorio preventivo: el pago vence en N días. */
+export function buildReminderMessage(o: {
+  name: string
+  unit: string
+  amount: number
+  daysUntil: number
+}): string {
+  const cuando = o.daysUntil <= 0 ? 'vence HOY' : `vence en ${o.daysUntil} día${o.daysUntil === 1 ? '' : 's'}`
+  return `Hola ${o.name} 👋 Te recordamos que la renta del depto ${o.unit} por ${fmtMoney(o.amount)} ${cuando}. Puedes pagar y revisar tu estado de cuenta desde tu portal. ¡Gracias! — BaW`
+}
+
+/** Aviso de mora según el nivel de escalamiento. */
+export function buildDunningMessage(o: {
+  name: string
+  unit: string
+  amount: number
+  daysPastDue: number
+  level: MoraLevel
+}): string {
+  const base = `Hola ${o.name}, la renta del depto ${o.unit} por ${fmtMoney(o.amount)} tiene ${o.daysPastDue} día${o.daysPastDue === 1 ? '' : 's'} de atraso.`
+  switch (o.level) {
+    case 'warning':
+      return `${base} Te pedimos regularizar tu pago a la brevedad para evitar cargos por mora. Cualquier duda, contáctanos. — BaW Admin`
+    case 'critical':
+      return `${base} Se aplica un cargo por mora. Por favor regulariza con urgencia; revisa tu estado de cuenta en tu portal. — BaW Admin`
+    case 'legal':
+      return `⚠️ ${base} Tu cuenta entró en proceso de aviso legal. Contáctanos hoy mismo para evitar acciones adicionales. — BaW Admin`
+    case 'abogado':
+      return `🚨 ${base} Tu cuenta fue escalada a cobranza legal. Es indispensable que te comuniques de inmediato. — BaW Admin`
+    default:
+      return base
+  }
+}

--- a/src/lib/whatsapp.ts
+++ b/src/lib/whatsapp.ts
@@ -97,6 +97,20 @@ export function buildReceiptMessage(o: {
   return `Hola ${o.name} ✅ Recibimos tu pago de ${fmtMoney(o.amount)} del depto ${o.unit}${metodo}${fecha}.${ref} ¡Gracias! Puedes ver tu estado de cuenta en tu portal. — BaW`
 }
 
+/** Aviso de renovación: el contrato vence pronto o ya venció (sigue vigente). */
+export function buildRenewalMessage(o: {
+  name: string
+  unit: string
+  endDate: string
+  daysUntil: number
+}): string {
+  if (o.daysUntil < 0) {
+    return `Hola ${o.name} 👋 Tu contrato del depto ${o.unit} venció el ${o.endDate}, pero sigue vigente mientras lo renovamos. Para no dejar pendientes, contáctanos y armamos tu renovación. — BaW Admin`
+  }
+  const cuando = o.daysUntil === 0 ? 'vence HOY' : `vence en ${o.daysUntil} día${o.daysUntil === 1 ? '' : 's'} (${o.endDate})`
+  return `Hola ${o.name} 👋 Te avisamos que tu contrato del depto ${o.unit} ${cuando}. Si deseas renovar, contáctanos y lo dejamos listo a tiempo. ¡Gracias por seguir con nosotros! — BaW Admin`
+}
+
 /** Aviso de mora según el nivel de escalamiento. */
 export function buildDunningMessage(o: {
   name: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@
 export type UnitType = 'STR' | 'MTR' | 'LTR' | 'OFFICE' | 'COMMON'
 export type UnitStatus = 'available' | 'occupied' | 'maintenance' | 'reserved' | 'inactive'
 export type ContractStatus = 'active' | 'expired' | 'terminated' | 'pending' | 'renewed' | 'en_renovacion'
+export type RentType = 'LTR' | 'MTR' | 'STR' // larga / media / corta
 export type PaymentStatus = 'pending' | 'paid' | 'late' | 'partial' | 'waived'
 export type IncidentStatus = 'open' | 'in_progress' | 'waiting_parts' | 'resolved' | 'cancelled'
 export type IncidentPriority = 'low' | 'medium' | 'high' | 'urgent'
@@ -191,6 +192,7 @@ export interface Contract {
   deposit_paid: boolean
   payment_day: number
   status: ContractStatus
+  rent_type?: RentType
   contract_url?: string
   drive_folder_url?: string
   notes?: string

--- a/supabase/migrations/20260612_rls_close_allow_all.sql
+++ b/supabase/migrations/20260612_rls_close_allow_all.sql
@@ -1,0 +1,115 @@
+-- BaW OS — Security audit 2026-06-12: cerrar RLS allow_all en org_members y
+-- user_profiles (introducidas en 20260416_settings_mvp.sql).
+--
+-- BUG CRÍTICO que esto corrige: con `org_members_allow_all` (USING true,
+-- WITH CHECK true), cualquier usuario autenticado podía leer/editar/borrar
+-- membresías de CUALQUIER org — incluyendo auto-promoverse a pm_owner de una
+-- org ajena. Lo mismo para perfiles en user_profiles.
+--
+-- Diseño: las políticas de org_members no pueden referenciarse a sí mismas
+-- (recursión infinita en PG), así que usamos funciones SECURITY DEFINER.
+-- Los roles admin aceptan pm_* (canónicos) y owner/admin (legacy, issue #23).
+-- service_role bypassa RLS por diseño (las APIs server-side no cambian).
+
+BEGIN;
+
+-- =====================================================================
+-- 1) Helpers SECURITY DEFINER (evitan recursión y centralizan la lógica)
+-- =====================================================================
+CREATE OR REPLACE FUNCTION public.user_org_ids(uid uuid)
+RETURNS SETOF uuid
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT org_id FROM public.org_members
+  WHERE user_id = uid AND is_active = true
+$$;
+
+CREATE OR REPLACE FUNCTION public.user_is_org_admin(uid uuid, org uuid)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.org_members
+    WHERE user_id = uid
+      AND org_id = org
+      AND is_active = true
+      AND role IN (
+        'pm_owner'::member_role, 'pm_admin'::member_role,
+        'owner'::member_role, 'admin'::member_role  -- legacy, issue #23
+      )
+  )
+$$;
+
+REVOKE ALL ON FUNCTION public.user_org_ids(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.user_is_org_admin(uuid, uuid) FROM anon;
+
+-- =====================================================================
+-- 2) org_members — reemplazar allow_all por políticas reales
+-- =====================================================================
+ALTER TABLE public.org_members ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS org_members_allow_all ON public.org_members;
+
+-- Ver: tu propia membresía + el roster de tus orgs
+DROP POLICY IF EXISTS org_members_select ON public.org_members;
+CREATE POLICY org_members_select ON public.org_members
+  FOR SELECT
+  USING (
+    user_id = auth.uid()
+    OR org_id IN (SELECT public.user_org_ids(auth.uid()))
+  );
+
+-- Crear/editar/borrar membresías: solo admins de ESA org
+DROP POLICY IF EXISTS org_members_insert ON public.org_members;
+CREATE POLICY org_members_insert ON public.org_members
+  FOR INSERT
+  WITH CHECK (public.user_is_org_admin(auth.uid(), org_id));
+
+DROP POLICY IF EXISTS org_members_update ON public.org_members;
+CREATE POLICY org_members_update ON public.org_members
+  FOR UPDATE
+  USING (public.user_is_org_admin(auth.uid(), org_id))
+  WITH CHECK (public.user_is_org_admin(auth.uid(), org_id));
+
+DROP POLICY IF EXISTS org_members_delete ON public.org_members;
+CREATE POLICY org_members_delete ON public.org_members
+  FOR DELETE
+  USING (public.user_is_org_admin(auth.uid(), org_id));
+
+-- =====================================================================
+-- 3) user_profiles — reemplazar allow_all
+-- =====================================================================
+ALTER TABLE public.user_profiles ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS user_profiles_allow_all ON public.user_profiles;
+
+-- Ver: tu propio perfil + perfiles de compañeros de org (para el roster)
+DROP POLICY IF EXISTS user_profiles_select ON public.user_profiles;
+CREATE POLICY user_profiles_select ON public.user_profiles
+  FOR SELECT
+  USING (
+    id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.org_members om
+      WHERE om.user_id = user_profiles.id
+        AND om.org_id IN (SELECT public.user_org_ids(auth.uid()))
+    )
+  );
+
+-- Escribir: solo tu propio perfil
+DROP POLICY IF EXISTS user_profiles_insert ON public.user_profiles;
+CREATE POLICY user_profiles_insert ON public.user_profiles
+  FOR INSERT
+  WITH CHECK (id = auth.uid());
+
+DROP POLICY IF EXISTS user_profiles_update ON public.user_profiles;
+CREATE POLICY user_profiles_update ON public.user_profiles
+  FOR UPDATE
+  USING (id = auth.uid())
+  WITH CHECK (id = auth.uid());
+
+COMMIT;
+
+-- Rollback (NO usar salvo emergencia — reabre el hueco de seguridad):
+--   CREATE POLICY org_members_allow_all ON org_members FOR ALL USING (true) WITH CHECK (true);
+--   CREATE POLICY user_profiles_allow_all ON user_profiles FOR ALL USING (true) WITH CHECK (true);

--- a/supabase/migrations/20260615_contract_status_en_renovacion.sql
+++ b/supabase/migrations/20260615_contract_status_en_renovacion.sql
@@ -1,0 +1,19 @@
+-- BaW OS — Fix: agregar 'en_renovacion' al enum contract_status.
+--
+-- BUG: el código usa status='en_renovacion' (contracts/page.tsx, renovación,
+-- alertas) y la migración 20260330_contracts_legal.sql afirma que es "valid
+-- value" pero NUNCA lo agregó al tipo. Si la columna sigue siendo el ENUM
+-- contract_status, cualquier UPDATE a 'en_renovacion' falla (invalid input
+-- value for enum). Esto rompe el flujo de renovación de contratos.
+--
+-- Defensivo: solo actúa si el tipo enum existe (si la columna ya fue convertida
+-- a TEXT en prod, no hay nada que hacer y este bloque no falla). ADD VALUE IF
+-- NOT EXISTS es idempotente.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'contract_status') THEN
+    ALTER TYPE contract_status ADD VALUE IF NOT EXISTS 'en_renovacion';
+  END IF;
+END
+$$;

--- a/supabase/migrations/20260615_contracts_rent_type.sql
+++ b/supabase/migrations/20260615_contracts_rent_type.sql
@@ -1,0 +1,31 @@
+-- BaW OS — Tipo de renta explícito en contratos (Bloque 2).
+-- Antes el tipo de renta (larga/media/corta) solo se infería del unit.type. Ahora
+-- el contrato lo declara explícitamente: permite que la generación mensual de renta
+-- omita estancias cortas (STR, que se cobran por reserva, no por mes) y habilita
+-- reportes por modalidad. Se respalda la taxonomía existente UnitType (LTR/MTR/STR).
+--
+-- Aditiva + idempotente. Rollback: ALTER TABLE contracts DROP COLUMN rent_type.
+
+ALTER TABLE public.contracts
+  ADD COLUMN IF NOT EXISTS rent_type TEXT NOT NULL DEFAULT 'LTR';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'contracts_rent_type_chk'
+  ) THEN
+    ALTER TABLE public.contracts
+      ADD CONSTRAINT contracts_rent_type_chk CHECK (rent_type IN ('LTR', 'MTR', 'STR'));
+  END IF;
+END$$;
+
+-- Backfill: arrastrar el tipo desde la unidad cuando aplica.
+UPDATE public.contracts c
+SET rent_type = u.type
+FROM public.units u
+WHERE c.unit_id = u.id
+  AND u.type IN ('LTR', 'MTR', 'STR')
+  AND c.rent_type = 'LTR';
+
+COMMENT ON COLUMN public.contracts.rent_type IS
+  'Modalidad de renta: LTR (larga), MTR (media), STR (corta). STR no genera renta mensual automática.';

--- a/supabase/migrations/20260615_payments_late_fee.sql
+++ b/supabase/migrations/20260615_payments_late_fee.sql
@@ -1,0 +1,14 @@
+-- BaW OS — Cargos moratorios persistidos (Bloque 1: cobranza).
+-- Antes el recargo por mora (3%/10%...) se calculaba solo en la UI y NUNCA se
+-- guardaba: el inquilino "debía" un monto que no estaba en el sistema. Ahora el
+-- runner de cobranza persiste el cargo escalonado por nivel en cada pago vencido.
+--
+-- Aditiva. Rollback: ALTER TABLE payments DROP COLUMN late_fee_amount, ...
+
+ALTER TABLE public.payments
+  ADD COLUMN IF NOT EXISTS late_fee_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS late_fee_level TEXT,
+  ADD COLUMN IF NOT EXISTS late_fee_updated_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.payments.late_fee_amount IS
+  'Cargo por mora aplicado a este pago (escalonado por nivel). El saldo del inquilino = amount + late_fee_amount.';

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/cobranza",
       "schedule": "0 13 * * *"
+    },
+    {
+      "path": "/api/cron/renovaciones",
+      "schedule": "0 14 * * *"
     }
   ],
   "installCommand": "git submodule update --init --recursive && npm install"


### PR DESCRIPTION
## Resumen

Trabajo posterior al merge del PR #71. Tres bloques sobre la misma rama:

### Bloque 1 — Cobranza viva (renta fija)
- **Recordatorios preventivos + avisos de mora por WhatsApp**, vía cron diario. Resuelve correctamente inquilino/unidad (antes fallaba el lookup).
- **Mora escalonada persistida** en la BD: **5%** de 6 a 15 días de atraso, **10%** de 16 días en adelante (dos tramos, política confirmada por Fran).
- **Recibos automáticos** por WhatsApp al registrar un pago.
- Los mensajes incluyen el **link al portal del inquilino**.
- **Gate de seguridad**: nada se envía hasta `COBRANZA_WHATSAPP_ENABLED=true`. Sin el flag corre en *dry-run* (registra en audit, no envía).

### Bloque 2 — Ciclo de vida del contrato
- **Agente `renovaciones` nuevo** + cron diario: contratos `active` que vencen en ≤30 días o ya vencidos pasan a **`en_renovacion`**, avisando al inquilino, **sin cortar la facturación** (cubre la tácita reconducción). Nunca pone `expired` solo — eso es decisión humana.
- **`rent_type` explícito** en contratos (LTR / MTR / STR) con backfill desde la unidad. La **renta corta (STR) ya no genera cobro mensual automático** — se cobrará por reserva (terreno para el Bloque 3). Selector añadido en crear/editar contrato.

### Endurecimiento de seguridad
- Cierre de RLS `allow_all` en `org_members` / `user_profiles`; aceptación de roles canónicos `pm_*`.
- Validación de `x-org-id` y endurecimiento de onboarding, mora, channex, whatsapp, view-mode y sync-session.
- Menús del sidebar y tabs de settings restringidos por rol; toggle de agentes solo para admins.
- Fix de crash latente: `en_renovacion` faltaba en el enum `contract_status` de la BD.

## ⚠️ Acción requerida tras el merge — aplicar migraciones en Supabase
En orden:
1. `20260612_rls_close_allow_all.sql`
2. `20260615_contract_status_en_renovacion.sql`
3. `20260615_payments_late_fee.sql`
4. `20260615_contracts_rent_type.sql`

(Las de `20260611_*` de agentes ya venían de PRs previos; si no se han corrido, primero esas.)

## Validación
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (rutas nuevas compilan: `/api/cron/renovaciones`)
- Suite de tests de agentes: 4/4 ✅

## Notas
- Todo el envío real de WhatsApp queda detrás del flag + credenciales de Meta. Mergear esto **no dispara** mensajes por sí solo.

https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_