### PR TITLE
fix: registrar pago (enum método) + estado de cuenta Unauthorized

### DIFF
--- a/src/app/api/contracts/[id]/estado-cuenta/route.ts
+++ b/src/app/api/contracts/[id]/estado-cuenta/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import React from 'react'
 import { renderToBuffer, type DocumentProps } from '@react-pdf/renderer'
 import { validateApiKey, createServiceClient } from '@/lib/api-auth'
-import { createSupabaseServer } from '@/lib/supabase-server'
+import { createSupabaseServerFromRequest } from '@/lib/supabase-server'
 import { getEstadoCuentaData } from '@/lib/estado-cuenta'
 import { EstadoCuentaPDF } from '@/lib/pdf/EstadoCuentaPDF'
 
@@ -23,7 +23,7 @@ export async function GET(
 ) {
   // Auth: API key (agente) usa service client; humano usa session client (RLS).
   const usingApiKey = validateApiKey(request)
-  const supabase = usingApiKey ? createServiceClient() : createSupabaseServer()
+  const supabase = usingApiKey ? createServiceClient() : createSupabaseServerFromRequest(request)
   if (!usingApiKey) {
     const {
       data: { user },

--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -323,7 +323,7 @@ export default function CobrosPage() {
       late_fee_amount: lateFee,
       late_fee_level: lateFee > 0 ? lateLevel : null,
       paid_date: payForm.paid_date,
-      method: payForm.method,
+      method: paymentMethod,
       reference: payForm.reference || null,
       confirmed_by: confirmedBy,
       confirmed_at: new Date().toISOString(),

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import type { NextRequest } from 'next/server'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
@@ -21,6 +22,22 @@ export function createSupabaseServer() {
           // setAll called from Server Component — ignored (handled by middleware)
         }
       },
+    },
+  })
+}
+
+// Variante para Route Handlers detrás del middleware. Lee las cookies del propio
+// request (que el middleware ya refrescó), en vez de next/headers cookies(), que
+// en route handlers no siempre refleja ese refresh. Evita el Unauthorized por la
+// carrera de rotación de refresh-token cuando el access token expira.
+export function createSupabaseServerFromRequest(request: NextRequest) {
+  return createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll()
+      },
+      // No persistimos cookies aquí: el middleware ya hizo el refresh.
+      setAll() {},
     },
   })
 }


### PR DESCRIPTION
## Reportado por Fran (dos errores al registrar el primer pago)

### 1. Guardar pago → `invalid input value for enum payment_method: "Transferencia"`
La columna `payments.method` es un **enum en minúsculas** en la base real, pero se le escribía el label capitalizado del formulario (`"Transferencia"`). **Fix:** se guarda el valor normalizado (`transferencia` / `efectivo` / `otro`), igual que en `payment_method`. Bug latente — nunca se había registrado un pago real, por eso no había saltado.

### 2. Botón "Estado" → `{"error":"Unauthorized"}`
El endpoint del PDF devolvía Unauthorized **después de un rato de sesión** (cuando el access token expira ~1h). El route handler leía las cookies vía `next/headers`, que no refleja el refresh que hace el middleware, y reintentaba refrescar con un **refresh-token ya rotado** → fallo de auth. **Fix:** nuevo `createSupabaseServerFromRequest(request)` que lee las cookies del **request** (ya refrescadas por el middleware); el endpoint lo usa. RLS sigue aplicando con la sesión del usuario.

## Validación
- `tsc --noEmit` y `eslint` limpios.
- El fix #2 es aditivo (no toca `createSupabaseServer`, que siguen usando otras rutas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_