### PR TITLE
fix: agrega payments.amount_paid (faltaba) — desbloquea registro de pagos y estado de cuenta

### DIFF
--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -299,7 +299,7 @@ export default function CobrosPage() {
     setPayingContract(null)
     setSaving(false)
     if (error) {
-      toast.error('Error al guardar — intenta de nuevo')
+      toast.error(`Error al guardar: ${error.message}`)
     } else {
       toast.success(isPartial ? 'Pago parcial registrado' : 'Pago registrado correctamente')
     }

--- a/supabase/migrations/20260617_payments_amount_paid.sql
+++ b/supabase/migrations/20260617_payments_amount_paid.sql
@@ -1,0 +1,41 @@
+-- BaW OS — Pagos parciales: columna amount_paid faltante (Bloque: cobranza).
+--
+-- El flujo de cobranza (marcar pago / pago parcial en /cobros) y la generación
+-- del estado de cuenta ESCRIBEN y LEEN payments.amount_paid, pero ninguna
+-- migración la creó: se introdujo con el bloque de pagos parciales sin su DDL.
+-- Sin esta columna, CUALQUIER registro de pago (incluso uno normal) y el estado
+-- de cuenta fallan. Esta migración la agrega.
+--
+-- Aditiva + idempotente. Rollback: ALTER TABLE payments DROP COLUMN amount_paid.
+
+ALTER TABLE public.payments
+  ADD COLUMN IF NOT EXISTS amount_paid DECIMAL(10,2);
+
+-- Backfill: los pagos ya marcados como 'paid' cubrieron el total.
+UPDATE public.payments
+  SET amount_paid = amount
+  WHERE status = 'paid' AND amount_paid IS NULL;
+
+COMMENT ON COLUMN public.payments.amount_paid IS
+  'Monto efectivamente recibido. amount_paid < amount => pago parcial (status=partial).';
+
+-- Si existe un CHECK sobre payments.status que NO contempla 'partial', se quita
+-- para no bloquear los pagos parciales (la app controla los valores válidos).
+-- Idempotente: si no hay constraint, o ya admite 'partial', no hace nada.
+DO $$
+DECLARE
+  cname text;
+  cdef  text;
+BEGIN
+  SELECT conname, pg_get_constraintdef(oid)
+    INTO cname, cdef
+  FROM pg_constraint
+  WHERE conrelid = 'public.payments'::regclass
+    AND contype = 'c'
+    AND pg_get_constraintdef(oid) ILIKE '%status%'
+  LIMIT 1;
+
+  IF cname IS NOT NULL AND cdef NOT ILIKE '%partial%' THEN
+    EXECUTE format('ALTER TABLE public.payments DROP CONSTRAINT %I', cname);
+  END IF;
+END $$;


### PR DESCRIPTION
## Hallazgo (auditoría proactiva antes de cargar el histórico de pagos)
El flujo de cobranza (`/cobros`, marcar pago / pago parcial) y el **estado de cuenta** escriben y leen `payments.amount_paid`, pero **ninguna migración creaba esa columna** — se introdujo con el bloque de pagos parciales sin su DDL. Como hasta un pago **normal** escribe `amount_paid`, sin la columna **fallaría todo registro de pago y la generación del estado de cuenta**.

## Cambios
1. **Migración `20260617_payments_amount_paid.sql`**:
   - `ADD COLUMN IF NOT EXISTS amount_paid DECIMAL(10,2)` (idempotente).
   - **Backfill**: los pagos ya `paid` cubrieron el total (`amount_paid = amount`).
   - Quita defensivamente un eventual `CHECK` de `status` que no admita `'partial'` (idempotente: si no hay constraint o ya lo admite, no hace nada).
2. **`/cobros`**: el toast de error ahora muestra el **motivo real** (`error.message`) en vez del genérico, para diagnosticar al instante.

## ⚠️ Requiere aplicar la migración
Igual que la del CRM: hay que correr `supabase/migrations/20260617_payments_amount_paid.sql` en Supabase **antes** de registrar pagos. Es aditiva, idempotente y con rollback documentado.

## Validación
- `tsc --noEmit` limpio · `eslint` sin errores (solo el warning preexistente de `exhaustive-deps`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_