### PR TITLE
fix: cambio de edificio/org se refleja al instante (sin refresh manual)

### DIFF
--- a/src/lib/useActiveContext.ts
+++ b/src/lib/useActiveContext.ts
@@ -12,6 +12,14 @@ import { supabase } from '@/lib/supabase'
 const STORAGE_KEY_ORG = 'baw:active_org_id'
 const STORAGE_KEY_BUILDING = 'baw:active_building_id'
 
+// Eventos para sincronizar TODAS las instancias del hook en la misma pestaña.
+// El hook se monta por separado en cada componente (sidebar, páginas, etc.) y
+// sin esto solo la instancia que dispara el cambio se entera; las demás se
+// quedan con el valor viejo hasta un refresh. Al emitir estos eventos, cada
+// instancia actualiza su estado local al instante.
+const EVT_ORG_CHANGED = 'baw:active-org-changed'
+const EVT_BUILDING_CHANGED = 'baw:active-building-changed'
+
 // Valor centinela para "Todos los edificios" (vista consolidada).
 // activeBuildingId === ALL_BUILDINGS → las pantallas muestran toda la org.
 export const ALL_BUILDINGS = 'all'
@@ -60,6 +68,9 @@ export function useActiveContext(): ActiveContext {
     } catch {
       // ignore
     }
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(EVT_ORG_CHANGED, { detail: id }))
+    }
   }, [])
 
   const setActiveBuildingId = useCallback((id: string) => {
@@ -68,6 +79,9 @@ export function useActiveContext(): ActiveContext {
       localStorage.setItem(STORAGE_KEY_BUILDING, id)
     } catch {
       // ignore
+    }
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(EVT_BUILDING_CHANGED, { detail: id }))
     }
   }, [])
 
@@ -190,6 +204,36 @@ export function useActiveContext(): ActiveContext {
   useEffect(() => {
     refresh()
   }, [refresh])
+
+  // Mantiene esta instancia en sync con cualquier otra que cambie org/edificio
+  // (p.ej. el switcher del sidebar) sin requerir refresh de la página. También
+  // escucha `storage` para sincronizar entre pestañas.
+  useEffect(() => {
+    function onOrg(e: Event) {
+      const id = (e as CustomEvent<string>).detail
+      setActiveOrgIdState((prev) => (prev === id ? prev : id))
+    }
+    function onBuilding(e: Event) {
+      const id = (e as CustomEvent<string>).detail
+      setActiveBuildingIdState((prev) => (prev === id ? prev : id))
+    }
+    function onStorage(e: StorageEvent) {
+      if (e.key === STORAGE_KEY_ORG && e.newValue) {
+        setActiveOrgIdState((prev) => (prev === e.newValue ? prev : e.newValue))
+      }
+      if (e.key === STORAGE_KEY_BUILDING && e.newValue) {
+        setActiveBuildingIdState((prev) => (prev === e.newValue ? prev : e.newValue))
+      }
+    }
+    window.addEventListener(EVT_ORG_CHANGED, onOrg)
+    window.addEventListener(EVT_BUILDING_CHANGED, onBuilding)
+    window.addEventListener('storage', onStorage)
+    return () => {
+      window.removeEventListener(EVT_ORG_CHANGED, onOrg)
+      window.removeEventListener(EVT_BUILDING_CHANGED, onBuilding)
+      window.removeEventListener('storage', onStorage)
+    }
+  }, [])
 
   // Si cambia la org activa, ajustar el building activo si pertenece a otra org
   useEffect(() => {


### PR DESCRIPTION
## Síntoma
Al cambiar de edificio (809 / 2020 / Todos) en el switcher de abajo a la izquierda, la página no se actualizaba: había que darle **refresh** manual para ver los datos del edificio seleccionado.

## Causa
`useActiveContext` se monta **por separado en cada componente** (el switcher del sidebar, cada página) y **no hay un Context/Provider compartido**. Cuando el switcher llama `setActiveBuildingId`, solo cambia **su** estado y `localStorage`. Las demás instancias (las de las páginas) solo leen `localStorage` **una vez al montar**, así que no se enteran del cambio hasta un refresh.

## Fix
Sincroniza todas las instancias del hook con `CustomEvents` en `window`:
- Los setters (`setActiveOrgId` / `setActiveBuildingId`) emiten un evento con el nuevo valor.
- Cada instancia se suscribe y actualiza su estado local al instante (con guard `prev === id` para evitar renders de más).
- Bonus: escucha el evento nativo `storage` para sincronizar **entre pestañas**.

Las páginas que ya dependen de `activeBuildingId`/`activeOrgId` en sus efectos de fetch (dashboard, `units`, `search`) vuelven a consultar **solas** en cuanto el valor cambia. Sin refactor de provider, sin tocar las páginas.

## Validación
- `tsc --noEmit` limpio · `eslint` sin errores.
- Prueba manual sugerida: cambiar de edificio en el switcher → el dashboard y `/units` deben refrescar sus datos sin recargar la página.

## Nota
Esto resuelve el caso del **switcher** (cambio estructural global). El patrón más amplio que mencionaste —"tras guardar en una sección hay que refrescar"— es por-pantalla (cada mutación debe re-consultar o actualizar su estado); lo podemos auditar pantalla por pantalla en un PR aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_