### PR TITLE
Búsqueda global (⌘K) + Estado de cuenta por inquilino (PDF) + mora consistente

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -5,6 +5,7 @@ import { Search, Building2, FileText, Users, Wrench } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { SkeletonText } from '@/components/Skeleton'
 import Link from 'next/link'
+import { useActiveContext, ALL_BUILDINGS } from '@/lib/useActiveContext'
 
 interface SearchResult {
   category: 'units' | 'contracts' | 'occupants' | 'incidents'
@@ -22,6 +23,7 @@ const CATEGORY_META = {
 }
 
 export default function SearchPage() {
+  const { activeOrgId, activeBuildingId } = useActiveContext()
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
   const [loading, setLoading] = useState(false)
@@ -38,37 +40,53 @@ export default function SearchPage() {
       setResults([])
       return
     }
+    if (!activeOrgId) {
+      setResults([])
+      return
+    }
     timerRef.current = setTimeout(() => {
       performSearch(query.trim())
     }, 300)
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
     }
-  }, [query])
+  }, [query, activeOrgId, activeBuildingId])
 
   async function performSearch(q: string) {
+    if (!activeOrgId) return
     setLoading(true)
     const pattern = `%${q}%`
+    // Edificio activo específico (no "Todos") acota las unidades.
+    const bId =
+      activeBuildingId && activeBuildingId !== ALL_BUILDINGS
+        ? activeBuildingId
+        : null
+
+    let unitsQ = supabase
+      .from('units')
+      .select('id, number, notes, status')
+      .eq('org_id', activeOrgId)
+      .or(`number.ilike.${pattern},notes.ilike.${pattern}`)
+    if (bId) unitsQ = unitsQ.eq('building_id', bId)
 
     const [unitsRes, contractsRes, occupantsRes, incidentsRes] = await Promise.all([
-      supabase
-        .from('units')
-        .select('id, number, notes, status')
-        .or(`number.ilike.${pattern},notes.ilike.${pattern}`)
-        .limit(5),
+      unitsQ.limit(5),
       supabase
         .from('contracts')
-        .select('id, status, occupant:occupants(name), unit:units(number)')
-        .or(`occupant.name.ilike.${pattern}`)
+        .select('id, status, occupant:occupants!inner(name), unit:units(number)')
+        .eq('org_id', activeOrgId)
+        .ilike('occupant.name', pattern)
         .limit(5),
       supabase
         .from('occupants')
         .select('id, name, phone, email')
+        .eq('org_id', activeOrgId)
         .or(`name.ilike.${pattern},phone.ilike.${pattern},email.ilike.${pattern}`)
         .limit(5),
       supabase
         .from('incidents')
         .select('id, title, status, unit:units(number)')
+        .eq('org_id', activeOrgId)
         .ilike('title', pattern)
         .limit(5),
     ])

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useState, useCallback } from 'react'
 import Link from 'next/link'
 import { Search, Bell } from 'lucide-react'
@@ -79,6 +79,19 @@ function getPageTitle(pathname: string): string {
 function GlobalHeader({ pathname }: { pathname: string }) {
   const title = getPageTitle(pathname)
   const [unread, setUnread] = useState(0)
+  const router = useRouter()
+
+  // ⌘K / Ctrl+K abren el buscador global (página /search).
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        router.push('/search')
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [router])
 
   const fetchUnread = useCallback(async () => {
     try {
@@ -135,13 +148,14 @@ function GlobalHeader({ pathname }: { pathname: string }) {
           {/* Search ⌘K */}
           <button
             type="button"
-            className="inline-flex items-center gap-2 px-2.5 py-1.5 rounded-md text-[12px] transition-colors"
+            onClick={() => router.push('/search')}
+            className="inline-flex items-center gap-2 px-2.5 py-1.5 rounded-md transition-colors hover:bg-white/5 text-[12px]"
             style={{
               backgroundColor: 'var(--baw-surface)',
               color: 'var(--baw-muted)',
               border: '1px solid var(--baw-border)',
             }}
-            title="Buscar"
+            title="Buscar (⌘K)"
           >
             <Search className="w-3.5 h-3.5" />
             <span className="hidden sm:inline">Buscar</span>


### PR DESCRIPTION
Esta rama agrupa dos entregas del bloque de cobranza.

## 1 · Búsqueda global (⌘K)
El botón de búsqueda arriba a la derecha no tenía handler y no existía listener de teclado, así que ni el clic ni `⌘K` hacían nada. La página `/search` ya existía pero quedaba inalcanzable y **no filtraba por `org_id`**.
- El botón y el atajo **⌘K / Ctrl+K** abren `/search` desde cualquier pantalla.
- Todas las queries filtran por `activeOrgId`; las unidades se acotan al edificio activo.
- Se corrigió el filtro de contratos por inquilino (inner join).

## 2 · Estado de cuenta por inquilino (PDF)
Documento nuevo, generado por el sistema, en la **línea gráfica de BaW OS**.
- **Motor** (`src/lib/estado-cuenta.ts`): agregación pura y testeable → saldo anterior, cargos del periodo, **pagos recibidos (incluye parciales)**, recargos por mora y saldo total, con ledger de movimientos y **antigüedad de saldo**. Cuadra por construcción y reusa los criterios del runner de cobranza (recargos persistidos en `late_fee_amount`).
- **PDF** (`@react-pdf/renderer`): indigo 266, Inter + IBM Plex Mono (importes/IDs) + Instrument Serif (número hero), light mode. Marca **del edificio dominante** y **"Operado con BaW OS"** discreto al pie. Fuentes TTF empaquetadas en el repo.
- **Endpoint** `GET /api/contracts/[id]/estado-cuenta?periodo=YYYY-MM` (sesión o API key) → PDF. Botón **"Estado"** por fila en `/cobros`.

## 3 · Mora consistente en /cobros
`/cobros` mostraba una mora cosmética **hardcodeada al 3%**, inconsistente con la política. Ahora usa `calcMoraSurcharge` (**5%** 6-15 días, **10%** 16+) con los días reales de atraso — la misma fuente de verdad que el agente de cobranza.

## Validación
- `tsc --noEmit` limpio; `eslint` sin errores (solo warnings preexistentes de `exhaustive-deps`).
- Render del PDF probado end-to-end: genera PDF válido, fuentes embebidas, y el resumen cuadra ($11,400 = saldo anterior + cargos + recargos − pagos en el caso de prueba).

## Follow-ups sugeridos
- Enviar el PDF por WhatsApp desde `/cobros` (el canal ya existe).
- Hacer la política de mora configurable desde UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)