### PR TITLE
chore(copy): "Built by ZXY Ventures" + limpieza de jerga en pantalla Agentes

### DIFF
--- a/src/app/(public)/apply/[token]/ApplyForm.tsx
+++ b/src/app/(public)/apply/[token]/ApplyForm.tsx
@@ -627,7 +627,7 @@ export default function ApplyForm({
           style={{ fontFamily: 'var(--font-mono)', color: 'var(--baw-faint)' }}
           className="text-center text-[10px] uppercase tracking-[0.2em] mt-12"
         >
-          BaW Design Lab · ZXY Ventures
+          Built by ZXY Ventures
         </p>
       </div>
     </div>

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -132,9 +132,9 @@ const FAMILY_DESC: Record<string, string> = {
   'ops-core': 'Tier Starter+ · Cobro, facturación y operación del edificio',
   'experiencia': 'Tier Professional+ · Comunicación, captación y ciclo de vida del residente',
   'inteligencia': 'Tier Enterprise/Max · Reporting, governance y compliance',
-  'third-party': 'Agentes que operan BaW OS desde fuera (ZXY Agent OS, vía Discord).',
+  'third-party': 'Agentes conectados que trabajan dentro de BaW OS para ejecutar tareas en tu nombre.',
   'pm-ops': 'Familia legacy — migrada a escuadrones',
-  'zxy-shared': 'Agentes que operan BaW OS desde fuera (ZXY Agent OS, vía Discord).',
+  'zxy-shared': 'Agentes conectados que trabajan dentro de BaW OS para ejecutar tareas en tu nombre.',
 }
 
 const FAMILY_ORDER = ['baw-coord', 'ops-core', 'experiencia', 'inteligencia', 'third-party', 'pm-ops', 'zxy-shared']

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -269,7 +269,7 @@ export default async function AgentsPage() {
             className="text-[11px] uppercase tracking-wider"
             style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
           >
-            Agentes third-party conectados a BaW OS · Alicia opera Mateos 809P · Hugo supervisa · Sprint 5A MVP
+            Tu equipo de agentes de IA conectados a BaW OS · Ejecutan tareas y registran cada acción en tiempo real
           </p>
         </div>
         <ViewModeSwitch initialMode={viewMode} size="sm" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ const instrumentSerif = Instrument_Serif({
 
 export const metadata: Metadata = {
   title: 'BaW OS',
-  description: 'Property Management System — BaW Design Lab · ZXY Ventures',
+  description: 'Property Management System — Built by ZXY Ventures',
   icons: {
     icon: '/favicon.svg',
   },

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -232,7 +232,7 @@ function LoginForm() {
           style={{ fontFamily: 'var(--font-mono)' }}
           className="text-center text-[10px] uppercase tracking-[0.2em] text-[--baw-faint] mt-10"
         >
-          BaW Design Lab · ZXY Ventures
+          Built by ZXY Ventures
         </p>
       </div>
     </div>

--- a/src/app/quotes/page.tsx
+++ b/src/app/quotes/page.tsx
@@ -546,7 +546,7 @@ export default function QuotesPage() {
             {/* Footer */}
             <div className="mt-6 pt-4 border-t border-gray-200 text-xs text-gray-400 space-y-1">
               <p>Cotización válida por 15 días. Precios en MXN. Sujeto a disponibilidad.</p>
-              <p>BaW Design Lab · ZXY Ventures · baw-os.vercel.app</p>
+              <p>Built by ZXY Ventures · baw-os.vercel.app</p>
             </div>
 
             {/* Close button (not printed) */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 // BaW OS — Core TypeScript Types
-// BaW Design Lab · ZXY Ventures
+// Built by ZXY Ventures
 
 export type UnitType = 'STR' | 'MTR' | 'LTR' | 'RETAIL' | 'OFFICE' | 'COMMON'
 export type UnitStatus = 'available' | 'occupied' | 'maintenance' | 'reserved' | 'inactive'


### PR DESCRIPTION
## Qué cambia (solo copy, sin lógica)

Alinea branding y limpia jerga interna en pantallas de usuario.

### 1. Branding → "Built by ZXY Ventures"
Reemplaza `BaW Design Lab · ZXY Ventures` en:
- Footer del login
- Footer del PDF del cotizador (`Built by ZXY Ventures · baw-os.vercel.app`)
- Metadata del sitio (título al compartir/buscar)
- Footer del formulario público de aplicación
- Comentario de cabecera en `src/types/index.ts` (consistencia)

### 2. Pantalla Agentes — quita jerga de dev
- **Subtítulo**: `Agentes third-party … Mateos 809P … Sprint 5A MVP` → `Tu equipo de agentes de IA conectados a BaW OS · Ejecutan tareas y registran cada acción en tiempo real`
- **Descripción de sección**: `Agentes que operan BaW OS desde fuera (ZXY Agent OS, vía Discord)` → `Agentes conectados que trabajan dentro de BaW OS para ejecutar tareas en tu nombre.`

## Validación
- `npx tsc --noEmit` → verde
- Sin cambios de lógica ni de datos; solo strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_