### PR TITLE
fix: alta de contrato usaba type 'tenant' inválido (viola occupants_type_check)

### DIFF
--- a/src/app/contracts/new/page.tsx
+++ b/src/app/contracts/new/page.tsx
@@ -42,7 +42,7 @@ export default function NewContractPage() {
   useEffect(() => {
     Promise.all([
       supabase.from('units').select('*').order('number'),
-      supabase.from('occupants').select('*').eq('type', 'tenant').order('name'),
+      supabase.from('occupants').select('*').order('name'),
     ]).then(([unitsRes, occupantsRes]) => {
       setUnits(unitsRes.data || [])
       setOccupants(occupantsRes.data || [])
@@ -64,6 +64,9 @@ export default function NewContractPage() {
     let occupantId = form.occupant_id
 
     if (newOccupant) {
+      // occupants.type solo admite 'ltr' | 'str' | 'both' (modalidad de renta del
+      // contacto), no roles. Lo derivamos del tipo de renta del contrato.
+      const occupantType = form.rent_type === 'STR' ? 'str' : 'ltr'
       const { data: occ, error: occError } = await supabase
         .from('occupants')
         .insert({
@@ -71,7 +74,7 @@ export default function NewContractPage() {
           name: occupantForm.name,
           phone: occupantForm.phone || null,
           email: occupantForm.email || null,
-          type: 'tenant',
+          type: occupantType,
         })
         .select()
         .single()


### PR DESCRIPTION
## Síntoma
Al crear el contrato con inquilino nuevo: **"Error al crear el inquilino: new row for relation \"occupants\" violates check constraint \"occupants_type_check\""**.

## Causa
La columna `occupants.type` tiene `CHECK (type IN ('ltr','str','both'))` (migration `20260330_occupants_type.sql`) — representa la **modalidad de renta** del contacto, no un rol. Pero el form de alta de contrato insertaba `type: 'tenant'`, valor que la base rechaza. El tipo TS `OccupantType = 'tenant' | 'guest' | 'owner' | 'staff'` está desfasado del esquema real y mandó al código por mal camino.

Bonus del mismo bug: la carga de inquilinos existentes filtraba por `.eq('type','tenant')`, así que el dropdown **"Seleccionar existente" salía siempre vacío**.

## Fix
- Inserta un `type` **válido** derivado del tipo de renta del contrato: `STR → 'str'`, `LTR/MTR → 'ltr'`.
- Quita el filtro `.eq('type','tenant')` para que el dropdown liste los inquilinos existentes.

## Validación
- `tsc --noEmit` limpio · `eslint` sin errores.

## Follow-up (aparte)
Conviene **corregir el tipo TS `OccupantType`** para que refleje el esquema (`'ltr' | 'str' | 'both'`) y evitar que vuelva a inducir este tipo de errores. Lo dejo para un PR de limpieza para no mezclar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_