### PR TITLE
Propietarios: separar vigencia de propiedad vs administración (con etiquetas claras)

### DIFF
--- a/src/app/owners/StakeModal.tsx
+++ b/src/app/owners/StakeModal.tsx
@@ -29,6 +29,8 @@ export default function StakeModal({
     percentage: stake?.percentage?.toString() || '100',
     starts_on: stake?.starts_on || '',
     ends_on: stake?.ends_on || '',
+    mgmt_starts_on: stake?.mgmt_starts_on || '',
+    mgmt_ends_on: stake?.mgmt_ends_on || '',
     notes: stake?.notes || '',
   })
 
@@ -44,6 +46,8 @@ export default function StakeModal({
       percentage: pctNum,
       starts_on: form.starts_on || null,
       ends_on: form.ends_on || null,
+      mgmt_starts_on: form.mgmt_starts_on || null,
+      mgmt_ends_on: form.mgmt_ends_on || null,
       notes: form.notes.trim() || null,
     })
   }
@@ -145,28 +149,68 @@ export default function StakeModal({
               </p>
             )}
           </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">
-                Inicio
-              </label>
-              <input
-                type="date"
-                value={form.starts_on}
-                onChange={(e) => setForm({ ...form, starts_on: e.target.value })}
-                className="input-field"
-              />
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Vigencia de propiedad
+            </p>
+            <p className="text-xs text-gray-400">
+              Desde / hasta cuándo el propietario tiene este % del edificio (titularidad). Deja el fin vacío si sigue vigente.
+            </p>
+            <div className="grid grid-cols-2 gap-4 pt-1">
+              <div>
+                <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  Inicio
+                </label>
+                <input
+                  type="date"
+                  value={form.starts_on}
+                  onChange={(e) => setForm({ ...form, starts_on: e.target.value })}
+                  className="input-field"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  Fin (opcional)
+                </label>
+                <input
+                  type="date"
+                  value={form.ends_on}
+                  onChange={(e) => setForm({ ...form, ends_on: e.target.value })}
+                  className="input-field"
+                />
+              </div>
             </div>
-            <div>
-              <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">
-                Fin (opcional)
-              </label>
-              <input
-                type="date"
-                value={form.ends_on}
-                onChange={(e) => setForm({ ...form, ends_on: e.target.value })}
-                className="input-field"
-              />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Vigencia de administración
+            </p>
+            <p className="text-xs text-gray-400">
+              Desde / hasta cuándo BaW administra este edificio por encargo del dueño (mandato de gestión). Deja el fin vacío si sigue vigente.
+            </p>
+            <div className="grid grid-cols-2 gap-4 pt-1">
+              <div>
+                <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  Inicio
+                </label>
+                <input
+                  type="date"
+                  value={form.mgmt_starts_on}
+                  onChange={(e) => setForm({ ...form, mgmt_starts_on: e.target.value })}
+                  className="input-field"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  Fin (opcional)
+                </label>
+                <input
+                  type="date"
+                  value={form.mgmt_ends_on}
+                  onChange={(e) => setForm({ ...form, mgmt_ends_on: e.target.value })}
+                  className="input-field"
+                />
+              </div>
             </div>
           </div>
           <div>

--- a/src/app/owners/page.tsx
+++ b/src/app/owners/page.tsx
@@ -391,8 +391,14 @@ export default function OwnersPage() {
                                 </div>
                                 {(s.starts_on || s.ends_on) && (
                                   <div className="text-[11px] text-gray-500 mt-0.5">
-                                    {s.starts_on || '—'}
+                                    Propiedad: {s.starts_on || '—'}
                                     {s.ends_on ? ` → ${s.ends_on}` : ''}
+                                  </div>
+                                )}
+                                {(s.mgmt_starts_on || s.mgmt_ends_on) && (
+                                  <div className="text-[11px] text-gray-500">
+                                    Administración: {s.mgmt_starts_on || '—'}
+                                    {s.mgmt_ends_on ? ` → ${s.mgmt_ends_on}` : ''}
                                   </div>
                                 )}
                               </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,8 +49,10 @@ export interface OwnershipStake {
   building_id: string
   property_owner_id: string
   percentage: number
-  starts_on?: string | null
-  ends_on?: string | null
+  starts_on?: string | null // vigencia de propiedad: inicio
+  ends_on?: string | null // vigencia de propiedad: fin (null = indefinido)
+  mgmt_starts_on?: string | null // vigencia de administración (mandato BaW): inicio
+  mgmt_ends_on?: string | null // vigencia de administración: fin (null = indefinido)
   notes?: string | null
   created_at: string
   updated_at: string

--- a/supabase/migrations/20260616_ownership_stakes_mgmt_vigencia.sql
+++ b/supabase/migrations/20260616_ownership_stakes_mgmt_vigencia.sql
@@ -1,0 +1,22 @@
+-- BaW OS — Vigencias separadas en ownership_stakes (propiedad vs administración).
+-- Antes había un solo par de fechas (starts_on/ends_on) cuyo significado era
+-- ambiguo: ¿desde cuándo es DUEÑO o desde cuándo BaW ADMINISTRA? Fran pidió
+-- distinguir ambas. Decisión:
+--   starts_on / ends_on        → vigencia de PROPIEDAD (titularidad del %).
+--   mgmt_starts_on / mgmt_ends_on → vigencia de ADMINISTRACIÓN (mandato a BaW).
+-- Fin (ends_on / mgmt_ends_on) vacío = vigente/indefinido.
+--
+-- Aditiva + idempotente. Rollback: DROP COLUMN mgmt_starts_on, mgmt_ends_on.
+
+ALTER TABLE public.ownership_stakes
+  ADD COLUMN IF NOT EXISTS mgmt_starts_on date,
+  ADD COLUMN IF NOT EXISTS mgmt_ends_on   date;
+
+COMMENT ON COLUMN public.ownership_stakes.starts_on IS
+  'Vigencia de PROPIEDAD: desde cuándo el propietario tiene este % del edificio.';
+COMMENT ON COLUMN public.ownership_stakes.ends_on IS
+  'Vigencia de PROPIEDAD: hasta cuándo (NULL = vigente/indefinido).';
+COMMENT ON COLUMN public.ownership_stakes.mgmt_starts_on IS
+  'Vigencia de ADMINISTRACIÓN: desde cuándo BaW administra el edificio por mandato del dueño.';
+COMMENT ON COLUMN public.ownership_stakes.mgmt_ends_on IS
+  'Vigencia de ADMINISTRACIÓN: hasta cuándo (NULL = vigente/indefinido).';


### PR DESCRIPTION
## Contexto
En "Asignar / Editar propiedad" (Propietarios) había un solo par de fechas Inicio/Fin sin explicación, y su significado era ambiguo: ¿desde cuándo es DUEÑO o desde cuándo BaW ADMINISTRA? Fran pidió **distinguir ambas vigencias por separado**.

## Cambios
- **Migración** (`20260616_ownership_stakes_mgmt_vigencia.sql`): agrega `mgmt_starts_on` / `mgmt_ends_on` a `ownership_stakes`. Aditiva e idempotente. Se documentan las 4 columnas con `COMMENT`:
  - `starts_on` / `ends_on` → **vigencia de propiedad** (titularidad del %).
  - `mgmt_starts_on` / `mgmt_ends_on` → **vigencia de administración** (mandato a BaW).
- **Modal de stake**: ahora muestra **dos secciones etiquetadas** con texto de ayuda — "Vigencia de propiedad" y "Vigencia de administración" — para que nadie vuelva a dudar qué significan. Fin vacío = vigente/indefinido.
- **Lista de propietarios**: cada edificio muestra ambas vigencias con su etiqueta ("Propiedad:" / "Administración:").
- Tipo `OwnershipStake` actualizado.

## ⚠️ Acción tras el merge
Aplicar en Supabase: `20260616_ownership_stakes_mgmt_vigencia.sql` (junto con las otras migraciones pendientes del Bloque 1/2 si aún no se han corrido).

## Validación
- `npx tsc --noEmit` ✅

https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_