### PR TITLE
fix(audit): permitir actor_type 'system' para que el filtro "Sistema" del Timeline funcione

### DIFF
--- a/supabase/migrations/20260620_audit_log_actor_type_system.sql
+++ b/supabase/migrations/20260620_audit_log_actor_type_system.sql
@@ -1,0 +1,32 @@
+-- Allow 'system' as a valid actor_type in audit_log.
+--
+-- The activity Timeline (src/app/audit/page.tsx) exposes a "Sistema" filter and
+-- already renders actor_type = 'system', but the original CHECK constraint only
+-- permitted 'human' | 'agent', so system events could never be stored and the
+-- filter was always empty. Widen the constraint to include 'system'.
+--
+-- The constraint was created inline in 20260403_audit_log.sql, so Postgres named
+-- it audit_log_actor_type_check. Drop defensively (covers any rename) before
+-- re-adding the widened version.
+
+DO $$
+DECLARE
+  c text;
+BEGIN
+  FOR c IN
+    SELECT con.conname
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+    WHERE rel.relname = 'audit_log'
+      AND ns.nspname = 'public'
+      AND con.contype = 'c'
+      AND pg_get_constraintdef(con.oid) ILIKE '%actor_type%'
+  LOOP
+    EXECUTE format('ALTER TABLE public.audit_log DROP CONSTRAINT %I', c);
+  END LOOP;
+END $$;
+
+ALTER TABLE public.audit_log
+  ADD CONSTRAINT audit_log_actor_type_check
+  CHECK (actor_type IN ('human', 'agent', 'system'));


### PR DESCRIPTION
## Problema
El Timeline de actividad (`/audit`) ofrece un filtro **"Sistema"** y ya renderiza `actor_type = 'system'`, pero el `CHECK` de la tabla `audit_log` solo permitía `('human','agent')`. Resultado: nunca se podían guardar eventos de sistema y la pestaña quedaba siempre vacía.

## Cambio
Migración `20260620_audit_log_actor_type_system.sql` que amplía el constraint a `('human','agent','system')`.
- Borra el constraint viejo de forma **defensiva** (lo busca por su definición, no por nombre exacto).
- Re-crea el constraint con `'system'` incluido.
- **No destructiva**: no toca datos existentes, solo amplía valores aceptados.

## ⚠️ Post-merge
La migración hay que **aplicarla a la base** por el pipeline normal de Supabase. Mergear este PR solo agrega el archivo al repo. Además, la pestaña "Sistema" seguirá vacía hasta que algún flujo registre eventos con `actor_type:'system'` (cambio aparte).

## Validación
- Sin cambios de TypeScript (solo SQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_