### PR TITLE
Fix toggle Human/Agent (posición + tamaño) y edición de organización en /settings

### DIFF
--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -257,22 +257,22 @@ export default async function AgentsPage() {
 
   return (
     <div className="space-y-8">
-      <div>
-        <h1
-          className="text-[28px] mb-1 tracking-tight"
-          style={{ color: 'var(--baw-text)', fontFamily: 'var(--font-display)' }}
-        >
-          Agentes
-        </h1>
-        <p
-          className="text-[11px] uppercase tracking-wider"
-          style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
-        >
-          Agentes third-party conectados a BaW OS · Alicia opera Mateos 809P · Hugo supervisa · Sprint 5A MVP
-        </p>
-        <div className="mt-3">
-          <ViewModeSwitch initialMode={viewMode} />
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1
+            className="text-[28px] mb-1 tracking-tight"
+            style={{ color: 'var(--baw-text)', fontFamily: 'var(--font-display)' }}
+          >
+            Agentes
+          </h1>
+          <p
+            className="text-[11px] uppercase tracking-wider"
+            style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
+          >
+            Agentes third-party conectados a BaW OS · Alicia opera Mateos 809P · Hugo supervisa · Sprint 5A MVP
+          </p>
         </div>
+        <ViewModeSwitch initialMode={viewMode} />
       </div>
 
       {Object.entries(grouped)


### PR DESCRIPTION
## Cambios

### 1. Toggle Human/Agent — posición fija
Antes saltaba: en Human estaba abajo-izquierda (bajo el subtítulo), en Agent arriba-derecha. Ahora queda **arriba a la derecha, alineado con el título** en ambas vistas.

### 2. Toggle Human/Agent — tamaño consistente
En Human usaba tamaño `md` y en Agent `sm`, por lo que "crecía" al cambiar. Unificado a `sm` en ambas.

### 3. /settings — la organización vuelve a ser editable (renombrar empresa)
**Problema:** `/settings` (pestaña "General"/Organización) mostraba "No encontramos una organización activa" y el botón "Editar" de `/onboarding` mandaba a ese dead-end, sin poder cambiar el nombre de la empresa.

**Causa:** `/settings` dependía 100% del contexto de org del **servidor** (`/api/me/org` → `resolveOrgContext`), que para algunos usuarios (p. ej. platform admin / sesión que no llega al server) falla. `/onboarding` no falla porque resuelve la org **del lado del navegador**.

**Fix:** `/settings` ahora cae al contexto de navegador (`useActiveContext`, el mismo que `/onboarding` usa con éxito) cuando el de servidor no resuelve. El rol admin se deriva del contexto de servidor o, si falta, de la membresía ya cargada. Con esto la pestaña **Organización** carga y el nombre de la empresa es editable y guardable.

> Nota: el fix desbloquea la edición de forma robusta. La causa de fondo (por qué el contexto de servidor falla para este usuario) queda por confirmar con acceso a DB/Supabase; puede afectar otras vistas que dependan de auth server-side.

## Validación
- `npx tsc --noEmit` ✅

https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U