### PR TITLE
Fix: toggle Human/Agent vuelve a funcionar (quita candado de auth en view-mode)

### DIFF
--- a/src/app/api/me/view-mode/route.ts
+++ b/src/app/api/me/view-mode/route.ts
@@ -1,9 +1,12 @@
 // BaW OS — GET/POST /api/me/view-mode
-// Lee y persiste la preferencia Human/Agent del usuario activo en su org activa.
+// Lee y persiste la preferencia Human/Agent en una cookie. Es una preferencia de
+// PRESENTACIÓN (qué layout ve el usuario), no un límite de seguridad: el acceso a
+// datos sigue protegido por RLS y el contexto de org aguas abajo. Por eso NO se
+// exige sesión aquí — exigirla rompía el toggle para platform admins sin usuario
+// estándar de Supabase Auth (getUser() → null → 401 → la cookie nunca se guardaba).
 
 import { NextRequest, NextResponse } from 'next/server'
 import { getViewMode, setViewMode, type ViewMode } from '@/lib/agents/view-mode'
-import { createSupabaseServer } from '@/lib/supabase-server'
 
 export async function GET() {
   const mode = await getViewMode()
@@ -11,17 +14,6 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const supabase = createSupabaseServer()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) {
-    return NextResponse.json(
-      { success: false, error: 'Unauthorized' },
-      { status: 401 }
-    )
-  }
-
   let body: { mode?: ViewMode }
   try {
     body = await req.json()

--- a/src/components/ViewModeSwitch.tsx
+++ b/src/components/ViewModeSwitch.tsx
@@ -2,7 +2,7 @@
 
 // BaW OS — Switch Human ↔ Agent
 // Drop-in: monta donde quieras (sidebar, navbar, header).
-// Persiste vía POST /api/me/view-mode → org_members.preferred_view_mode.
+// Persiste vía POST /api/me/view-mode → cookie baw_view_mode (preferencia de UI).
 
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
@@ -39,18 +39,23 @@ export default function ViewModeSwitch({
 
   const apply = async (next: ViewMode) => {
     if (next === mode) return
+    const prev = mode
     setSaving(true)
     setMode(next)
     try {
-      await fetch('/api/me/view-mode', {
+      const res = await fetch('/api/me/view-mode', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ mode: next }),
       })
+      // Si el guardado no persistió, revertimos para no mentir en el UI.
+      if (!res.ok) {
+        setMode(prev)
+        return
+      }
       router.refresh()
     } catch {
-      // revert si falla
-      setMode(mode)
+      setMode(prev)
     } finally {
       setSaving(false)
     }


### PR DESCRIPTION
## Problema
El toggle Human/Agent en `/agents` volvió a "no hacer nada": el botón cambia visualmente pero el contenido sigue en Human.

## Causa raíz
En el endurecimiento de seguridad (`52920e7`) se añadió un candado de auth al `POST /api/me/view-mode`:
```ts
const { data: { user } } = await supabase.auth.getUser()
if (!user) return 401
```
Para un **platform admin** (sin usuario estándar de Supabase Auth en ese contexto), `getUser()` devuelve `null` → el POST responde **401** → la cookie `baw_view_mode` nunca se guarda → al `router.refresh()` el servidor re-renderiza en Human. Es la reaparición del bug que ya se había corregido en el PR #71.

## Fix
- **Se quita el candado de auth** del `POST /api/me/view-mode`. El modo Human/Agent es una preferencia de **presentación** (qué layout se ve), no un límite de seguridad: el acceso a datos sigue protegido por RLS y el contexto de org aguas abajo. El gate no aportaba seguridad y rompía el toggle.
- **El switch ahora revierte** el estado del botón si el guardado no persiste (`res.ok === false`), para que el UI no "mienta" en el futuro.
- Comentarios obsoletos corregidos (ya no persiste en `org_members`, sino en cookie).

## Validación
- `npx tsc --noEmit` ✅

https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_