### PR TITLE
fix: estado de cuenta Unauthorized al abrir el PDF en pestaña nueva

### DIFF
--- a/src/app/api/contracts/[id]/estado-cuenta/route.ts
+++ b/src/app/api/contracts/[id]/estado-cuenta/route.ts
@@ -6,7 +6,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import React from 'react'
 import { renderToBuffer, type DocumentProps } from '@react-pdf/renderer'
 import { validateApiKey, createServiceClient } from '@/lib/api-auth'
-import { createSupabaseServerFromRequest } from '@/lib/supabase-server'
+import {
+  createSupabaseServerFromRequest,
+  createSupabaseFromToken,
+  bearerFromRequest,
+} from '@/lib/supabase-server'
 import { getEstadoCuentaData } from '@/lib/estado-cuenta'
 import { EstadoCuentaPDF } from '@/lib/pdf/EstadoCuentaPDF'
 
@@ -21,10 +25,19 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  // Auth: API key (agente) usa service client; humano usa session client (RLS).
+  // Auth, tres caminos (todos con RLS por org salvo la API key de agente):
+  //  1. API key (agente)        → service client.
+  //  2. Bearer token de usuario → cliente con ese token. Lo usa el front al abrir
+  //     el PDF en pestaña nueva, donde la cookie puede traer un access token
+  //     vencido por la rotación de refresh-token (causa del Unauthorized).
+  //  3. Cookie de sesión        → fallback para enlaces directos.
   const usingApiKey = validateApiKey(request)
-  const supabase = usingApiKey ? createServiceClient() : createSupabaseServerFromRequest(request)
-  if (!usingApiKey) {
+  const bearer = bearerFromRequest(request)
+  let supabase
+  if (usingApiKey) {
+    supabase = createServiceClient()
+  } else {
+    supabase = bearer ? createSupabaseFromToken(bearer) : createSupabaseServerFromRequest(request)
     const {
       data: { user },
     } = await supabase.auth.getUser()

--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -404,6 +404,45 @@ export default function CobrosPage() {
     fetchBilling()
   }
 
+  // Abre el estado de cuenta (PDF) en pestaña nueva con un access token FRESCO.
+  // No usamos <a href> porque esa navegación manda la cookie tal cual, y si su
+  // access token venció por la rotación de refresh-token el server responde
+  // Unauthorized. getSession() del browser client refresca el token primero.
+  async function openEstadoCuenta(contractId: string, periodo: string) {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+    const token = session?.access_token
+    if (!token) {
+      toast.error('Tu sesión expiró. Vuelve a iniciar sesión.')
+      return
+    }
+    // Abrimos la pestaña dentro del gesto del clic (antes del await) para que el
+    // bloqueador de pop-ups no la mate.
+    const tab = window.open('', '_blank')
+    try {
+      const res = await fetch(
+        `/api/contracts/${contractId}/estado-cuenta?periodo=${periodo}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      if (!res.ok) {
+        tab?.close()
+        toast.error(
+          res.status === 401
+            ? 'Tu sesión expiró. Vuelve a iniciar sesión.'
+            : 'No se pudo generar el estado de cuenta.',
+        )
+        return
+      }
+      const url = URL.createObjectURL(await res.blob())
+      if (tab) tab.location.href = url
+      else window.open(url, '_blank')
+    } catch {
+      tab?.close()
+      toast.error('No se pudo generar el estado de cuenta.')
+    }
+  }
+
   const filtered =
     filter === 'all'
       ? rows
@@ -635,16 +674,14 @@ export default function CobrosPage() {
                             )}
                           </div>
                         )}
-                        <a
-                          href={`/api/contracts/${row.contract.id}/estado-cuenta?periodo=${row.month}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
+                        <button
+                          onClick={() => openEstadoCuenta(row.contract.id, row.month)}
                           className="inline-flex items-center gap-1 px-2 py-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded text-[11px] font-medium transition-colors"
                           title="Estado de cuenta (PDF)"
                         >
                           <Receipt className="w-3 h-3" />
                           Estado
-                        </a>
+                        </button>
                       </div>
                     </td>
                   </tr>

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,4 +1,5 @@
 import { createServerClient } from '@supabase/ssr'
+import { createClient } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 import type { NextRequest } from 'next/server'
 
@@ -39,5 +40,23 @@ export function createSupabaseServerFromRequest(request: NextRequest) {
       // No persistimos cookies aquí: el middleware ya hizo el refresh.
       setAll() {},
     },
+  })
+}
+
+// Lee 'Authorization: Bearer <jwt>' del request. Devuelve el token o null.
+export function bearerFromRequest(request: NextRequest): string | null {
+  const header = request.headers.get('authorization') || ''
+  return header.toLowerCase().startsWith('bearer ') ? header.slice(7).trim() || null : null
+}
+
+// Cliente autenticado con un access token de usuario (Authorization header).
+// Lo usan endpoints que se abren en pestaña nueva (PDFs): ahí la cookie puede
+// llegar con un access token vencido por la rotación de refresh-token, mientras
+// que el browser client garantiza un token fresco vía getSession(). Aplica RLS
+// como ese usuario, igual que la ruta por cookie.
+export function createSupabaseFromToken(accessToken: string) {
+  return createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+    auth: { persistSession: false, autoRefreshToken: false },
   })
 }


### PR DESCRIPTION
## El bug
Al hacer clic en **"Estado"** (estado de cuenta PDF), la pestaña nueva mostraba `{"error":"Unauthorized"}` aunque la sesión en la app estuviera viva. El pago de Feb sí se registró (el fix #94 funciona) — esto es un problema **aparte, de autenticación del PDF**.

## Por qué pasaba
El botón era un `<a href target="_blank">`. Esa navegación manda la **cookie** tal cual. El SPA nunca se rompe porque el cliente de Supabase en el browser **refresca el token en memoria**; pero la cookie puede quedar con un access token **vencido** por la rotación de refresh-token. Resultado: el server hace `getUser()` con un token muerto → 401. Por eso "re-iniciar sesión lo arreglaba un rato": refrescaba la cookie.

## El fix
Dejar de depender de la cookie para esa navegación:
- **Frontend** (`cobros/page.tsx`): `openEstadoCuenta()` pide un access token **fresco** con `supabase.auth.getSession()`, hace `fetch` autenticado con `Authorization: Bearer`, y abre el PDF como blob. Si no hay sesión → toast claro *"Tu sesión expiró, vuelve a iniciar sesión"* en vez de una pantalla con JSON.
- **Backend** (`estado-cuenta/route.ts`): acepta el **Bearer token de usuario** (`createSupabaseFromToken`) además de la cookie (fallback) y la API key de agente. **RLS por org se mantiene** en los tres caminos.
- **`supabase-server.ts`**: helpers `bearerFromRequest()` y `createSupabaseFromToken()`.

## Validación
- `tsc --noEmit` y `eslint` limpios.
- **Prueba manual pendiente (Fran):** abrir "Estado" en un depto con sesión ya viejita → debe abrir el PDF, no el Unauthorized.

## Nota
Este es exactamente el flujo que un test E2E de **Fase 2 (Playwright)** dejaría blindado: login → cobrar → abrir PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_