### PR TITLE
fix: alta de contrato usa la org activa del switcher (no /api/me/org)

### DIFF
--- a/src/app/contracts/new/page.tsx
+++ b/src/app/contracts/new/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { ArrowLeft } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
-import { useOrgContext } from '@/hooks/useOrgContext'
+import { useActiveContext } from '@/lib/useActiveContext'
 import { useToast } from '@/components/Toast'
 import Breadcrumbs from '@/components/Breadcrumbs'
 import type { Unit, Occupant } from '@/types'
@@ -12,7 +12,7 @@ import Link from 'next/link'
 
 export default function NewContractPage() {
   const router = useRouter()
-  const { orgId } = useOrgContext()
+  const { activeOrgId } = useActiveContext()
   const toast = useToast()
   const [units, setUnits] = useState<Unit[]>([])
   const [occupants, setOccupants] = useState<Occupant[]>([])
@@ -51,6 +51,10 @@ export default function NewContractPage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    // El contrato (y el inquilino) pertenecen a la misma org que la unidad
+    // seleccionada; respaldo a la org activa del switcher.
+    const selectedUnit = units.find((u) => u.id === form.unit_id)
+    const orgId = selectedUnit?.org_id ?? activeOrgId
     if (!orgId) {
       toast.error('No se pudo resolver tu organización; recarga la página e intenta de nuevo')
       return


### PR DESCRIPTION
## Síntoma
Al crear contrato salía el toast **"No se pudo resolver tu organización; recarga la página e intenta de nuevo"** — el guard que agregué en #85 se disparaba porque la org venía nula.

## Causa raíz
Había **dos fuentes de "org" distintas** en la app:
- El **switcher** (sidebar) usa `useActiveContext` → resuelve membresías por el cliente y guarda en `localStorage`. **Funciona** (lo confirmamos: ya cambia de edificio al instante).
- El **alta de contrato** usaba `useOrgContext` → `/api/me/org`, que resuelve la org en el **servidor** leyendo la cookie `baw_active_org_id`. Ese path devolvía null para esta cuenta y bloqueaba el guardado.

## Fix
El contrato (y el inquilino nuevo inline) ahora toman el `org_id` de la **unidad seleccionada** — que por construcción es la org correcta — con `activeOrgId` del switcher como respaldo. Fuente 100% client-side y consistente con lo que el usuario ve seleccionado. Sin dependencia de `/api/me/org`.

## Validación
- `tsc --noEmit` limpio · `eslint` sin errores.

## Follow-up recomendado (sistémico, aparte)
El switcher escribe la org activa en `localStorage` (`baw:active_org_id`) pero el servidor la lee de la **cookie** `baw_active_org_id`. Para usuarios multi-org, todo lo server-side (`/api/me/org`, generación de documentos, etc.) puede resolver una org distinta a la del switcher. Convendría que el switcher **también** escriba esa cookie, para alinear cliente y servidor en una sola fuente de verdad. Lo puedo hacer en un PR dedicado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_