### PR TITLE
feat: referencia y folio ordenados por depto + periodo (no aleatorios)

### DIFF
--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -77,6 +77,13 @@ function methodLabel(method: string | null | undefined): string {
   }
 }
 
+// Referencia auto-generada: depto + periodo (ordenada por fecha, no aleatoria).
+// Ej. D102 + 2026-02 => 'D102-2026-02'. Editable por si va la referencia bancaria.
+function referenceFor(unitNumber: string | null | undefined, month: string): string {
+  const depto = (unitNumber || '').trim().replace(/\s+/g, '') || 'SN'
+  return `${depto}-${month}`
+}
+
 function monthLabel(month: string): string {
   const [y, m] = month.split('-').map(Number)
   return `${MONTH_NAMES[m - 1]} ${y}`
@@ -280,7 +287,7 @@ export default function CobrosPage() {
       water_fee: water,
       late_fee: lateFee,
       method: 'Transferencia',
-      reference: '',
+      reference: row.payment?.reference || referenceFor(c.unit?.number, row.month),
       paid_date: today,
       is_partial: false,
       amount_paid: rent + water + lateFee,

--- a/src/lib/estado-cuenta.ts
+++ b/src/lib/estado-cuenta.ts
@@ -271,10 +271,11 @@ export function computeEstadoCuenta(
 
 // ── Capa de datos ───────────────────────────────────────────────────────────
 
-/** Folio determinista por contrato + periodo (no se persiste). */
-export function folioFor(contractId: string, periodo: string): string {
-  const short = contractId.replace(/-/g, '').slice(0, 4).toUpperCase()
-  return `EC-${periodo}-${short}`
+/** Folio determinista por depto + periodo (no se persiste). Ordenado por fecha,
+ *  legible y estable: mismo depto+mes => mismo folio. */
+export function folioFor(unitNumber: string | null | undefined, periodo: string): string {
+  const depto = (unitNumber || '').trim().replace(/\s+/g, '') || 'SN'
+  return `EC-${depto}-${periodo}`
 }
 
 /**
@@ -335,7 +336,7 @@ export async function getEstadoCuentaData(
     tenantPhone: (occupant?.phone as string) || null,
     unitNumber: (unit?.number as string) || '—',
     contractId,
-    folio: folioFor(contractId, periodo),
+    folio: folioFor(unit?.number as string, periodo),
     data,
     emittedAt: new Date().toISOString(),
   }


### PR DESCRIPTION
## Pedido de Fran
El número de referencia debe **generarse solo, ordenado, no aleatorio**, conforme a la fecha/características del pago. Decisión: formato **Depto + periodo**.

## Cambios
- **Folio del estado de cuenta**: pasa de `EC-2026-02-AB12` (4 chars de UUID, se veía aleatorio) a **`EC-{depto}-{periodo}`** → `EC-D102-2026-02`. Determinista, legible y ordenado: mismo depto+mes = mismo folio.
- **Referencia del pago**: el campo "Referencia" del modal se **autollena** con `{depto}-{periodo}` → `D102-2026-02`. Sigue **editable** por si se quiere capturar la referencia bancaria real. Si ya había referencia en el pago, se respeta.

## Validación
- `tsc --noEmit` y `eslint` limpios.
- Sin cambios de esquema: el folio se deriva, no se persiste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_