### PR TITLE
fix: cobros arrancaba un mes antes (zona horaria) + fecha de inicio editable

### DIFF
--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -76,9 +76,11 @@ function scheduleMonths(startISO: string | null, cutoff: string): string[] {
   let y: number
   let m: number
   if (startISO) {
-    const s = new Date(startISO)
-    y = s.getFullYear()
-    m = s.getMonth() + 1
+    // Derivar el mes directo del string 'YYYY-MM-DD' para no desfasar por zona
+    // horaria (new Date('2026-02-01') retrocede a ene 31 en husos UTC negativos).
+    const [sy, sm] = startISO.slice(0, 7).split('-').map(Number)
+    y = sy
+    m = sm
   } else {
     y = cy
     m = cm

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -23,6 +23,7 @@ export default function ContractsPage() {
     status: 'active' as ContractStatus,
     rent_type: 'LTR' as 'LTR' | 'MTR' | 'STR',
     notes: '',
+    start_date: '',
     end_date: '',
     drive_link: '',
     aval: '',
@@ -75,6 +76,7 @@ export default function ContractsPage() {
       status: contract.status,
       rent_type: (contract.rent_type as 'LTR' | 'MTR' | 'STR') || 'LTR',
       notes: contract.notes?.replace(/\n?📎 https?:\/\/\S+/, '').trim() || '',
+      start_date: contract.start_date || '',
       end_date: contract.end_date || '',
       drive_link: existingLink,
       aval: contract.aval || '',
@@ -97,6 +99,7 @@ export default function ContractsPage() {
         payment_day: editForm.payment_day,
         status: editForm.status,
         rent_type: editForm.rent_type,
+        start_date: editForm.start_date || null,
         notes: notesValue || null,
         end_date: editForm.end_date || null,
         aval: editForm.aval || null,
@@ -488,6 +491,16 @@ export default function ContractsPage() {
                   <option value="MTR">Media (MTR)</option>
                   <option value="STR">Corta (STR) — sin cobro mensual</option>
                 </select>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Fecha de inicio</label>
+                <input
+                  type="date"
+                  value={editForm.start_date}
+                  onChange={(e) => setEditForm({ ...editForm, start_date: e.target.value })}
+                  className="input-field w-full"
+                />
+                <p className="text-xs text-gray-400 mt-1">Determina desde qué mes se generan los cobros.</p>
               </div>
               <div>
                 <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Fecha fin</label>


### PR DESCRIPTION
## Reportado por Fran
En `/cobros` aparecía un renglón de **Enero 2026** cuando el contrato inicia el **1 de febrero**. Y al revisar el contrato, el modal de edición **no mostraba la fecha de inicio** para verificarla.

## Causa
`scheduleMonths` derivaba el mes de inicio con `new Date('2026-02-01')`. En husos horarios UTC negativos (México, UTC-6) esa fecha-solo se interpreta como UTC y al leer el mes en local retrocede a **ene 31**, así que la serie arrancaba en enero.

## Fix
1. **Cobros:** el mes de inicio se deriva del string `start_date.slice(0,7)` — sin `Date`, sin desfase. Ahora arranca correctamente en el mes de `start_date` (feb).
2. **Editar contrato:** se agrega el campo **"Fecha de inicio"** (con nota de que determina desde qué mes se generan los cobros), para poder verificarla y corregirla.

## Notas
- No hay datos corruptos: `start_date` se guardó bien (`2026-02-01`); el bug era solo de presentación en cobros. Tras el deploy, el renglón de enero desaparece y quedan feb–jun.
- `tsc --noEmit` y `eslint` limpios (solo warning preexistente de `exhaustive-deps` en contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_