### PR TITLE
Filtrar por edificio activo: opción "Todos" + dashboard de Inicio

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import {
   type StatusKind,
 } from '@/components/ui/status'
 import ContractAlertsBanner from '@/components/ContractAlertsBanner'
-import { useActiveContext } from '@/lib/useActiveContext'
+import { useActiveContext, ALL_BUILDINGS } from '@/lib/useActiveContext'
 
 // S9 hotfix: Mission Control ahora espera el contexto activo y filtra todas
 // las queries por activeOrgId. Antes confiaba 100% en RLS y, cuando una sola
@@ -54,7 +54,7 @@ function fmtMoney(n: number) {
 }
 
 export default function MissionControl() {
-  const { activeOrgId, loading: ctxLoading, orgs } = useActiveContext()
+  const { activeOrgId, activeBuildingId, loading: ctxLoading, orgs } = useActiveContext()
   const [metrics, setMetrics] = useState<DashboardMetrics>({
     totalUnits: 0,
     occupiedUnits: 0,
@@ -91,35 +91,62 @@ export default function MissionControl() {
           return
         }
 
+        // Edificio activo: si hay uno específico (no "Todos" ni vacío) filtramos.
+        // Contratos/pagos/incidencias cuelgan de la unidad, así que filtramos por
+        // el edificio de la unidad usando joins !inner de PostgREST.
+        const bId =
+          activeBuildingId && activeBuildingId !== ALL_BUILDINGS
+            ? activeBuildingId
+            : null
+
+        // Selects: con filtro de edificio usamos !inner para poder filtrar por
+        // la columna anidada; sin filtro, embeds normales (no excluir filas).
+        const contractsSel = bId
+          ? 'id, unit_id, monthly_amount, end_date, status, unit:units!inner(number, building_id), occupant:occupants(name)'
+          : 'id, unit_id, monthly_amount, end_date, status, unit:units(number), occupant:occupants(name)'
+        const paymentsSel = bId
+          ? 'id, amount, due_date, status, contract:contracts!inner(unit:units!inner(number, building_id), occupant:occupants(name))'
+          : 'id, amount, due_date, status, contract:contracts(unit:units(number), occupant:occupants(name))'
+        const incidentsSel = bId
+          ? 'id, status, created_at, description, unit:units!inner(number, building_id)'
+          : 'id, status, created_at, description, unit:units(number)'
+
+        // Nota: los filtros .eq() van ANTES de .order()/.limit() (el builder de
+        // Supabase deja de exponer .eq() una vez transformado).
+        let unitsQ = supabase.from('units').select('*').eq('org_id', activeOrgId)
+        if (bId) unitsQ = unitsQ.eq('building_id', bId)
+        const unitsFinal = unitsQ.order('floor').order('number')
+
+        let contractsQ = supabase
+          .from('contracts')
+          .select(contractsSel)
+          .eq('org_id', activeOrgId)
+          .in('status', ['active', 'en_renovacion'])
+        if (bId) contractsQ = contractsQ.eq('unit.building_id', bId)
+
+        let paymentsQ = supabase
+          .from('payments')
+          .select(paymentsSel)
+          .eq('org_id', activeOrgId)
+          .in('status', ['pending', 'late'])
+        if (bId) paymentsQ = paymentsQ.eq('contract.unit.building_id', bId)
+        const paymentsFinal = paymentsQ.order('due_date', { ascending: true })
+
+        let incidentsQ = supabase
+          .from('incidents')
+          .select(incidentsSel)
+          .eq('org_id', activeOrgId)
+          .in('status', ['open', 'in_progress', 'pending'])
+        if (bId) incidentsQ = incidentsQ.eq('unit.building_id', bId)
+        const incidentsFinal = incidentsQ
+          .order('created_at', { ascending: false })
+          .limit(5)
+
         const [unitsRes, contractsRes, paymentsRes, maintRes] = await Promise.all([
-          supabase
-            .from('units')
-            .select('*')
-            .eq('org_id', activeOrgId)
-            .order('floor')
-            .order('number'),
-          supabase
-            .from('contracts')
-            .select(
-              'id, unit_id, monthly_amount, end_date, status, unit:units(number), occupant:occupants(name)'
-            )
-            .eq('org_id', activeOrgId)
-            .in('status', ['active', 'en_renovacion']),
-          supabase
-            .from('payments')
-            .select(
-              'id, amount, due_date, status, contract:contracts(unit:units(number), occupant:occupants(name))'
-            )
-            .eq('org_id', activeOrgId)
-            .in('status', ['pending', 'late'])
-            .order('due_date', { ascending: true }),
-          supabase
-            .from('incidents')
-            .select('id, status, created_at, description, unit:units(number)')
-            .eq('org_id', activeOrgId)
-            .in('status', ['open', 'in_progress', 'pending'])
-            .order('created_at', { ascending: false })
-            .limit(5),
+          unitsFinal,
+          contractsQ,
+          paymentsFinal,
+          incidentsFinal,
         ])
 
         const units = unitsRes.data || []
@@ -208,7 +235,7 @@ export default function MissionControl() {
     }
 
     fetchDashboard()
-  }, [ctxLoading, activeOrgId, orgs.length])
+  }, [ctxLoading, activeOrgId, activeBuildingId, orgs.length])
 
   const occupancyPct =
     metrics.totalUnits > 0

--- a/src/components/WorkspaceSwitcher.tsx
+++ b/src/components/WorkspaceSwitcher.tsx
@@ -7,7 +7,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { Building2, ChevronRight, Check, Plus } from 'lucide-react'
 import Link from 'next/link'
-import { useActiveContext } from '@/lib/useActiveContext'
+import { useActiveContext, ALL_BUILDINGS } from '@/lib/useActiveContext'
 
 interface Props {
   expanded: boolean
@@ -50,6 +50,8 @@ export default function WorkspaceSwitcher({ expanded }: Props) {
     : activeOrg?.name ?? '—'
   const subText = isEmpty
     ? 'Empezar onboarding'
+    : activeBuildingId === ALL_BUILDINGS
+    ? 'Todos los edificios'
     : activeBuilding
     ? `${activeBuilding.name}${activeBuilding.city ? `, ${activeBuilding.city}` : ''}`
     : 'Sin edificio'
@@ -152,6 +154,22 @@ export default function WorkspaceSwitcher({ expanded }: Props) {
             </div>
           ) : (
             <ul>
+              <li>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setActiveBuildingId(ALL_BUILDINGS)
+                    setOpen(false)
+                  }}
+                  className="w-full flex items-center justify-between gap-2 px-3 py-1.5 text-[12px] hover:bg-white/5"
+                  style={{ color: 'var(--baw-text)' }}
+                >
+                  <span className="truncate font-medium">Todos los edificios</span>
+                  {activeBuildingId === ALL_BUILDINGS && (
+                    <Check size={12} style={{ color: 'var(--baw-primary)' }} />
+                  )}
+                </button>
+              </li>
               {buildingsForActiveOrg.map((b) => (
                 <li key={b.id}>
                   <button

--- a/src/lib/useActiveContext.ts
+++ b/src/lib/useActiveContext.ts
@@ -12,6 +12,10 @@ import { supabase } from '@/lib/supabase'
 const STORAGE_KEY_ORG = 'baw:active_org_id'
 const STORAGE_KEY_BUILDING = 'baw:active_building_id'
 
+// Valor centinela para "Todos los edificios" (vista consolidada).
+// activeBuildingId === ALL_BUILDINGS → las pantallas muestran toda la org.
+export const ALL_BUILDINGS = 'all'
+
 export interface OrgOption {
   id: string
   name: string
@@ -152,7 +156,9 @@ export function useActiveContext(): ActiveContext {
         let nextActiveBld: string | null = null
         try {
           const stored = localStorage.getItem(STORAGE_KEY_BUILDING)
-          if (
+          if (stored === ALL_BUILDINGS) {
+            nextActiveBld = ALL_BUILDINGS
+          } else if (
             stored &&
             bldList.some(
               (b) => b.id === stored && b.org_id === nextActiveOrg,
@@ -188,6 +194,7 @@ export function useActiveContext(): ActiveContext {
   // Si cambia la org activa, ajustar el building activo si pertenece a otra org
   useEffect(() => {
     if (!activeOrgId) return
+    if (activeBuildingId === ALL_BUILDINGS) return // consolidado: válido en cualquier org
     if (activeBuildingId) {
       const current = buildings.find((b) => b.id === activeBuildingId)
       if (current && current.org_id === activeOrgId) return


### PR DESCRIPTION
## Problema

Al cambiar de edificio en el selector de la barra lateral, el **dashboard de Inicio (Mission Control) no cambiaba nada**: sus métricas se calculaban a nivel organización (todos los edificios), ignorando el edificio activo. Solo cambiaba el subtítulo (cosmético). Además, el selector **no tenía opción para ver consolidado** ("Todos").

## Cambios (PR 1 de la iniciativa "filtrar por edificio")

1. **`useActiveContext`** — nuevo centinela `ALL_BUILDINGS = 'all'` (persistido en localStorage, válido en cualquier org). Es la selección explícita de "consolidado".
2. **`WorkspaceSwitcher`** — entrada **"Todos los edificios"** arriba de la lista, con su palomita cuando está activa.
3. **Mission Control (`src/app/page.tsx`)** — ahora filtra por el edificio activo:
   - Edificio específico → filtra unidades, contratos, pagos e incidencias por ese edificio. Como contratos/pagos/incidencias cuelgan de la unidad, se usa el filtro anidado de PostgREST (`!inner` sobre `unit.building_id`).
   - **"Todos"** → vista consolidada (el comportamiento previo, embeds normales para no excluir filas como pagos de contratos independientes).

## Comportamiento
- Elegir 809 o 2020 ahora cambia ocupación, ingreso, morosidad, disponibles y mantenimiento al alcance de ese edificio.
- "Todos los edificios" muestra el agregado de la organización.

## Alcance / roadmap
Esto es el **cimiento + el dashboard**. En PRs siguientes aplico el mismo patrón a las demás pantallas que deben respetar el edificio (Cobros, Morosidad, Finanzas, Contratos, Mantenimiento). Se parte por área para que cada PR sea revisable.

## Notas
- Verde local: `tsc --noEmit` y `eslint`.
- Sin cambios de base de datos (las unidades ya tienen `building_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_