### PR TITLE
Fase 1: "Local comercial" como tipo de unidad

### DIFF
--- a/src/app/api/v1/units/route.ts
+++ b/src/app/api/v1/units/route.ts
@@ -4,7 +4,7 @@ import { v1Ok, v1Error } from '@/lib/agents/v1/responses'
 import { parsePagination, makeCursor } from '@/lib/agents/v1/pagination'
 import { createServiceClient } from '@/lib/supabase'
 
-const UNIT_TYPES = ['STR', 'MTR', 'LTR', 'OFFICE', 'COMMON']
+const UNIT_TYPES = ['STR', 'MTR', 'LTR', 'RETAIL', 'OFFICE', 'COMMON']
 const UNIT_STATUSES = ['available', 'occupied', 'maintenance', 'reserved', 'inactive']
 
 export const GET = v1Read({

--- a/src/app/units/UnitModal.tsx
+++ b/src/app/units/UnitModal.tsx
@@ -81,6 +81,7 @@ export default function UnitModal({ unit, onSave, onClose }: Props) {
                 <option value="LTR">Larga estancia (LTR)</option>
                 <option value="MTR">Media estancia (MTR)</option>
                 <option value="STR">Corta estancia (STR)</option>
+                <option value="RETAIL">Local comercial</option>
                 <option value="OFFICE">Oficina</option>
                 <option value="COMMON">Área común</option>
               </select>

--- a/src/app/units/[id]/page.tsx
+++ b/src/app/units/[id]/page.tsx
@@ -45,6 +45,7 @@ const typeLabels: Record<string, string> = {
   STR: 'Corta estancia',
   MTR: 'Media estancia',
   LTR: 'Larga estancia',
+  RETAIL: 'Local comercial',
   OFFICE: 'Oficina',
   COMMON: 'Área común',
 }

--- a/src/app/units/page.tsx
+++ b/src/app/units/page.tsx
@@ -28,6 +28,7 @@ const typeLabels: Record<UnitType, string> = {
   STR: 'Corta estancia',
   MTR: 'Media estancia',
   LTR: 'Larga estancia',
+  RETAIL: 'Local comercial',
   OFFICE: 'Oficina',
   COMMON: 'Área común',
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 // BaW OS — Core TypeScript Types
 // BaW Design Lab · ZXY Ventures
 
-export type UnitType = 'STR' | 'MTR' | 'LTR' | 'OFFICE' | 'COMMON'
+export type UnitType = 'STR' | 'MTR' | 'LTR' | 'RETAIL' | 'OFFICE' | 'COMMON'
 export type UnitStatus = 'available' | 'occupied' | 'maintenance' | 'reserved' | 'inactive'
 export type ContractStatus = 'active' | 'expired' | 'terminated' | 'pending' | 'renewed' | 'en_renovacion'
 export type RentType = 'LTR' | 'MTR' | 'STR' // larga / media / corta


### PR DESCRIPTION
## Fase 1 de Ruta B — Local comercial como tipo de unidad

Agrega **"Local comercial" (`RETAIL`)** a la taxonomía de tipos de unidad. Cubre de inmediato los 2 locales comerciales del edificio 809.

### Cambios
- `UnitType` ahora incluye `RETAIL`.
- Opción "Local comercial" en el formulario de crear/editar unidad.
- Etiqueta "Local comercial" en la lista de unidades y en el detalle de unidad.
- Validación de la API v1 (`/v1/units`) acepta `RETAIL`.

### Notas de diseño
- **Sin migración:** `units.type` no tiene CHECK en la BD (es texto validado en código), así que el tipo nuevo funciona sin tocar el esquema.
- **Facturación:** un local comercial se renta con contrato mensual → su `rent_type` queda en `LTR` (mensual) por el flujo existente. No requiere cambios en cobranza.
- Estacionamientos y espectaculares **no** se agregan aquí — van en la Fase 2 como módulo de "Otros ingresos / activos accesorios" (PRs siguientes), para no distorsionar las métricas de ocupación.

### Validación
- `npx tsc --noEmit` ✅

https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_