### PR TITLE
chore: una sola fuente de org en cliente + tipos alineados (arregla Contactos/Clientes que no cargaban)

### DIFF
--- a/src/hooks/useOrgContext.ts
+++ b/src/hooks/useOrgContext.ts
@@ -1,11 +1,18 @@
-// BaW OS — useOrgContext hook (Sprint 4 / S4-1)
+// BaW OS — useOrgContext hook
 // Hook para client components que necesitan el org_id activo del usuario logueado.
-// Reemplaza el patrón legacy: const ORG_ID = '<hardcoded>' (e.g. org pre-Sprint3 wipe)
-// UUID canónico prod actual: org=81a011c4-4ea6-4b79-924d-73dbe6d35e14 building=0d05c6d8-a9cd-437c-8b26-bd637bed7d49
+//
+// 2026-06: reescrito para derivar del MISMO origen confiable que el switcher del
+// sidebar (useActiveContext, client-side) en vez de pegarle a /api/me/org. Ese
+// endpoint resolvía la org en el servidor (auth.getUser + cookie) y devolvía
+// null para algunas sesiones, dejando páginas enteras (contactos, clientes,
+// cobros, etc.) atascadas en loading. Ahora hay una sola fuente de verdad de la
+// org activa en el cliente.
 
 'use client'
 
 import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useActiveContext } from '@/lib/useActiveContext'
 
 export interface OrgContext {
   orgId: string | null
@@ -15,68 +22,41 @@ export interface OrgContext {
   error: string | null
 }
 
-let cachedContext: Omit<OrgContext, 'loading' | 'error'> | null = null
-let cachedAt = 0
-const CACHE_TTL_MS = 60_000
-
-async function fetchOrgContext() {
-  const res = await fetch('/api/me/org', { credentials: 'include' })
-  const json = await res.json()
-  if (!res.ok || !json.success) {
-    throw new Error(json.error || 'Failed to resolve org')
-  }
-  return {
-    orgId: json.data.org_id as string,
-    userId: json.data.user_id as string,
-    role: json.data.role as string,
-  }
-}
-
 export function useOrgContext(): OrgContext {
-  const [state, setState] = useState<OrgContext>(() => {
-    if (cachedContext && Date.now() - cachedAt < CACHE_TTL_MS) {
-      return { ...cachedContext, loading: false, error: null }
-    }
-    return { orgId: null, userId: null, role: null, loading: true, error: null }
-  })
+  const { activeOrgId, userId, loading } = useActiveContext()
+  const [role, setRole] = useState<string | null>(null)
 
   useEffect(() => {
-    let cancelled = false
-
-    if (cachedContext && Date.now() - cachedAt < CACHE_TTL_MS) {
-      setState({ ...cachedContext, loading: false, error: null })
+    if (!activeOrgId || !userId) {
+      setRole(null)
       return
     }
-
-    fetchOrgContext()
-      .then((ctx) => {
-        cachedContext = ctx
-        cachedAt = Date.now()
-        if (!cancelled) {
-          setState({ ...ctx, loading: false, error: null })
-        }
+    let cancelled = false
+    supabase
+      .from('org_members')
+      .select('role')
+      .eq('user_id', userId)
+      .eq('org_id', activeOrgId)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (!cancelled) setRole((data?.role as string | undefined) ?? null)
       })
-      .catch((err) => {
-        if (!cancelled) {
-          setState({
-            orgId: null,
-            userId: null,
-            role: null,
-            loading: false,
-            error: err.message,
-          })
-        }
-      })
-
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [activeOrgId, userId])
 
-  return state
+  return {
+    orgId: activeOrgId,
+    userId,
+    role,
+    loading,
+    error: null,
+  }
 }
 
+// Compat: el cache vivía en este módulo. Ya no hay cache propio (useActiveContext
+// gestiona su estado). Se conserva el export como no-op por si algo lo importa.
 export function clearOrgContextCache() {
-  cachedContext = null
-  cachedAt = 0
+  /* no-op */
 }

--- a/src/lib/useActiveContext.ts
+++ b/src/lib/useActiveContext.ts
@@ -20,6 +20,18 @@ const STORAGE_KEY_BUILDING = 'baw:active_building_id'
 const EVT_ORG_CHANGED = 'baw:active-org-changed'
 const EVT_BUILDING_CHANGED = 'baw:active-building-changed'
 
+// Cookie legible por el servidor para que la resolución server-side de org
+// (resolveOrgId / /api/me/org / generación de PDFs) coincida con la org que el
+// usuario tiene activa en el switcher. El cliente la escribe; el server la lee.
+const ACTIVE_ORG_COOKIE = 'baw_active_org_id'
+function persistOrgCookie(id: string) {
+  try {
+    document.cookie = `${ACTIVE_ORG_COOKIE}=${id}; path=/; max-age=31536000; samesite=lax`
+  } catch {
+    // ignore (SSR / cookies deshabilitadas)
+  }
+}
+
 // Valor centinela para "Todos los edificios" (vista consolidada).
 // activeBuildingId === ALL_BUILDINGS → las pantallas muestran toda la org.
 export const ALL_BUILDINGS = 'all'
@@ -68,6 +80,7 @@ export function useActiveContext(): ActiveContext {
     } catch {
       // ignore
     }
+    persistOrgCookie(id)
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent(EVT_ORG_CHANGED, { detail: id }))
     }
@@ -152,6 +165,7 @@ export function useActiveContext(): ActiveContext {
         nextActiveOrg = orgList[0].id
       }
       setActiveOrgIdState(nextActiveOrg)
+      if (nextActiveOrg) persistOrgCookie(nextActiveOrg)
 
       // Buildings de todas las orgs del usuario
       if (orgList.length > 0) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,9 @@ export type IncidentPriority = 'low' | 'medium' | 'high' | 'urgent'
 export type ReservationStatus = 'tentative' | 'confirmed' | 'cancelled' | 'checked_in' | 'checked_out'
 export type ReservationPaymentStatus = 'pending' | 'partial' | 'paid'
 export type BookingMode = 'full' | 'room' | 'bed'
-export type OccupantType = 'tenant' | 'guest' | 'owner' | 'staff'
+// occupants.type en la BD: CHECK IN ('ltr','str','both') — modalidad de renta
+// del contacto, no un rol. (migration 20260330_occupants_type.sql)
+export type OccupantType = 'ltr' | 'str' | 'both'
 export type AncillaryKind = 'parking' | 'billboard' | 'storage' | 'antenna' | 'other'
 export type AncillaryCadence = 'monthly' | 'annual'
 export type AncillaryOwnership = 'ours' | 'third_party'


### PR DESCRIPTION
## Contexto
PR de limpieza que ataca la **raíz** de varios bugs que veníamos parchando uno por uno, más los dos follow-ups que tenía pendientes.

## El problema de fondo
Convivían **dos fuentes de "org activa"**:
- `useActiveContext` (switcher del sidebar) — client-side, **confiable**.
- `useOrgContext` (`/api/me/org`) — server-side por cookie/sesión, **devolvía null** para algunas sesiones.

Como **13 páginas** dependen de `useOrgContext` (contactos, clientes/CRM, cobros, gastos, reportes, ledger, parking, reservations, ancillary, settings, pricing, maintenance), cuando devolvía null se quedaban **atascadas en loading** — justo lo que pasó con **Contactos** ("0 contactos" + skeleton infinito) y **Clientes**.

## Cambios
1. **`useOrgContext` reescrito** sobre `useActiveContext` (misma fuente que el switcher) + query client-side del `role`. Adiós dependencia de `/api/me/org`. Misma firma de retorno, así que las 13 páginas se arreglan sin tocarlas. `clearOrgContextCache` queda como no-op por compatibilidad.
2. **`useActiveContext` escribe la cookie `baw_active_org_id`** — así la resolución **server-side** (generación del PDF de estado de cuenta, etc.) coincide con la org del switcher. Cierra el desajuste localStorage↔cookie.
3. **`OccupantType` alineado al esquema real** (`'ltr' | 'str' | 'both'`). El tipo viejo (`'tenant' | 'guest' | ...`) era el que indujo el bug del `occupants_type_check` en el alta de contrato.

## Alcance / seguridad
- `OccupantType` solo se referencia en la definición del tipo — cambio seguro.
- `role` (lo usa solo `settings`) se sigue entregando.
- `tsc --noEmit` limpio · `eslint` sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_