### PR TITLE
test: QA Fase 0 — candado de regresión para cobros + smoke checklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Run tests (v1)
         run: bash tests/v1/run-all.sh
 
+      - name: Run tests (cobros)
+        run: bash tests/cobros/run-all.sh
+
   smoke-supabase:
     name: smoke-supabase
     needs: lint-and-typecheck

--- a/docs/SMOKE.md
+++ b/docs/SMOKE.md
@@ -1,0 +1,75 @@
+# SMOKE.md — Checklist de smoke testing manual (BaW OS)
+
+> **Qué es:** la lista mínima de caminos críticos que se prueban **a mano** antes de
+> soltar un release a producción. No reemplaza los tests automáticos del CI — los
+> complementa con lo que solo un humano (o un agente clickeando) puede ver.
+>
+> **Cuándo se corre:** antes de mergear a `main` algo que toque cobros, contratos,
+> auth o PDFs. Toma ~10-15 min. Si algo aquí falla, es **blocker**: no se suelta.
+>
+> **Cómo se usa:** copia la sección relevante en el PR como checklist, marca cada
+> paso, y pega el resultado. Si un paso falla, abre issue con `pasos / esperado / actual / screenshot`.
+
+---
+
+## Convención de severidad
+
+| Sev | Significado | Acción |
+|---|---|---|
+| **blocker** | Rompe un camino crítico (no se puede cobrar, login roto, datos perdidos) | Frena el release. No merge a `main`. |
+| **mayor** | Funciona pero mal (cálculo incorrecto, UI rota en flujo principal) | Se arregla antes del release o se documenta riesgo. |
+| **menor** | Cosmético o caso borde raro | Va al backlog. |
+
+---
+
+## 1 · Auth y sesión  *(camino crítico)*
+
+- [ ] Login con credenciales válidas → entra al dashboard.
+- [ ] Recargar la página estando logueado → **sigue** logueado (no rebota a login).
+- [ ] Cerrar sesión → vuelve a login y no se puede entrar a rutas privadas con back.
+- [ ] **Sesión vieja:** con la app abierta horas, una acción server-side (ej. generar PDF)
+      **no** debe dar "Unauthorized" silencioso. Si lo da, re-login debe resolverlo.
+      *(Esta es la clase del bug del PDF — verificar siempre.)*
+
+## 2 · Cobros  *(camino crítico — zona de bugs recientes)*
+
+- [ ] La tabla de cobros carga con saldos y estatus (al corriente / vencido / mora) correctos.
+- [ ] **Registrar pago completo:** abrir modal → método "Transferencia" → guardar →
+      muestra *"Pago registrado correctamente"* y el renglón pasa a pagado.
+      *(Candado automático: `tests/cobros/payment-method.test.mjs` — bug del enum #94.)*
+- [ ] **Registrar pago en efectivo:** mismo flujo con método "Efectivo" → guarda igual.
+- [ ] **Pago parcial:** abono menor al total → el saldo restante se refleja, no se duplica el cargo.
+- [ ] **Referencia auto:** el campo Referencia llega prellenado tipo `D102-2026-02` y es editable.
+      *(Candado automático: `tests/cobros/folio-reference.test.mjs` — bug del folio #95.)*
+- [ ] **Mora:** un pago vencido sugiere el recargo escalonado correcto (0% gracia / 5% / 10%).
+
+## 3 · Estado de cuenta / PDF  *(camino crítico)*
+
+- [ ] Generar estado de cuenta de un contrato → abre el PDF sin "Unauthorized".
+- [ ] El **folio** se ve tipo `EC-D102-2026-02` (legible, no fragmento de UUID).
+- [ ] Los montos (renta, agua, mora, saldo) del PDF cuadran con la tabla de cobros.
+- [ ] El mismo depto + mismo mes genera **el mismo folio** (determinista).
+
+## 4 · Contratos / unidades  *(camino importante)*
+
+- [ ] Listado de contratos y unidades carga sin error.
+- [ ] Crear / editar un contrato persiste y se refleja al recargar.
+- [ ] Un contrato sin ocupante o sin unidad no rompe la vista (fallbacks "—").
+
+## 5 · General  *(sanity)*
+
+- [ ] No hay errores rojos en la consola del navegador en los flujos de arriba.
+- [ ] Navegación principal (sidebar) lleva a cada sección sin 404.
+- [ ] En móvil, los flujos de cobros y PDF son usables (no se rompe el layout).
+
+---
+
+## Antes de cada release (resumen)
+
+1. CI verde en el PR (lint + typecheck + build + tests, incluido `tests/cobros`).
+2. Correr esta checklist en **staging** (no en prod).
+3. Sin blockers abiertos → merge a `main` → smoke rápido en prod (secciones 1-3).
+4. Si aparece un bug en prod, abrir issue con la plantilla y etiquetar severidad.
+
+*Mantener esta lista viva: cada bug nuevo que se escape a prod agrega un paso aquí
+para que no vuelva a pasar inadvertido.*

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "prebuild": "node scripts/check-design-tokens.mjs",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "test": "bash tests/cobros/run-all.sh && bash tests/v1/run-all.sh && bash tests/public-booking/run-all.sh && bash tests/agents/run-all.sh"
   },
   "dependencies": {
     "@react-pdf/renderer": "^4.5.1",

--- a/tests/cobros/folio-reference.test.mjs
+++ b/tests/cobros/folio-reference.test.mjs
@@ -1,0 +1,60 @@
+// BaW OS — Regresión: folio y referencia ordenados (candado del bug PR #95)
+//
+// Antes: el folio del estado de cuenta usaba 4 chars del UUID (EC-2026-02-AB12),
+// que se veía aleatorio, y la referencia del pago quedaba vacía. Ahora ambos se
+// derivan de forma determinista de depto + periodo, y deben ser estables:
+// mismo depto + mismo mes => mismo identificador.
+//
+// Pure-logic: espejeamos folioFor() de src/lib/estado-cuenta.ts:276 y
+// referenceFor() de src/app/cobros/page.tsx. Cuando entre vitest (Fase 1),
+// importar las funciones reales en vez de re-declararlas.
+//
+// Run: node tests/cobros/folio-reference.test.mjs
+
+import { strict as assert } from 'node:assert'
+
+// ── Mirror de src/lib/estado-cuenta.ts:folioFor ──────────────────────────────
+function folioFor(unitNumber, periodo) {
+  const depto = (unitNumber || '').trim().replace(/\s+/g, '') || 'SN'
+  return `EC-${depto}-${periodo}`
+}
+
+// ── Mirror de src/app/cobros/page.tsx:referenceFor ───────────────────────────
+function referenceFor(unitNumber, month) {
+  const depto = (unitNumber || '').trim().replace(/\s+/g, '') || 'SN'
+  return `${depto}-${month}`
+}
+
+let passed = 0
+function check(name, fn) {
+  fn()
+  passed++
+  console.log(`  ✓ ${name}`)
+}
+
+// 1. Formato legible y ordenado, no aleatorio.
+check('folio = EC-{depto}-{periodo}', () => {
+  assert.equal(folioFor('D102', '2026-02'), 'EC-D102-2026-02')
+})
+check('referencia = {depto}-{periodo}', () => {
+  assert.equal(referenceFor('D102', '2026-02'), 'D102-2026-02')
+})
+
+// 2. Determinismo: mismo depto + mes => mismo identificador (clave del pedido).
+check('folio es determinista (mismo input => mismo folio)', () => {
+  assert.equal(folioFor('D102', '2026-02'), folioFor('D102', '2026-02'))
+})
+
+// 3. INVARIANTE: nada de fragmentos de UUID ni aleatoriedad. Solo depto + fecha.
+check('no quedan rastros aleatorios en el folio', () => {
+  const folio = folioFor('D102', '2026-02')
+  assert.ok(/^EC-[A-Za-z0-9]+-\d{4}-\d{2}$/.test(folio), `folio con forma inesperada: ${folio}`)
+})
+
+// 4. Fallback defensivo cuando falta el número de depto.
+check('sin depto usa SN como marcador, no truena', () => {
+  assert.equal(folioFor(null, '2026-02'), 'EC-SN-2026-02')
+  assert.equal(referenceFor('  ', '2026-02'), 'SN-2026-02')
+})
+
+console.log(`\nfolio-reference.test.mjs: ${passed} checks passed.`)

--- a/tests/cobros/payment-method.test.mjs
+++ b/tests/cobros/payment-method.test.mjs
@@ -1,0 +1,66 @@
+// BaW OS — Regresión: mapeo de método de pago (candado del bug PR #94)
+//
+// Bug original: el modal de cobros enviaba el label en español ("Transferencia")
+// a la columna payments.method, que es un ENUM en inglés (transfer/cash/stripe…).
+// Postgres rechazaba el insert y el pago "no guardaba". El typecheck no lo veía
+// porque era un string válido en TS. Esta es justo la clase de bug que solo se
+// atrapa con un test del contrato app↔DB.
+//
+// Pure-logic: espejeamos el mapeo de src/app/cobros/page.tsx:331-333.
+// Cuando se integre vitest (Fase 1 de QA), este test debe IMPORTAR el helper
+// real en vez de re-declararlo, para que cubra el source y no solo la copia.
+//
+// Run: node tests/cobros/payment-method.test.mjs
+
+import { strict as assert } from 'node:assert'
+
+// ── Valores válidos del enum payment_method en la DB (inglés) ────────────────
+// Si la app envía algo fuera de este set a payments.method, Postgres revienta.
+const PAYMENT_METHOD_ENUM = new Set(['cash', 'transfer', 'stripe', 'other'])
+
+// ── Mirror de src/app/cobros/page.tsx:331-333 ────────────────────────────────
+function mapMethod(uiLabel) {
+  const m = String(uiLabel).toLowerCase()
+  const methodEnum = m === 'efectivo' ? 'cash' : 'transfer' // transferencia y depósito → transfer
+  const paymentMethodEs =
+    m === 'efectivo' ? 'efectivo' : m === 'transferencia' ? 'transferencia' : 'otro'
+  return { methodEnum, paymentMethodEs }
+}
+
+let passed = 0
+function check(name, fn) {
+  fn()
+  passed++
+  console.log(`  ✓ ${name}`)
+}
+
+// 1. Los labels de la UI mapean al enum inglés correcto.
+check('Transferencia → transfer', () => {
+  assert.equal(mapMethod('Transferencia').methodEnum, 'transfer')
+})
+check('Efectivo → cash', () => {
+  assert.equal(mapMethod('Efectivo').methodEnum, 'cash')
+})
+check('Depósito (u otro) cae en transfer', () => {
+  assert.equal(mapMethod('Depósito').methodEnum, 'transfer')
+})
+
+// 2. INVARIANTE DEL BUG: method NUNCA debe llevar un valor en español.
+check('method siempre es un valor válido del enum (nunca español)', () => {
+  for (const label of ['Transferencia', 'Efectivo', 'Depósito', 'Otro', '']) {
+    const { methodEnum } = mapMethod(label)
+    assert.ok(
+      PAYMENT_METHOD_ENUM.has(methodEnum),
+      `method="${methodEnum}" no está en el enum de la DB (regresión del bug #94)`,
+    )
+  }
+})
+
+// 3. La columna paralela payment_method (TEXT, español) sí conserva el español.
+check('payment_method conserva el español para reportes', () => {
+  assert.equal(mapMethod('Transferencia').paymentMethodEs, 'transferencia')
+  assert.equal(mapMethod('Efectivo').paymentMethodEs, 'efectivo')
+  assert.equal(mapMethod('Depósito').paymentMethodEs, 'otro')
+})
+
+console.log(`\npayment-method.test.mjs: ${passed} checks passed.`)

--- a/tests/cobros/run-all.sh
+++ b/tests/cobros/run-all.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# BaW OS — Tests de regresión del dominio de cobros (sin DB, sin framework).
+# Candados de los bugs PR #94 (enum de method) y PR #95 (folio/referencia).
+# Run: bash tests/cobros/run-all.sh
+set -e
+cd "$(dirname "$0")/../.."
+
+echo "=== payment-method.test.mjs ==="
+node tests/cobros/payment-method.test.mjs
+
+echo ""
+echo "=== folio-reference.test.mjs ==="
+node tests/cobros/folio-reference.test.mjs
+
+echo ""
+echo "All cobros regression tests passed."


### PR DESCRIPTION
Primer paso del proceso de QA sistematizado. Convierte los fixes recientes (#94, #95) en una **red de seguridad permanente** y establece la estructura para las fases siguientes.

## Qué incluye

**Candados de regresión** (siguen la convención pure-logic de los tests existentes):
- `tests/cobros/payment-method.test.mjs` — bug **#94** (enum `method` inglés vs español). Verifica que la app **nunca** mande español a `payments.method`.
- `tests/cobros/folio-reference.test.mjs` — bug **#95** (folio/referencia deterministas `EC-{depto}-{periodo}`, sin rastros aleatorios de UUID).

**CI y scripts:**
- Nuevo paso `Run tests (cobros)` en `ci.yml` → corre en cada PR.
- `package.json`: `npm test` (todo el suite) y `npm run typecheck`.

**Proceso manual:**
- `docs/SMOKE.md` — checklist de smoke testing de caminos críticos (auth/sesión, cobros, estado de cuenta/PDF, contratos) con tabla de severidades (blocker/mayor/menor).

## Validación
- `npm test`: **4 suites, 38 checks, 0 fallos** (incluye los 10 nuevos de cobros).
- `tsc --noEmit` y `eslint` limpios.

## Nota
Los tests espejean el source (igual que `classifier.test.mjs` hoy). La **Fase 1** (Vitest) los hará importar el source directo para endurecer el candado. Eso, más Playwright (Fase 2) y Sentry/beta (Fase 3), van por separado.

## Acción manual pendiente para Fran
Para que el candado sea **obligatorio**: GitHub → Settings → Branches → regla en `main` → *Require status checks to pass* → marcar **`all-checks-pass`**. Así ningún PR que rompa estos tests puede mergearse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_