### PR TITLE
Cargos accesorios: estacionamiento + espectaculares (B1–B3)

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -124,6 +124,7 @@ CREATE TABLE payments (
   status          payment_status NOT NULL DEFAULT 'pending',
   method          payment_method,
   reference       TEXT,                 -- número de transferencia, ID de Stripe, etc.
+  -- ancillary_charge_id: ver sección ANCILLARY (FK agregada por ALTER para evitar referencia hacia adelante)
   notes           TEXT,
   created_at      TIMESTAMPTZ DEFAULT NOW(),
   updated_at      TIMESTAMPTZ DEFAULT NOW()
@@ -189,6 +190,10 @@ CREATE POLICY "ancillary_assets_org_isolation" ON ancillary_assets
 ALTER TABLE ancillary_charges ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "ancillary_charges_org_isolation" ON ancillary_charges
   USING (org_id IN (SELECT org_id FROM org_members WHERE user_id = auth.uid()));
+
+-- Enlace pago ↔ cargo accesorio (ver migración 20260616_03). NULL = renta normal.
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS ancillary_charge_id UUID REFERENCES ancillary_charges(id) ON DELETE SET NULL;
 
 -- ============================================
 -- INCIDENTS (Incidencias y mantenimiento)

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -86,7 +86,7 @@ CREATE TYPE contract_status AS ENUM ('active', 'expired', 'terminated', 'pending
 CREATE TABLE contracts (
   id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   org_id          UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
-  unit_id         UUID NOT NULL REFERENCES units(id),
+  unit_id         UUID REFERENCES units(id),            -- NULL = contrato independiente (standalone), ej. anunciante
   occupant_id     UUID NOT NULL REFERENCES occupants(id),
   start_date      DATE NOT NULL,
   end_date        DATE,
@@ -134,6 +134,61 @@ CREATE POLICY "payments_org_isolation" ON payments
   USING (org_id IN (
     SELECT org_id FROM org_members WHERE user_id = auth.uid()
   ));
+
+-- ============================================
+-- ANCILLARY (Estacionamiento + Espectaculares) — ver migración 20260616_02
+-- ============================================
+-- Pool de estacionamiento (informativo): buildings.parking_total y
+-- units.parking_included. El cobro de cajones extra y espectaculares vive en
+-- ancillary_charges, SIEMPRE ligado a un contrato (que puede ser independiente).
+CREATE TYPE ancillary_kind AS ENUM ('parking', 'billboard', 'storage', 'antenna', 'other');
+CREATE TYPE ancillary_cadence AS ENUM ('monthly', 'annual');
+CREATE TYPE ancillary_ownership AS ENUM ('ours', 'third_party');
+CREATE TYPE ancillary_status AS ENUM ('active', 'inactive', 'ended');
+
+CREATE TABLE ancillary_assets (
+  id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  org_id      UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  building_id UUID REFERENCES buildings(id) ON DELETE SET NULL,
+  kind        ancillary_kind NOT NULL DEFAULT 'billboard',
+  label       TEXT NOT NULL,
+  ownership   ancillary_ownership NOT NULL DEFAULT 'ours',
+  status      ancillary_status NOT NULL DEFAULT 'active',
+  notes       TEXT,
+  created_at  TIMESTAMPTZ DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE ancillary_charges (
+  id             UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  org_id         UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  contract_id    UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+  asset_id       UUID REFERENCES ancillary_assets(id) ON DELETE SET NULL,
+  building_id    UUID REFERENCES buildings(id) ON DELETE SET NULL,
+  unit_id        UUID REFERENCES units(id) ON DELETE SET NULL,
+  kind           ancillary_kind NOT NULL,
+  description    TEXT,
+  amount         DECIMAL(10,2) NOT NULL,
+  cadence        ancillary_cadence NOT NULL DEFAULT 'monthly',
+  billing_day    INTEGER NOT NULL DEFAULT 1,
+  quantity       INTEGER NOT NULL DEFAULT 1,
+  effective_from DATE NOT NULL DEFAULT CURRENT_DATE,
+  effective_to   DATE,
+  status         ancillary_status NOT NULL DEFAULT 'active',
+  notes          TEXT,
+  created_at     TIMESTAMPTZ DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT ancillary_charges_billing_day_chk CHECK (billing_day BETWEEN 1 AND 28),
+  CONSTRAINT ancillary_charges_amount_chk CHECK (amount >= 0),
+  CONSTRAINT ancillary_charges_quantity_chk CHECK (quantity >= 1)
+);
+
+ALTER TABLE ancillary_assets ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "ancillary_assets_org_isolation" ON ancillary_assets
+  USING (org_id IN (SELECT org_id FROM org_members WHERE user_id = auth.uid()));
+ALTER TABLE ancillary_charges ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "ancillary_charges_org_isolation" ON ancillary_charges
+  USING (org_id IN (SELECT org_id FROM org_members WHERE user_id = auth.uid()));
 
 -- ============================================
 -- INCIDENTS (Incidencias y mantenimiento)

--- a/src/app/ancillary-assets/page.tsx
+++ b/src/app/ancillary-assets/page.tsx
@@ -1,0 +1,411 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Megaphone, Plus, Pencil, Trash2, X, Save, Package, RadioTower, Tag } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
+import { useToast } from '@/components/Toast'
+import { SkeletonTable } from '@/components/Skeleton'
+import EmptyState from '@/components/EmptyState'
+import type { AncillaryOwnership, AncillaryStatus } from '@/types'
+
+// Los activos discretos (parking es un pool del edificio, no un activo)
+type AssetKind = 'billboard' | 'storage' | 'antenna' | 'other'
+const ASSET_KINDS: AssetKind[] = ['billboard', 'storage', 'antenna', 'other']
+
+const KIND_LABELS: Record<AssetKind, string> = {
+  billboard: 'Espectacular',
+  storage: 'Bodega',
+  antenna: 'Antena',
+  other: 'Otro',
+}
+
+const KIND_COLORS: Record<AssetKind, string> = {
+  billboard: 'bg-purple-500/15 text-purple-400 border-purple-500/20',
+  storage: 'bg-orange-500/15 text-orange-500 border-orange-500/20',
+  antenna: 'bg-teal-500/15 text-teal-500 border-teal-500/20',
+  other: 'bg-gray-500/15 text-gray-400 border-gray-500/20',
+}
+
+const KIND_ICONS: Record<AssetKind, React.ComponentType<{ className?: string }>> = {
+  billboard: Megaphone,
+  storage: Package,
+  antenna: RadioTower,
+  other: Tag,
+}
+
+const OWNERSHIP_LABELS: Record<AncillaryOwnership, string> = {
+  ours: 'Nuestra (estructura propia)',
+  third_party: 'De terceros',
+}
+
+const STATUS_LABELS: Record<AncillaryStatus, string> = {
+  active: 'Activo',
+  inactive: 'Inactivo',
+  ended: 'Terminado',
+}
+
+interface AssetRow {
+  id: string
+  building_id: string | null
+  kind: AssetKind
+  label: string
+  ownership: AncillaryOwnership
+  status: AncillaryStatus
+  notes: string | null
+  created_at: string
+  building?: { name: string } | null
+}
+
+interface BuildingOption {
+  id: string
+  name: string
+}
+
+const emptyForm = {
+  label: '',
+  kind: 'billboard' as AssetKind,
+  building_id: '' as string,
+  ownership: 'ours' as AncillaryOwnership,
+  status: 'active' as AncillaryStatus,
+  notes: '',
+}
+
+export default function AncillaryAssetsPage() {
+  const toast = useToast()
+  const { orgId } = useOrgContext()
+  const [assets, setAssets] = useState<AssetRow[]>([])
+  const [buildings, setBuildings] = useState<BuildingOption[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [showModal, setShowModal] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState({ ...emptyForm })
+  const [saving, setSaving] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<AssetRow | null>(null)
+
+  async function fetchAssets() {
+    setLoading(true)
+    const { data } = await supabase
+      .from('ancillary_assets')
+      .select('*, building:buildings(name)')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false })
+    setAssets((data || []) as unknown as AssetRow[])
+    setLoading(false)
+  }
+
+  async function fetchBuildings() {
+    const { data } = await supabase
+      .from('buildings')
+      .select('id, name')
+      .order('name')
+    setBuildings((data || []) as unknown as BuildingOption[])
+  }
+
+  useEffect(() => {
+    if (!orgId) return
+    fetchBuildings()
+    fetchAssets()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId])
+
+  function openNew() {
+    setEditingId(null)
+    setForm({ ...emptyForm })
+    setShowModal(true)
+  }
+
+  function openEdit(asset: AssetRow) {
+    setEditingId(asset.id)
+    setForm({
+      label: asset.label,
+      kind: asset.kind,
+      building_id: asset.building_id || '',
+      ownership: asset.ownership,
+      status: asset.status,
+      notes: asset.notes || '',
+    })
+    setShowModal(true)
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    const payload = {
+      org_id: orgId,
+      label: form.label,
+      kind: form.kind,
+      building_id: form.building_id || null,
+      ownership: form.ownership,
+      status: form.status,
+      notes: form.notes || null,
+    }
+
+    let error = null
+    if (editingId) {
+      const res = await supabase.from('ancillary_assets').update(payload).eq('id', editingId)
+      error = res.error
+    } else {
+      const res = await supabase.from('ancillary_assets').insert(payload)
+      error = res.error
+    }
+
+    setShowModal(false)
+    setSaving(false)
+    if (error) {
+      toast.error('Error al guardar — intenta de nuevo')
+    } else {
+      toast.success('Activo guardado')
+    }
+    fetchAssets()
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/ancillary-assets?id=${deleteTarget.id}`, { method: 'DELETE' })
+      const json = await res.json()
+      if (!json.success) {
+        toast.error('Error al eliminar activo — intenta de nuevo')
+      } else {
+        toast.success('Activo eliminado')
+      }
+    } catch {
+      toast.error('Error al eliminar activo — intenta de nuevo')
+    }
+    setDeleteTarget(null)
+    setSaving(false)
+    fetchAssets()
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Megaphone className="w-6 h-6 text-purple-500" />
+          <div>
+            <h1 className="text-xl sm:text-2xl font-bold">Activos publicitarios</h1>
+            <p className="text-gray-500 dark:text-gray-400 mt-1">
+              Espectaculares, bodegas y antenas. El cobro se liga a un contrato en Cargos adicionales.
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={openNew}
+          className="flex items-center gap-2 px-4 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-sm font-medium transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          Nuevo activo
+        </button>
+      </div>
+
+      {/* Table */}
+      {loading ? (
+        <SkeletonTable />
+      ) : assets.length === 0 ? (
+        <EmptyState
+          icon={Megaphone}
+          title="No hay activos registrados"
+          description="Registra espectaculares (ej. el 809 o los del 2020), bodegas o antenas"
+        />
+      ) : (
+        <div className="card overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-gray-800">
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Tipo</th>
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Etiqueta</th>
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Edificio</th>
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Propiedad</th>
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Estado</th>
+                <th className="text-center px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {assets.map((asset) => {
+                const Icon = KIND_ICONS[asset.kind]
+                return (
+                  <tr key={asset.id} className="border-b border-gray-100 dark:border-gray-800/50 hover:bg-gray-50 dark:hover:bg-gray-800/30">
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium border ${KIND_COLORS[asset.kind]}`}>
+                        <Icon className="w-3 h-3" />
+                        {KIND_LABELS[asset.kind]}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 font-medium text-gray-900 dark:text-white">
+                      {asset.label}
+                    </td>
+                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                      {asset.building?.name || '—'}
+                    </td>
+                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                      {OWNERSHIP_LABELS[asset.ownership]}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={asset.status === 'active' ? 'text-green-500' : 'text-gray-400'}>
+                        {STATUS_LABELS[asset.status]}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <div className="flex items-center justify-center gap-1">
+                        <button
+                          onClick={() => openEdit(asset)}
+                          title="Editar"
+                          className="p-1.5 rounded-lg hover:bg-indigo-100 dark:hover:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 transition-colors"
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => setDeleteTarget(asset)}
+                          title="Eliminar"
+                          className="p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition-colors"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Create/Edit Modal */}
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="card w-full max-w-lg mx-4 relative max-h-[90vh] overflow-y-auto">
+            <button
+              onClick={() => setShowModal(false)}
+              className="absolute top-4 right-4 text-gray-400 hover:text-gray-200"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+              {editingId ? 'Editar activo' : 'Nuevo activo'}
+            </h2>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Etiqueta</label>
+                <input
+                  type="text"
+                  value={form.label}
+                  onChange={(e) => setForm({ ...form, label: e.target.value })}
+                  className="input-field w-full"
+                  placeholder='Ej. "Espectacular 809" o "Azotea 2020 #3"'
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Tipo</label>
+                  <select
+                    value={form.kind}
+                    onChange={(e) => setForm({ ...form, kind: e.target.value as AssetKind })}
+                    className="input-field w-full"
+                  >
+                    {ASSET_KINDS.map((k) => (
+                      <option key={k} value={k}>{KIND_LABELS[k]}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Propiedad</label>
+                  <select
+                    value={form.ownership}
+                    onChange={(e) => setForm({ ...form, ownership: e.target.value as AncillaryOwnership })}
+                    className="input-field w-full"
+                  >
+                    <option value="ours">Nuestra (estructura propia)</option>
+                    <option value="third_party">De terceros</option>
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Edificio</label>
+                <select
+                  value={form.building_id}
+                  onChange={(e) => setForm({ ...form, building_id: e.target.value })}
+                  className="input-field w-full"
+                >
+                  <option value="">Sin edificio</option>
+                  {buildings.map((b) => (
+                    <option key={b.id} value={b.id}>{b.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Estado</label>
+                <select
+                  value={form.status}
+                  onChange={(e) => setForm({ ...form, status: e.target.value as AncillaryStatus })}
+                  className="input-field w-full"
+                >
+                  <option value="active">Activo</option>
+                  <option value="inactive">Inactivo</option>
+                  <option value="ended">Terminado</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Notas</label>
+                <textarea
+                  value={form.notes}
+                  onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                  className="input-field w-full"
+                  rows={2}
+                  placeholder="Opcional"
+                />
+              </div>
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  onClick={() => setShowModal(false)}
+                  className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={saving || !form.label}
+                  className="flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+                >
+                  <Save className="w-4 h-4" />
+                  Guardar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation */}
+      {deleteTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="card w-full max-w-md mx-4">
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-2">Eliminar activo</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+              ¿Eliminar <strong className="text-gray-900 dark:text-white">{deleteTarget.label}</strong>? Esta acción no se puede deshacer.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setDeleteTarget(null)}
+                className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={saving}
+                className="flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+              >
+                <Trash2 className="w-4 h-4" />
+                Eliminar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/ancillary-charges/page.tsx
+++ b/src/app/ancillary-charges/page.tsx
@@ -1,0 +1,537 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Coins, Plus, Pencil, Trash2, X, Save, Car, Megaphone, Package, RadioTower, Tag } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
+import { useToast } from '@/components/Toast'
+import { formatCurrency } from '@/lib/utils'
+import { SkeletonTable } from '@/components/Skeleton'
+import EmptyState from '@/components/EmptyState'
+import type { AncillaryKind, AncillaryCadence, AncillaryStatus } from '@/types'
+
+const KINDS: AncillaryKind[] = ['parking', 'billboard', 'storage', 'antenna', 'other']
+
+const KIND_LABELS: Record<AncillaryKind, string> = {
+  parking: 'Estacionamiento',
+  billboard: 'Espectacular',
+  storage: 'Bodega',
+  antenna: 'Antena',
+  other: 'Otro',
+}
+
+const KIND_COLORS: Record<AncillaryKind, string> = {
+  parking: 'bg-blue-500/15 text-blue-500 border-blue-500/20',
+  billboard: 'bg-purple-500/15 text-purple-400 border-purple-500/20',
+  storage: 'bg-orange-500/15 text-orange-500 border-orange-500/20',
+  antenna: 'bg-teal-500/15 text-teal-500 border-teal-500/20',
+  other: 'bg-gray-500/15 text-gray-400 border-gray-500/20',
+}
+
+const KIND_ICONS: Record<AncillaryKind, React.ComponentType<{ className?: string }>> = {
+  parking: Car,
+  billboard: Megaphone,
+  storage: Package,
+  antenna: RadioTower,
+  other: Tag,
+}
+
+const CADENCE_LABELS: Record<AncillaryCadence, string> = {
+  monthly: 'Mensual',
+  annual: 'Anual',
+}
+
+const STATUS_LABELS: Record<AncillaryStatus, string> = {
+  active: 'Activo',
+  inactive: 'Inactivo',
+  ended: 'Terminado',
+}
+
+interface ChargeRow {
+  id: string
+  contract_id: string
+  asset_id: string | null
+  kind: AncillaryKind
+  description: string | null
+  amount: number
+  cadence: AncillaryCadence
+  billing_day: number
+  quantity: number
+  effective_from: string
+  effective_to: string | null
+  status: AncillaryStatus
+  notes: string | null
+  created_at: string
+  contract?: { id: string; unit?: { number: string } | null; occupant?: { name: string } | null } | null
+  asset?: { label: string } | null
+}
+
+interface ContractOption {
+  id: string
+  unit?: { number: string } | null
+  occupant?: { name: string } | null
+}
+
+function contractLabel(c?: ContractOption | ChargeRow['contract']): string {
+  if (!c) return 'Contrato eliminado'
+  const who = c.occupant?.name ?? 'Sin ocupante'
+  const where = c.unit?.number ? `Depto ${c.unit.number}` : 'Independiente'
+  return `${who} — ${where}`
+}
+
+const emptyForm = {
+  contract_id: '',
+  kind: 'parking' as AncillaryKind,
+  description: '',
+  amount: 0,
+  cadence: 'monthly' as AncillaryCadence,
+  billing_day: 1,
+  quantity: 1,
+  effective_from: new Date().toISOString().split('T')[0],
+  effective_to: '',
+  status: 'active' as AncillaryStatus,
+  notes: '',
+}
+
+export default function AncillaryChargesPage() {
+  const toast = useToast()
+  const { orgId } = useOrgContext()
+  const [charges, setCharges] = useState<ChargeRow[]>([])
+  const [contracts, setContracts] = useState<ContractOption[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // Modal state
+  const [showModal, setShowModal] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState({ ...emptyForm })
+  const [saving, setSaving] = useState(false)
+
+  // Delete confirmation
+  const [deleteTarget, setDeleteTarget] = useState<ChargeRow | null>(null)
+
+  async function fetchCharges() {
+    setLoading(true)
+    const { data } = await supabase
+      .from('ancillary_charges')
+      .select('*, contract:contracts(id, unit:units(number), occupant:occupants(name)), asset:ancillary_assets(label)')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false })
+    setCharges((data || []) as unknown as ChargeRow[])
+    setLoading(false)
+  }
+
+  async function fetchContracts() {
+    const { data } = await supabase
+      .from('contracts')
+      .select('id, unit:units(number), occupant:occupants(name)')
+      .order('created_at', { ascending: false })
+    setContracts((data || []) as unknown as ContractOption[])
+  }
+
+  useEffect(() => {
+    if (!orgId) return
+    fetchContracts()
+    fetchCharges()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId])
+
+  function openNew() {
+    setEditingId(null)
+    setForm({ ...emptyForm })
+    setShowModal(true)
+  }
+
+  function openEdit(charge: ChargeRow) {
+    setEditingId(charge.id)
+    setForm({
+      contract_id: charge.contract_id,
+      kind: charge.kind,
+      description: charge.description || '',
+      amount: Number(charge.amount),
+      cadence: charge.cadence,
+      billing_day: charge.billing_day,
+      quantity: charge.quantity,
+      effective_from: charge.effective_from,
+      effective_to: charge.effective_to || '',
+      status: charge.status,
+      notes: charge.notes || '',
+    })
+    setShowModal(true)
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    const payload = {
+      org_id: orgId,
+      contract_id: form.contract_id,
+      kind: form.kind,
+      description: form.description || null,
+      amount: form.amount,
+      cadence: form.cadence,
+      billing_day: form.billing_day,
+      quantity: form.quantity,
+      effective_from: form.effective_from,
+      effective_to: form.effective_to || null,
+      status: form.status,
+      notes: form.notes || null,
+    }
+
+    let error = null
+    if (editingId) {
+      const res = await supabase.from('ancillary_charges').update(payload).eq('id', editingId)
+      error = res.error
+    } else {
+      const res = await supabase.from('ancillary_charges').insert(payload)
+      error = res.error
+    }
+
+    setShowModal(false)
+    setSaving(false)
+    if (error) {
+      toast.error('Error al guardar — intenta de nuevo')
+    } else {
+      toast.success('Cargo guardado')
+    }
+    fetchCharges()
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/ancillary-charges?id=${deleteTarget.id}`, { method: 'DELETE' })
+      const json = await res.json()
+      if (!json.success) {
+        toast.error('Error al eliminar cargo — intenta de nuevo')
+      } else {
+        toast.success('Cargo eliminado')
+      }
+    } catch {
+      toast.error('Error al eliminar cargo — intenta de nuevo')
+    }
+    setDeleteTarget(null)
+    setSaving(false)
+    fetchCharges()
+  }
+
+  // Totales de ingresos recurrentes activos (monto × cantidad)
+  const periodTotal = (c: ChargeRow) => Number(c.amount) * (c.quantity || 1)
+  const monthlyRecurring = charges
+    .filter((c) => c.status === 'active' && c.cadence === 'monthly')
+    .reduce((s, c) => s + periodTotal(c), 0)
+  const annualRecurring = charges
+    .filter((c) => c.status === 'active' && c.cadence === 'annual')
+    .reduce((s, c) => s + periodTotal(c), 0)
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Coins className="w-6 h-6 text-indigo-500" />
+          <div>
+            <h1 className="text-xl sm:text-2xl font-bold">Cargos adicionales</h1>
+            <p className="text-gray-500 dark:text-gray-400 mt-1">
+              Estacionamiento extra y espectaculares, ligados a un contrato
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={openNew}
+          className="flex items-center gap-2 px-4 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-sm font-medium transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          Nuevo cargo
+        </button>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="card">
+          <p className="text-xs text-gray-500 dark:text-gray-400">Ingreso mensual recurrente</p>
+          <p className="text-xl font-bold text-gray-900 dark:text-white">{formatCurrency(monthlyRecurring)}</p>
+        </div>
+        <div className="card">
+          <p className="text-xs text-gray-500 dark:text-gray-400">Ingreso anual</p>
+          <p className="text-xl font-bold text-gray-900 dark:text-white">{formatCurrency(annualRecurring)}</p>
+        </div>
+      </div>
+
+      {/* Table */}
+      {loading ? (
+        <SkeletonTable />
+      ) : charges.length === 0 ? (
+        <EmptyState
+          icon={Coins}
+          title="No hay cargos adicionales"
+          description="Registra cajones extra o espectaculares ligados a un contrato"
+        />
+      ) : (
+        <div className="card overflow-x-auto p-0">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-gray-800">
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Tipo</th>
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Contrato</th>
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Descripción</th>
+                <th className="text-right px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Monto c/u</th>
+                <th className="text-center px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Cant.</th>
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Cadencia</th>
+                <th className="text-center px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Día</th>
+                <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Estado</th>
+                <th className="text-center px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {charges.map((charge) => {
+                const Icon = KIND_ICONS[charge.kind]
+                return (
+                  <tr key={charge.id} className="border-b border-gray-100 dark:border-gray-800/50 hover:bg-gray-50 dark:hover:bg-gray-800/30">
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium border ${KIND_COLORS[charge.kind]}`}>
+                        <Icon className="w-3 h-3" />
+                        {KIND_LABELS[charge.kind]}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                      {contractLabel(charge.contract)}
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 dark:text-gray-400 max-w-[200px] truncate">
+                      {charge.description || charge.asset?.label || '—'}
+                    </td>
+                    <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-white">
+                      {formatCurrency(Number(charge.amount))}
+                    </td>
+                    <td className="px-4 py-3 text-center text-gray-700 dark:text-gray-300">
+                      {charge.quantity}
+                    </td>
+                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                      {CADENCE_LABELS[charge.cadence]}
+                    </td>
+                    <td className="px-4 py-3 text-center text-gray-700 dark:text-gray-300">
+                      {charge.billing_day}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={charge.status === 'active' ? 'text-green-500' : 'text-gray-400'}>
+                        {STATUS_LABELS[charge.status]}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <div className="flex items-center justify-center gap-1">
+                        <button
+                          onClick={() => openEdit(charge)}
+                          title="Editar"
+                          className="p-1.5 rounded-lg hover:bg-indigo-100 dark:hover:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 transition-colors"
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => setDeleteTarget(charge)}
+                          title="Eliminar"
+                          className="p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition-colors"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Create/Edit Modal */}
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="card w-full max-w-lg mx-4 relative max-h-[90vh] overflow-y-auto">
+            <button
+              onClick={() => setShowModal(false)}
+              className="absolute top-4 right-4 text-gray-400 hover:text-gray-200"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+              {editingId ? 'Editar cargo' : 'Nuevo cargo'}
+            </h2>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Contrato</label>
+                <select
+                  value={form.contract_id}
+                  onChange={(e) => setForm({ ...form, contract_id: e.target.value })}
+                  className="input-field w-full"
+                >
+                  <option value="">Seleccionar contrato...</option>
+                  {contracts.map((c) => (
+                    <option key={c.id} value={c.id}>{contractLabel(c)}</option>
+                  ))}
+                </select>
+                <p className="text-xs text-gray-400 mt-1">Todo cargo cuelga de un contrato (puede ser independiente).</p>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Tipo</label>
+                  <select
+                    value={form.kind}
+                    onChange={(e) => setForm({ ...form, kind: e.target.value as AncillaryKind })}
+                    className="input-field w-full"
+                  >
+                    {KINDS.map((k) => (
+                      <option key={k} value={k}>{KIND_LABELS[k]}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Cadencia</label>
+                  <select
+                    value={form.cadence}
+                    onChange={(e) => setForm({ ...form, cadence: e.target.value as AncillaryCadence })}
+                    className="input-field w-full"
+                  >
+                    <option value="monthly">Mensual</option>
+                    <option value="annual">Anual</option>
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Descripción</label>
+                <input
+                  type="text"
+                  value={form.description}
+                  onChange={(e) => setForm({ ...form, description: e.target.value })}
+                  className="input-field w-full"
+                  placeholder='Ej. "2 cajones extra" o "Espectacular azotea"'
+                />
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                <div>
+                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Monto c/u</label>
+                  <input
+                    type="number"
+                    value={form.amount}
+                    onChange={(e) => setForm({ ...form, amount: Number(e.target.value) })}
+                    className="input-field w-full"
+                    min={0}
+                    step="0.01"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Cantidad</label>
+                  <input
+                    type="number"
+                    value={form.quantity}
+                    onChange={(e) => setForm({ ...form, quantity: Math.max(1, Number(e.target.value)) })}
+                    className="input-field w-full"
+                    min={1}
+                    step="1"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Día cobro</label>
+                  <input
+                    type="number"
+                    value={form.billing_day}
+                    onChange={(e) => setForm({ ...form, billing_day: Math.min(28, Math.max(1, Number(e.target.value))) })}
+                    className="input-field w-full"
+                    min={1}
+                    max={28}
+                    step="1"
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Vigente desde</label>
+                  <input
+                    type="date"
+                    value={form.effective_from}
+                    onChange={(e) => setForm({ ...form, effective_from: e.target.value })}
+                    className="input-field w-full"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Vigente hasta</label>
+                  <input
+                    type="date"
+                    value={form.effective_to}
+                    onChange={(e) => setForm({ ...form, effective_to: e.target.value })}
+                    className="input-field w-full"
+                    placeholder="Indefinido"
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Estado</label>
+                <select
+                  value={form.status}
+                  onChange={(e) => setForm({ ...form, status: e.target.value as AncillaryStatus })}
+                  className="input-field w-full"
+                >
+                  <option value="active">Activo</option>
+                  <option value="inactive">Inactivo</option>
+                  <option value="ended">Terminado</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Notas</label>
+                <textarea
+                  value={form.notes}
+                  onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                  className="input-field w-full"
+                  rows={2}
+                  placeholder="Opcional"
+                />
+              </div>
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  onClick={() => setShowModal(false)}
+                  className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={saving || !form.contract_id || !form.amount}
+                  className="flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+                >
+                  <Save className="w-4 h-4" />
+                  Guardar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation */}
+      {deleteTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="card w-full max-w-md mx-4">
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-2">Eliminar cargo</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+              ¿Eliminar el cargo de <strong className="text-gray-900 dark:text-white">{formatCurrency(Number(deleteTarget.amount))}</strong> ({KIND_LABELS[deleteTarget.kind]})? Esta acción no se puede deshacer.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setDeleteTarget(null)}
+                className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={saving}
+                className="flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+              >
+                <Trash2 className="w-4 h-4" />
+                Eliminar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/api/ancillary-assets/route.ts
+++ b/src/app/api/ancillary-assets/route.ts
@@ -1,0 +1,76 @@
+// BaW OS — Ancillary Assets API (Tier 2 Agent Interface)
+// Activos accesorios discretos: espectaculares, bodegas, antenas.
+import { NextRequest } from 'next/server'
+import { createServiceClient, validateApiKey, unauthorized, apiError, apiOk, getOrgId } from '@/lib/api-auth'
+import { logEvent } from '@/lib/webhooks'
+
+export async function GET(request: NextRequest) {
+  if (!validateApiKey(request)) return unauthorized()
+
+  const supabase = createServiceClient()
+  const orgId = getOrgId()
+  const { searchParams } = new URL(request.url)
+  const buildingId = searchParams.get('building_id')
+  const kind = searchParams.get('kind')
+  const status = searchParams.get('status')
+
+  let query = supabase
+    .from('ancillary_assets')
+    .select('*, building:buildings(*)')
+    .eq('org_id', orgId)
+
+  if (buildingId) query = query.eq('building_id', buildingId)
+  if (kind) query = query.eq('kind', kind)
+  if (status) query = query.eq('status', status)
+
+  const { data, error } = await query.order('created_at', { ascending: false })
+  if (error) return apiError(error.message, 500)
+
+  return apiOk(data)
+}
+
+export async function POST(request: NextRequest) {
+  if (!validateApiKey(request)) return unauthorized()
+
+  const supabase = createServiceClient()
+  const orgId = getOrgId()
+  const body = await request.json()
+
+  if (!body.label) return apiError('label is required')
+
+  const { data, error } = await supabase
+    .from('ancillary_assets')
+    .insert({ ...body, org_id: orgId })
+    .select('*, building:buildings(*)')
+    .single()
+
+  if (error) return apiError(error.message, 500)
+
+  await logEvent('ancillary_asset.created', {
+    asset_id: data.id,
+    kind: data.kind,
+    building_id: data.building_id,
+  })
+
+  return apiOk(data)
+}
+
+export async function DELETE(request: NextRequest) {
+  if (!validateApiKey(request)) return unauthorized()
+  const supabase = createServiceClient()
+  const { searchParams } = new URL(request.url)
+
+  const id = searchParams.get('id')
+  if (!id) return apiError('id query param is required')
+
+  const { error } = await supabase
+    .from('ancillary_assets')
+    .delete()
+    .eq('id', id)
+
+  if (error) return apiError(error.message, 500)
+
+  await logEvent('ancillary_asset.deleted', { asset_id: id })
+
+  return apiOk({ deleted: id })
+}

--- a/src/app/api/ancillary-charges/route.ts
+++ b/src/app/api/ancillary-charges/route.ts
@@ -1,0 +1,82 @@
+// BaW OS — Ancillary Charges API (Tier 2 Agent Interface)
+// Cargos accesorios (estacionamiento extra, espectaculares) SIEMPRE ligados a
+// un contrato. La generación automática en cobranza vive en el cron (PR B3).
+import { NextRequest } from 'next/server'
+import { createServiceClient, validateApiKey, unauthorized, apiError, apiOk, getOrgId } from '@/lib/api-auth'
+import { logEvent } from '@/lib/webhooks'
+
+export async function GET(request: NextRequest) {
+  if (!validateApiKey(request)) return unauthorized()
+
+  const supabase = createServiceClient()
+  const orgId = getOrgId()
+  const { searchParams } = new URL(request.url)
+  const contractId = searchParams.get('contract_id')
+  const kind = searchParams.get('kind')
+  const status = searchParams.get('status')
+
+  let query = supabase
+    .from('ancillary_charges')
+    .select('*, contract:contracts(*, unit:units(*), occupant:occupants(*)), asset:ancillary_assets(*)')
+    .eq('org_id', orgId)
+
+  if (contractId) query = query.eq('contract_id', contractId)
+  if (kind) query = query.eq('kind', kind)
+  if (status) query = query.eq('status', status)
+
+  const { data, error } = await query.order('created_at', { ascending: false })
+  if (error) return apiError(error.message, 500)
+
+  return apiOk(data)
+}
+
+export async function POST(request: NextRequest) {
+  if (!validateApiKey(request)) return unauthorized()
+
+  const supabase = createServiceClient()
+  const orgId = getOrgId()
+  const body = await request.json()
+
+  // Invariante: todo cargo accesorio cuelga de un contrato.
+  if (!body.contract_id) return apiError('contract_id is required')
+  if (!body.kind) return apiError('kind is required')
+  if (body.amount === undefined || body.amount === null) return apiError('amount is required')
+
+  const { data, error } = await supabase
+    .from('ancillary_charges')
+    .insert({ ...body, org_id: orgId })
+    .select('*, contract:contracts(*, unit:units(*), occupant:occupants(*)), asset:ancillary_assets(*)')
+    .single()
+
+  if (error) return apiError(error.message, 500)
+
+  await logEvent('ancillary_charge.created', {
+    charge_id: data.id,
+    contract_id: data.contract_id,
+    kind: data.kind,
+    amount: data.amount,
+    cadence: data.cadence,
+  })
+
+  return apiOk(data)
+}
+
+export async function DELETE(request: NextRequest) {
+  if (!validateApiKey(request)) return unauthorized()
+  const supabase = createServiceClient()
+  const { searchParams } = new URL(request.url)
+
+  const id = searchParams.get('id')
+  if (!id) return apiError('id query param is required')
+
+  const { error } = await supabase
+    .from('ancillary_charges')
+    .delete()
+    .eq('id', id)
+
+  if (error) return apiError(error.message, 500)
+
+  await logEvent('ancillary_charge.deleted', { charge_id: id })
+
+  return apiOk({ deleted: id })
+}

--- a/src/app/api/cron/payments/route.ts
+++ b/src/app/api/cron/payments/route.ts
@@ -14,6 +14,18 @@ function getSupabase() {
   )
 }
 
+interface AncillaryCharge {
+  id: string
+  org_id: string
+  contract_id: string
+  amount: number
+  quantity: number
+  cadence: 'monthly' | 'annual'
+  billing_day: number
+  effective_from: string
+  effective_to: string | null
+}
+
 // This route is called by Vercel Cron on day 1 of each month
 // Vercel cron config goes in vercel.json
 export async function GET(request: Request) {
@@ -31,30 +43,31 @@ export async function GET(request: Request) {
 
   const supabase = getSupabase()
 
-  // Get all active and en_renovacion contracts.
-  // STR (renta corta) se cobra por reserva, no por mes → se excluye de la renta mensual.
+  // Existing payments this month, split by source (rent vs ancillary) so each
+  // generator only dedups against its own kind of row.
+  const { data: existingPayments } = await supabase
+    .from('payments')
+    .select('contract_id, ancillary_charge_id')
+    .gte('due_date', monthStart)
+    .lte('due_date', monthEnd)
+
+  const rentDoneContractIds = new Set(
+    (existingPayments || []).filter(p => !p.ancillary_charge_id).map(p => p.contract_id)
+  )
+  const ancillaryDoneChargeIds = new Set(
+    (existingPayments || []).filter(p => p.ancillary_charge_id).map(p => p.ancillary_charge_id)
+  )
+
+  // ── 1) Renta mensual ────────────────────────────────────────────────────
+  // STR (renta corta) se cobra por reserva, no por mes → se excluye.
   const { data: contracts } = await supabase
     .from('contracts')
     .select('id, monthly_amount, payment_day, org_id, rent_type')
     .in('status', ['active', 'en_renovacion'])
     .neq('rent_type', 'STR')
 
-  if (!contracts || contracts.length === 0) {
-    return NextResponse.json({ message: 'No active contracts', generated: 0 })
-  }
-
-  // Check which ones already have a payment this month
-  const { data: existingPayments } = await supabase
-    .from('payments')
-    .select('contract_id')
-    .gte('due_date', monthStart)
-    .lte('due_date', monthEnd)
-
-  const existingContractIds = new Set((existingPayments || []).map(p => p.contract_id))
-
-  // Generate pending payments for contracts without one this month
-  const toInsert = contracts
-    .filter(c => !existingContractIds.has(c.id))
+  const rentToInsert = (contracts || [])
+    .filter(c => !rentDoneContractIds.has(c.id))
     .map(c => ({
       org_id: c.org_id,
       contract_id: c.id,
@@ -62,12 +75,47 @@ export async function GET(request: Request) {
       rent_amount: Number(c.monthly_amount),
       water_fee: 250,
       due_date: `${year}-${String(month).padStart(2, '0')}-${String(c.payment_day || 5).padStart(2, '0')}`,
-      status: 'pending'
+      status: 'pending',
     }))
 
+  // ── 2) Cargos accesorios (estacionamiento extra, espectaculares) ─────────
+  // Activos y vigentes este mes. Mensuales: cada mes. Anuales: solo en su mes
+  // aniversario (el mes de effective_from).
+  const { data: charges } = await supabase
+    .from('ancillary_charges')
+    .select('id, org_id, contract_id, amount, quantity, cadence, billing_day, effective_from, effective_to')
+    .eq('status', 'active')
+    .lte('effective_from', monthEnd)
+    .or(`effective_to.is.null,effective_to.gte.${monthStart}`)
+
+  const ancillaryToInsert = ((charges || []) as AncillaryCharge[])
+    .filter(c => {
+      if (ancillaryDoneChargeIds.has(c.id)) return false
+      if (c.cadence === 'annual') {
+        // Solo en el mes aniversario (mes de effective_from)
+        const anniversaryMonth = new Date(c.effective_from).getUTCMonth() + 1
+        if (anniversaryMonth !== month) return false
+      }
+      return true
+    })
+    .map(c => ({
+      org_id: c.org_id,
+      contract_id: c.contract_id,
+      ancillary_charge_id: c.id,
+      amount: Number(c.amount) * (c.quantity || 1),
+      due_date: `${year}-${String(month).padStart(2, '0')}-${String(c.billing_day || 1).padStart(2, '0')}`,
+      status: 'pending',
+    }))
+
+  const toInsert = [...rentToInsert, ...ancillaryToInsert]
   if (toInsert.length > 0) {
     await supabase.from('payments').insert(toInsert)
   }
 
-  return NextResponse.json({ message: 'OK', generated: toInsert.length })
+  return NextResponse.json({
+    message: 'OK',
+    generated: toInsert.length,
+    rent: rentToInsert.length,
+    ancillary: ancillaryToInsert.length,
+  })
 }

--- a/src/app/parking/page.tsx
+++ b/src/app/parking/page.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Car, Save, Check } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
+import { useToast } from '@/components/Toast'
+import { SkeletonTable } from '@/components/Skeleton'
+import EmptyState from '@/components/EmptyState'
+
+interface BuildingPool {
+  id: string
+  name: string
+  parking_total: number
+  included: number // suma de cajones incluidos por unidades del edificio
+  extra: number // cajones extra cobrados (cargos activos)
+}
+
+export default function ParkingPage() {
+  const toast = useToast()
+  const { orgId } = useOrgContext()
+  const [pools, setPools] = useState<BuildingPool[]>([])
+  const [loading, setLoading] = useState(true)
+  const [edits, setEdits] = useState<Record<string, number>>({})
+  const [savingId, setSavingId] = useState<string | null>(null)
+
+  async function fetchPools() {
+    setLoading(true)
+
+    const [{ data: buildings }, { data: units }, { data: charges }] = await Promise.all([
+      supabase.from('buildings').select('id, name, parking_total').eq('org_id', orgId).order('name'),
+      supabase.from('units').select('building_id, parking_included').eq('org_id', orgId),
+      supabase
+        .from('ancillary_charges')
+        .select('quantity, contract:contracts(unit:units(building_id))')
+        .eq('org_id', orgId)
+        .eq('kind', 'parking')
+        .eq('status', 'active'),
+    ])
+
+    // Sumar cajones incluidos por edificio
+    const includedByBuilding: Record<string, number> = {}
+    for (const u of (units || []) as unknown as { building_id: string | null; parking_included: number | null }[]) {
+      if (!u.building_id) continue
+      includedByBuilding[u.building_id] = (includedByBuilding[u.building_id] || 0) + (u.parking_included || 0)
+    }
+
+    // Sumar cajones extra cobrados por edificio (vía contrato → unidad → edificio)
+    const extraByBuilding: Record<string, number> = {}
+    for (const c of (charges || []) as unknown as { quantity: number; contract?: { unit?: { building_id: string | null } | null } | null }[]) {
+      const bId = c.contract?.unit?.building_id
+      if (!bId) continue
+      extraByBuilding[bId] = (extraByBuilding[bId] || 0) + (c.quantity || 0)
+    }
+
+    const result: BuildingPool[] = ((buildings || []) as unknown as { id: string; name: string; parking_total: number | null }[]).map((b) => ({
+      id: b.id,
+      name: b.name,
+      parking_total: b.parking_total || 0,
+      included: includedByBuilding[b.id] || 0,
+      extra: extraByBuilding[b.id] || 0,
+    }))
+
+    setPools(result)
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    if (!orgId) return
+    fetchPools()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId])
+
+  async function saveTotal(buildingId: string) {
+    const value = edits[buildingId]
+    if (value === undefined) return
+    setSavingId(buildingId)
+    const { error } = await supabase.from('buildings').update({ parking_total: value }).eq('id', buildingId)
+    setSavingId(null)
+    if (error) {
+      toast.error('Error al guardar el total — intenta de nuevo')
+    } else {
+      toast.success('Total de cajones actualizado')
+      setEdits((prev) => {
+        const next = { ...prev }
+        delete next[buildingId]
+        return next
+      })
+      fetchPools()
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Car className="w-6 h-6 text-blue-500" />
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold">Estacionamiento</h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
+            Pool de cajones por edificio. Los cajones extra se cobran en Cargos adicionales.
+          </p>
+        </div>
+      </div>
+
+      {loading ? (
+        <SkeletonTable />
+      ) : pools.length === 0 ? (
+        <EmptyState
+          icon={Car}
+          title="No hay edificios"
+          description="Registra edificios para administrar su pool de estacionamiento"
+        />
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {pools.map((p) => {
+            const pending = edits[p.id] !== undefined ? edits[p.id] : p.parking_total
+            const available = pending - p.included - p.extra
+            return (
+              <div key={p.id} className="card space-y-4">
+                <h2 className="font-bold text-gray-900 dark:text-white">{p.name}</h2>
+
+                {/* Total editable */}
+                <div>
+                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Total de cajones</label>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={0}
+                      value={pending}
+                      onChange={(e) => setEdits({ ...edits, [p.id]: Math.max(0, Number(e.target.value)) })}
+                      className="input-field w-24"
+                    />
+                    {edits[p.id] !== undefined && edits[p.id] !== p.parking_total && (
+                      <button
+                        onClick={() => saveTotal(p.id)}
+                        disabled={savingId === p.id}
+                        className="flex items-center gap-1.5 px-3 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
+                      >
+                        <Save className="w-3.5 h-3.5" />
+                        Guardar
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {/* Desglose */}
+                <div className="space-y-1.5 text-sm">
+                  <div className="flex justify-between">
+                    <span className="text-gray-500 dark:text-gray-400">Incluidos en unidades</span>
+                    <span className="text-gray-700 dark:text-gray-300">{p.included}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500 dark:text-gray-400">Extra cobrados</span>
+                    <span className="text-gray-700 dark:text-gray-300">{p.extra}</span>
+                  </div>
+                  <div className="flex justify-between border-t border-gray-200 dark:border-gray-800 pt-1.5">
+                    <span className="font-medium text-gray-900 dark:text-white">Disponibles</span>
+                    <span className={`font-bold ${available < 0 ? 'text-red-500' : available === 0 ? 'text-gray-400' : 'text-green-500'}`}>
+                      {available}
+                    </span>
+                  </div>
+                </div>
+
+                {available < 0 && (
+                  <p className="flex items-center gap-1.5 text-xs text-red-500">
+                    Asignados más cajones de los que existen — revisa el total.
+                  </p>
+                )}
+                {available >= 0 && (
+                  <p className="flex items-center gap-1.5 text-xs text-gray-400">
+                    <Check className="w-3.5 h-3.5" />
+                    {available} cajón{available === 1 ? '' : 'es'} libre{available === 1 ? '' : 's'} para rentar
+                  </p>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -126,6 +126,7 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       '/reportes',
       '/quotes',
       '/pricing',
+      '/ancillary-charges',
     ],
     subNav: [
       { href: '/cobros', label: 'Cobros' },
@@ -136,6 +137,7 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       { href: '/reportes', label: 'Reportes' },
       { href: '/pricing', label: 'Precios' },
       { href: '/quotes', label: 'Cotizador' },
+      { href: '/ancillary-charges', label: 'Cargos adicionales' },
     ],
   },
   {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,10 @@ export type ReservationStatus = 'tentative' | 'confirmed' | 'cancelled' | 'check
 export type ReservationPaymentStatus = 'pending' | 'partial' | 'paid'
 export type BookingMode = 'full' | 'room' | 'bed'
 export type OccupantType = 'tenant' | 'guest' | 'owner' | 'staff'
+export type AncillaryKind = 'parking' | 'billboard' | 'storage' | 'antenna' | 'other'
+export type AncillaryCadence = 'monthly' | 'annual'
+export type AncillaryOwnership = 'ours' | 'third_party'
+export type AncillaryStatus = 'active' | 'inactive' | 'ended'
 export type ContactType = 'ltr' | 'str' | 'both'
 export type MemberRole = 'owner' | 'admin' | 'operator' | 'viewer' | 'agent' | 'pm_owner' | 'pm_admin' | 'pm_operator' | 'pm_viewer' | 'client'
 
@@ -24,6 +28,7 @@ export interface Building {
   state?: string | null
   country: string
   postal_code?: string | null
+  parking_total?: number // pool de cajones del edificio
   notes?: string | null
   created_at: string
   updated_at: string
@@ -104,6 +109,7 @@ export interface Unit {
   area_m2?: number
   bedrooms?: number
   bathrooms?: number
+  parking_included?: number // cajones incluidos sin cobro extra
   title?: string
   slug?: string
   description_short?: string
@@ -185,7 +191,7 @@ export interface Occupant {
 export interface Contract {
   id: string
   org_id: string
-  unit_id: string
+  unit_id?: string | null // NULL = contrato independiente (standalone)
   occupant_id: string
   start_date: string
   end_date?: string
@@ -233,6 +239,45 @@ export interface Payment {
   updated_at: string
   // Relations
   contract?: Contract
+}
+
+export interface AncillaryAsset {
+  id: string
+  org_id: string
+  building_id?: string | null
+  kind: AncillaryKind
+  label: string
+  ownership: AncillaryOwnership
+  status: AncillaryStatus
+  notes?: string
+  created_at: string
+  updated_at: string
+  // Relations
+  building?: Building
+}
+
+export interface AncillaryCharge {
+  id: string
+  org_id: string
+  contract_id: string // invariante: siempre ligado a un contrato
+  asset_id?: string | null
+  building_id?: string | null
+  unit_id?: string | null // NULL si el contrato es independiente
+  kind: AncillaryKind
+  description?: string
+  amount: number // monto por periodo (según cadence)
+  cadence: AncillaryCadence
+  billing_day: number // 1..28
+  quantity: number
+  effective_from: string
+  effective_to?: string | null
+  status: AncillaryStatus
+  notes?: string
+  created_at: string
+  updated_at: string
+  // Relations (joined)
+  contract?: Contract
+  asset?: AncillaryAsset
 }
 
 export interface Incident {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -234,6 +234,7 @@ export interface Payment {
   status: PaymentStatus
   method?: string
   reference?: string
+  ancillary_charge_id?: string | null // origen accesorio; null = renta normal
   notes?: string
   created_at: string
   updated_at: string

--- a/supabase/migrations/20260616_02_ancillary_charges.sql
+++ b/supabase/migrations/20260616_02_ancillary_charges.sql
@@ -1,0 +1,144 @@
+-- BaW OS — Cargos accesorios (estacionamiento + espectaculares) — Fase 2 / PR B1.
+--
+-- Contexto (decisión de Fran):
+--   Además de la renta de la unidad, un edificio genera ingresos accesorios:
+--     • Estacionamiento: cada edificio tiene un POOL de cajones. Muchos vienen
+--       incluidos con una unidad (sin cobro extra); los cajones libres se pueden
+--       rentar como EXTRA a un inquilino, sumándose a su renta.
+--     • Espectaculares (billboards): activos publicitarios sobre azotea. Dos casos
+--       reales: estructura PROPIA cobrada mensual (ej. 2020: 5 espectaculares a
+--       $5,000 c/u el día 15) y estructura de TERCEROS que paga renta ANUAL por el
+--       espacio (ej. 809).
+--
+-- Invariante pedido por Fran: TODO cargo accesorio cuelga de un CONTRATO. El
+-- contrato puede estar ligado a una unidad de renta, o ser INDEPENDIENTE (sin
+-- unidad) — p.ej. el contrato con un anunciante. Por eso este PR vuelve
+-- contracts.unit_id NULLABLE.
+--
+-- Este PR (B1) solo crea esquema + cimientos. La generación automática de cargos
+-- en cobranza (mensual vs anual) va en un PR posterior dedicado (B3).
+--
+-- Aditiva + idempotente. Rollback al final del archivo.
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 1) Contratos independientes: unit_id deja de ser obligatorio.
+--    Un contrato sin unidad (unit_id NULL) representa un contrato standalone
+--    (ej. anunciante de espectacular). occupant_id sigue siendo obligatorio:
+--    siempre hay un pagador.
+-- ───────────────────────────────────────────────────────────────────────────
+ALTER TABLE public.contracts ALTER COLUMN unit_id DROP NOT NULL;
+
+COMMENT ON COLUMN public.contracts.unit_id IS
+  'Unidad de renta asociada. NULL = contrato INDEPENDIENTE (standalone), p.ej. anunciante de espectacular sin unidad.';
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 2) Pool de estacionamiento (informativo a nivel edificio/unidad).
+--    El cobro de cajones EXTRA vive en ancillary_charges (kind='parking').
+-- ───────────────────────────────────────────────────────────────────────────
+ALTER TABLE public.buildings
+  ADD COLUMN IF NOT EXISTS parking_total INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE public.units
+  ADD COLUMN IF NOT EXISTS parking_included INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.buildings.parking_total IS
+  'Total de cajones de estacionamiento que existen en el edificio (pool).';
+COMMENT ON COLUMN public.units.parking_included IS
+  'Cajones incluidos con esta unidad sin cobro extra (baseline). Los extra se cobran vía ancillary_charges.';
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 3) Enums
+-- ───────────────────────────────────────────────────────────────────────────
+DO $$ BEGIN
+  CREATE TYPE ancillary_kind AS ENUM ('parking', 'billboard', 'storage', 'antenna', 'other');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE ancillary_cadence AS ENUM ('monthly', 'annual');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE ancillary_ownership AS ENUM ('ours', 'third_party');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE ancillary_status AS ENUM ('active', 'inactive', 'ended');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 4) ancillary_assets — activos accesorios discretos (espectaculares, bodegas…).
+--    Opcional: un cargo puede referenciar un activo, pero no es obligatorio
+--    (los cajones extra no tienen activo, salen del pool del edificio).
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.ancillary_assets (
+  id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  org_id      UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  building_id UUID REFERENCES buildings(id) ON DELETE SET NULL,
+  kind        ancillary_kind NOT NULL DEFAULT 'billboard',
+  label       TEXT NOT NULL,                 -- ej. "Espectacular azotea norte"
+  ownership   ancillary_ownership NOT NULL DEFAULT 'ours', -- 'ours' = estructura propia
+  status      ancillary_status NOT NULL DEFAULT 'active',
+  notes       TEXT,
+  created_at  TIMESTAMPTZ DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.ancillary_assets ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  CREATE POLICY "ancillary_assets_org_isolation" ON public.ancillary_assets
+    USING (org_id IN (SELECT org_id FROM org_members WHERE user_id = auth.uid()));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 5) ancillary_charges — línea de ingreso accesorio, SIEMPRE ligada a un contrato.
+--    Integra a cobranza vía cadence (mensual/anual) + billing_day en un PR futuro.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.ancillary_charges (
+  id             UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  org_id         UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  contract_id    UUID NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,  -- invariante: todo cargo cuelga de un contrato
+  asset_id       UUID REFERENCES ancillary_assets(id) ON DELETE SET NULL,   -- opcional (espectacular)
+  building_id    UUID REFERENCES buildings(id) ON DELETE SET NULL,          -- denormalizado para reportes
+  unit_id        UUID REFERENCES units(id) ON DELETE SET NULL,              -- denormalizado; NULL si contrato independiente
+  kind           ancillary_kind NOT NULL,
+  description    TEXT,                                  -- ej. "2 cajones extra", "Espectacular 809"
+  amount         DECIMAL(10,2) NOT NULL,                -- monto por periodo (según cadence)
+  cadence        ancillary_cadence NOT NULL DEFAULT 'monthly',
+  billing_day    INTEGER NOT NULL DEFAULT 1,            -- día de cobro (1..28); para anual = día del mes de aniversario
+  quantity       INTEGER NOT NULL DEFAULT 1,            -- nº de cajones / espectaculares
+  effective_from DATE NOT NULL DEFAULT CURRENT_DATE,
+  effective_to   DATE,                                  -- NULL = vigente/indefinido
+  status         ancillary_status NOT NULL DEFAULT 'active',
+  notes          TEXT,
+  created_at     TIMESTAMPTZ DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT ancillary_charges_billing_day_chk CHECK (billing_day BETWEEN 1 AND 28),
+  CONSTRAINT ancillary_charges_amount_chk CHECK (amount >= 0),
+  CONSTRAINT ancillary_charges_quantity_chk CHECK (quantity >= 1)
+);
+
+CREATE INDEX IF NOT EXISTS ancillary_charges_contract_idx ON public.ancillary_charges(contract_id);
+CREATE INDEX IF NOT EXISTS ancillary_charges_org_status_idx ON public.ancillary_charges(org_id, status);
+
+ALTER TABLE public.ancillary_charges ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  CREATE POLICY "ancillary_charges_org_isolation" ON public.ancillary_charges
+    USING (org_id IN (SELECT org_id FROM org_members WHERE user_id = auth.uid()));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+COMMENT ON TABLE public.ancillary_charges IS
+  'Ingresos accesorios (estacionamiento extra, espectaculares) ligados a un contrato. La cobranza genera pagos según cadence + billing_day (PR B3).';
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- ROLLBACK
+--   DROP TABLE IF EXISTS public.ancillary_charges;
+--   DROP TABLE IF EXISTS public.ancillary_assets;
+--   DROP TYPE  IF EXISTS ancillary_status;
+--   DROP TYPE  IF EXISTS ancillary_ownership;
+--   DROP TYPE  IF EXISTS ancillary_cadence;
+--   DROP TYPE  IF EXISTS ancillary_kind;
+--   ALTER TABLE public.units     DROP COLUMN IF EXISTS parking_included;
+--   ALTER TABLE public.buildings DROP COLUMN IF EXISTS parking_total;
+--   -- Nota: re-imponer NOT NULL en contracts.unit_id requiere que no existan
+--   -- contratos independientes:  ALTER TABLE public.contracts ALTER COLUMN unit_id SET NOT NULL;
+-- ───────────────────────────────────────────────────────────────────────────

--- a/supabase/migrations/20260616_03_payments_ancillary_link.sql
+++ b/supabase/migrations/20260616_03_payments_ancillary_link.sql
@@ -1,0 +1,20 @@
+-- BaW OS — Enlace pago ↔ cargo accesorio (Fase 2 / PR B3: cobranza).
+--
+-- El cron mensual ahora genera, además de la renta, un renglón de pago por cada
+-- cargo accesorio activo (estacionamiento extra, espectaculares):
+--   • cadence='monthly' → cada mes en su billing_day.
+--   • cadence='annual'  → una vez al año, en el mes de effective_from, día billing_day.
+--
+-- Esta columna liga el pago con el cargo que lo originó, y es la clave de
+-- idempotencia: el cron no vuelve a generar un pago para el mismo cargo en el
+-- mismo periodo si ya existe. NULL = pago de renta normal (no accesorio).
+--
+-- Aditiva + idempotente. Rollback: ALTER TABLE payments DROP COLUMN ancillary_charge_id.
+
+ALTER TABLE public.payments
+  ADD COLUMN IF NOT EXISTS ancillary_charge_id UUID REFERENCES ancillary_charges(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS payments_ancillary_charge_idx ON public.payments(ancillary_charge_id);
+
+COMMENT ON COLUMN public.payments.ancillary_charge_id IS
+  'Cargo accesorio que originó este pago (estacionamiento/espectacular). NULL = pago de renta normal.';


### PR DESCRIPTION
## Resumen

Agrega el manejo de **ingresos accesorios** (estacionamiento extra y espectaculares) ligados a un contrato, de punta a punta: esquema, API, pantallas y cobranza automática.

Invariante de diseño (pedido por Fran): **todo cargo accesorio cuelga de un contrato**, que puede estar ligado a una unidad de renta **o** ser independiente (ej. un anunciante sin unidad).

### B1 — Cimientos
- Tablas `ancillary_assets` (espectaculares/bodegas/antenas, con `ownership` propia vs. terceros) y `ancillary_charges` (la línea de ingreso, con `cadence` mensual/anual, `billing_day`, `quantity`, vigencia y `status`).
- Pool de estacionamiento: `buildings.parking_total` + `units.parking_included`.
- `contracts.unit_id` ahora **nullable** → contratos independientes.
- API Tier 2: `/api/ancillary-charges` y `/api/ancillary-assets`.

### B2 — Pantallas
- `/ancillary-charges` — cargos (lista + alta/edición + borrado, con totales mensual/anual).
- `/ancillary-assets` — activos publicitarios (el 809, los del 2020, etc.).
- `/parking` — pool de cajones por edificio con cálculo en vivo de disponibles.
- Enlaces en el menú de Finanzas.

### B3 — Cobranza
- El cron mensual genera, además de la renta, un renglón de pago por cada cargo activo:
  - **mensual** → cada mes en su `billing_day`.
  - **anual** → una vez al año, en el mes de `effective_from`.
- `payments.ancillary_charge_id` para idempotencia (no duplica), y fix del dedup de renta para que no se confunda con accesorios.

## Migraciones
Tres migraciones (`20260616_ownership_stakes_mgmt_vigencia`, `20260616_02_ancillary_charges`, `20260616_03_payments_ancillary_link`). **Ya aplicadas en producción** vía SQL Editor y verificadas. Validadas además en Postgres efímero (aplican limpio, idempotentes, invariantes y lógica de cobranza correctas).

## ⚠️ Incluye también trabajo previo de la rama (no de esta sesión)
Esta rama arrastraba commits anteriores que aún no estaban en `main` y entran en este PR:
- Fase 1: tipo de unidad "Local comercial" (RETAIL).
- Owners: vigencia separada propiedad vs. administración.
- Fix de resolución de org en `/settings`.
- Ajuste de tamaño del toggle Human/Agent.

## Notas
- Verde local: `tsc --noEmit` y `eslint` en todos los archivos nuevos.
- Comportamiento: un cargo se genera mientras su `status` sea `active`. Al terminar un contrato conviene poner sus cargos en `ended` (se puede automatizar si se desea).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_