### PR TITLE
feat(admin): editor de catálogo de agentes (L0) + catálogo DB-driven

### DIFF
--- a/src/app/admin/agents/AgentsCatalogManager.tsx
+++ b/src/app/admin/agents/AgentsCatalogManager.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+// BaW OS — Editor del catálogo de agentes (Platform Admin L0).
+// Edita metadata + controla `is_connectable`. No crea ni borra agentes.
+
+import { useState } from 'react'
+
+export interface CatalogAgent {
+  id: string
+  display_name: string
+  full_name: string
+  family: string
+  domain: string
+  description: string | null
+  role_label: string | null
+  capability_level: number
+  feedback_level: number
+  status: string
+  is_connectable: boolean
+  is_shared_zxy: boolean
+  updated_at: string
+}
+
+const STATUSES = ['planned', 'beta', 'live', 'paused', 'deprecated'] as const
+
+const STATUS_STYLE: Record<string, { bg: string; fg: string }> = {
+  planned: { bg: 'var(--baw-neutral-bg-soft)', fg: 'var(--baw-neutral-fg)' },
+  beta: { bg: 'var(--baw-agent-bg-soft)', fg: 'var(--baw-agent-fg)' },
+  live: { bg: 'var(--baw-success-bg-soft)', fg: 'var(--baw-success-fg)' },
+  paused: { bg: 'var(--baw-warning-bg-soft)', fg: 'var(--baw-warning-fg)' },
+  deprecated: { bg: 'var(--baw-danger-bg-soft)', fg: 'var(--baw-danger-fg)' },
+}
+
+export default function AgentsCatalogManager({
+  initialAgents,
+}: {
+  initialAgents: CatalogAgent[]
+}) {
+  const [agents, setAgents] = useState<CatalogAgent[]>(initialAgents)
+
+  const onSaved = (updated: CatalogAgent) => {
+    setAgents((prev) => prev.map((a) => (a.id === updated.id ? updated : a)))
+  }
+
+  // Agrupa por familia preservando el orden recibido (ya viene por family, name)
+  const families: string[] = []
+  for (const a of agents) if (!families.includes(a.family)) families.push(a.family)
+
+  return (
+    <div className="space-y-6">
+      {families.map((family) => (
+        <section key={family}>
+          <h3
+            className="text-[12px] font-semibold uppercase tracking-wider mb-2"
+            style={{ color: 'var(--baw-muted)', fontFamily: 'var(--font-mono)' }}
+          >
+            {family}
+          </h3>
+          <div className="space-y-2">
+            {agents
+              .filter((a) => a.family === family)
+              .map((a) => (
+                <AgentRow key={a.id} agent={a} onSaved={onSaved} />
+              ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+function AgentRow({
+  agent,
+  onSaved,
+}: {
+  agent: CatalogAgent
+  onSaved: (a: CatalogAgent) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [form, setForm] = useState({
+    display_name: agent.display_name,
+    full_name: agent.full_name,
+    role_label: agent.role_label ?? '',
+    description: agent.description ?? '',
+    domain: agent.domain,
+    family: agent.family,
+    capability_level: agent.capability_level,
+    feedback_level: agent.feedback_level,
+    status: agent.status,
+  })
+  const [saving, setSaving] = useState(false)
+  const [togglingConn, setTogglingConn] = useState(false)
+  const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
+
+  const set = <K extends keyof typeof form>(k: K, v: (typeof form)[K]) =>
+    setForm((f) => ({ ...f, [k]: v }))
+
+  async function patch(payload: Record<string, unknown>): Promise<CatalogAgent | null> {
+    const res = await fetch(`/api/admin/agents/${agent.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    const json = await res.json()
+    if (!res.ok || !json.success) {
+      setMsg({ kind: 'err', text: json.error || `HTTP ${res.status}` })
+      return null
+    }
+    return json.data as CatalogAgent
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    setMsg(null)
+    const updated = await patch(form)
+    if (updated) {
+      onSaved(updated)
+      setMsg({ kind: 'ok', text: 'Guardado' })
+      setOpen(false)
+    }
+    setSaving(false)
+  }
+
+  async function handleToggleConnectable() {
+    setTogglingConn(true)
+    setMsg(null)
+    const updated = await patch({ is_connectable: !agent.is_connectable })
+    if (updated) onSaved(updated)
+    setTogglingConn(false)
+  }
+
+  const s = STATUS_STYLE[agent.status] || STATUS_STYLE.planned
+
+  return (
+    <div
+      className="rounded-lg"
+      style={{ backgroundColor: 'var(--baw-surface)', border: '1px solid var(--baw-border)' }}
+    >
+      {/* Header row */}
+      <div className="flex items-center gap-3 p-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-[14px] font-semibold" style={{ color: 'var(--baw-text)' }}>
+              {agent.full_name}
+            </span>
+            <span
+              className="text-[10px] font-mono px-1.5 py-0.5 rounded"
+              style={{ backgroundColor: 'var(--baw-elevated)', color: 'var(--baw-muted)' }}
+            >
+              {agent.id}
+            </span>
+            <span
+              className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full"
+              style={{ backgroundColor: s.bg, color: s.fg }}
+            >
+              {agent.status}
+            </span>
+          </div>
+          <div className="text-[12px] mt-0.5" style={{ color: 'var(--baw-muted)' }}>
+            {agent.role_label || agent.domain} · L{agent.capability_level} · F{agent.feedback_level}
+          </div>
+        </div>
+
+        {/* Toggle conectable */}
+        <button
+          type="button"
+          onClick={handleToggleConnectable}
+          disabled={togglingConn}
+          title="¿Visible/conectable en /agents?"
+          className="text-[11px] px-2.5 py-1 rounded-full font-medium transition-colors disabled:opacity-50"
+          style={{
+            backgroundColor: agent.is_connectable ? 'var(--baw-success-bg-soft)' : 'var(--baw-neutral-bg-soft)',
+            color: agent.is_connectable ? 'var(--baw-success-fg)' : 'var(--baw-neutral-fg)',
+            border: `1px solid ${agent.is_connectable ? 'var(--baw-success-border, var(--baw-border))' : 'var(--baw-border)'}`,
+          }}
+        >
+          {togglingConn ? '…' : agent.is_connectable ? '● Conectable' : '○ Oculto'}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="text-[12px] underline"
+          style={{ color: 'var(--baw-accent)' }}
+        >
+          {open ? 'Cerrar' : 'Editar'}
+        </button>
+      </div>
+
+      {/* Edit form */}
+      {open && (
+        <div className="px-3 pb-3 pt-1 border-t" style={{ borderColor: 'var(--baw-border)' }}>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+            <Field label="Nombre corto">
+              <input className="input-field w-full" value={form.display_name} onChange={(e) => set('display_name', e.target.value)} />
+            </Field>
+            <Field label="Nombre completo">
+              <input className="input-field w-full" value={form.full_name} onChange={(e) => set('full_name', e.target.value)} />
+            </Field>
+            <Field label="Rol (línea de la tarjeta)">
+              <input className="input-field w-full" value={form.role_label} placeholder="ej. Operadora" onChange={(e) => set('role_label', e.target.value)} />
+            </Field>
+            <Field label="Dominio">
+              <input className="input-field w-full" value={form.domain} onChange={(e) => set('domain', e.target.value)} />
+            </Field>
+            <Field label="Familia">
+              <input className="input-field w-full" value={form.family} onChange={(e) => set('family', e.target.value)} />
+            </Field>
+            <Field label="Estado">
+              <select className="input-field w-full" value={form.status} onChange={(e) => set('status', e.target.value)}>
+                {STATUSES.map((st) => (
+                  <option key={st} value={st}>{st}</option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Capability (L) 0-5">
+              <input type="number" min={0} max={5} className="input-field w-full" value={form.capability_level} onChange={(e) => set('capability_level', Number(e.target.value))} />
+            </Field>
+            <Field label="Feedback (F) 0-5">
+              <input type="number" min={0} max={5} className="input-field w-full" value={form.feedback_level} onChange={(e) => set('feedback_level', Number(e.target.value))} />
+            </Field>
+            <div className="sm:col-span-2">
+              <Field label="Descripción">
+                <textarea className="input-field w-full" rows={2} value={form.description} onChange={(e) => set('description', e.target.value)} />
+              </Field>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3 mt-3">
+            <button type="button" onClick={handleSave} disabled={saving} className="btn-primary text-[13px] px-4 py-1.5 disabled:opacity-50">
+              {saving ? 'Guardando…' : 'Guardar'}
+            </button>
+            {msg && (
+              <span className="text-[12px]" style={{ color: msg.kind === 'ok' ? 'var(--baw-success-fg)' : 'var(--baw-danger-fg)' }}>
+                {msg.text}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Mensaje fuera del form (p.ej. error de toggle) */}
+      {!open && msg && (
+        <div className="px-3 pb-2 -mt-1">
+          <span className="text-[12px]" style={{ color: msg.kind === 'ok' ? 'var(--baw-success-fg)' : 'var(--baw-danger-fg)' }}>
+            {msg.text}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-[11px] font-medium uppercase tracking-wide mb-1" style={{ color: 'var(--baw-muted)' }}>
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/src/app/admin/agents/page.tsx
+++ b/src/app/admin/agents/page.tsx
@@ -1,0 +1,42 @@
+// BaW OS — Platform Admin · Catálogo de Agentes (L0)
+//
+// Edita la metadata de los agentes y controla cuáles aparecen como conectables
+// en /agents. El acceso ya está protegido por el layout de /admin (solo L0).
+
+import { createServiceClient } from '@/lib/api-auth'
+import AgentsCatalogManager, { type CatalogAgent } from './AgentsCatalogManager'
+
+export const dynamic = 'force-dynamic'
+
+async function getAgents(): Promise<CatalogAgent[]> {
+  const service = createServiceClient()
+  const { data } = await service
+    .from('agents')
+    .select(
+      'id, display_name, full_name, family, domain, description, role_label, capability_level, feedback_level, status, is_connectable, is_shared_zxy, updated_at'
+    )
+    .order('family')
+    .order('display_name')
+  return (data || []) as CatalogAgent[]
+}
+
+export default async function AdminAgentsPage() {
+  const agents = await getAgents()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-[20px] font-semibold" style={{ color: 'var(--baw-text)' }}>
+          Catálogo de Agentes
+        </h2>
+        <p className="text-[13px] mt-1" style={{ color: 'var(--baw-muted)' }}>
+          Edita nombre, descripción, rol y niveles de cada agente, y controla con{' '}
+          <strong>Conectable</strong> cuáles aparecen en la pantalla de Agentes para que un
+          admin de tenant les emita credenciales.
+        </p>
+      </div>
+
+      <AgentsCatalogManager initialAgents={agents} />
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,7 +6,7 @@
 import { redirect } from 'next/navigation'
 import { getPlatformAdminContext } from '@/lib/platform-admin'
 import Link from 'next/link'
-import { LayoutDashboard, Building2, Users, Server, Activity, Map } from 'lucide-react'
+import { LayoutDashboard, Building2, Users, Server, Activity, Map, Bot } from 'lucide-react'
 
 export const metadata = {
   title: 'Platform Admin · BaW OS',
@@ -70,6 +70,7 @@ export default async function AdminLayout({
         <AdminTab href="/admin" icon={<LayoutDashboard size={14} />} label="Dashboard" />
         <AdminTab href="/admin/roadmap" icon={<Map size={14} />} label="Roadmap" />
         <AdminTab href="/admin/tenants" icon={<Building2 size={14} />} label="Tenants" />
+        <AdminTab href="/admin/agents" icon={<Bot size={14} />} label="Agentes" />
         <AdminTab href="/admin/users" icon={<Users size={14} />} label="Usuarios" />
         <AdminTab href="/admin/admins" icon={<Server size={14} />} label="Platform Admins" />
         <AdminTab href="/admin/health" icon={<Activity size={14} />} label="Salud" />

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -22,6 +22,8 @@ interface AgentRow {
   feedback_level: number
   status: string
   is_shared_zxy: boolean
+  is_connectable: boolean
+  role_label: string | null
   autonomy_level?: number
 }
 
@@ -46,16 +48,14 @@ async function loadData() {
     orgId = null
   }
 
-  // MVP Sprint 5A: la UI muestra SOLO los agentes third-party activos del MVP
-  // (Alicia operadora + Hugo supervisor). Los nativos y los demás third-party
-  // (Beto, Maribel, Luis, Andrés, Rafa) permanecen en la tabla `agents` pero
-  // no se presentan en el catálogo. El runner de cobranza sigue corriendo como
-  // automatización interna vía /api/cron/cobranza.
-  const MVP_AGENT_IDS = ['alicia-ops', 'hugo-cos']
+  // Catálogo DB-driven: se muestran los agentes marcados como `is_connectable`
+  // desde el editor de Platform Admin (/admin/agents). Los demás permanecen en
+  // la tabla `agents` pero ocultos del catálogo. El runner de cobranza sigue
+  // corriendo como automatización interna vía /api/cron/cobranza.
   const { data: agentsData } = await supabase
     .from('agents')
     .select('*')
-    .in('id', MVP_AGENT_IDS)
+    .eq('is_connectable', true)
     .order('display_name')
 
   let runs: AgentRunRow[] = []
@@ -139,19 +139,12 @@ const FAMILY_DESC: Record<string, string> = {
 
 const FAMILY_ORDER = ['baw-coord', 'ops-core', 'experiencia', 'inteligencia', 'third-party', 'pm-ops', 'zxy-shared']
 
-// MVP Sprint 5A: agentes third-party activos y su rol operativo.
-// Los demás third-party quedan diferidos (Sprint 5B+).
-const MVP_AGENT_ROLES: Record<string, string> = {
-  'alicia-ops': 'Operadora · Mateos 809P',
-  'hugo-cos': 'Supervisor de Alicia · solo lectura',
-}
-
 function ConnectionBadge({
   connected,
-  isMvpAgent,
+  isConnectable,
 }: {
   connected: boolean
-  isMvpAgent: boolean
+  isConnectable: boolean
 }) {
   if (connected) {
     return (
@@ -166,7 +159,7 @@ function ConnectionBadge({
       </span>
     )
   }
-  if (isMvpAgent) {
+  if (isConnectable) {
     return (
       <span
         className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full"
@@ -295,7 +288,7 @@ export default async function AgentsPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
             {list.map((a) => {
               const isImpl = implemented.has(a.id)
-              const isMvpAgent = a.id in MVP_AGENT_ROLES
+              const isConnectable = a.is_connectable
               const connected = connectedIds.has(a.id)
               return (
                 <div
@@ -303,7 +296,7 @@ export default async function AgentsPage() {
                   className="rounded-lg p-4 flex flex-col gap-3"
                   style={{
                     backgroundColor: 'var(--baw-surface)',
-                    border: isMvpAgent
+                    border: isConnectable
                       ? '1px solid var(--baw-accent)'
                       : '1px solid var(--baw-border)',
                   }}
@@ -320,11 +313,11 @@ export default async function AgentsPage() {
                         className="text-[11px] mt-0.5"
                         style={{ color: 'var(--baw-muted)' }}
                       >
-                        {MVP_AGENT_ROLES[a.id] ?? a.domain} · L{a.capability_level} · F{a.feedback_level}
+                        {a.role_label ?? a.domain} · L{a.capability_level} · F{a.feedback_level}
                       </div>
                     </div>
                     <div className="flex flex-col items-end gap-1">
-                      <ConnectionBadge connected={connected} isMvpAgent={isMvpAgent} />
+                      <ConnectionBadge connected={connected} isConnectable={isConnectable} />
                       <StatusBadge status={a.status} />
                     </div>
                   </div>
@@ -338,7 +331,7 @@ export default async function AgentsPage() {
                   )}
                   {isImpl && orgId ? (
                     <AgentRunButton agentId={a.id} agentName={a.display_name} />
-                  ) : orgId && isMvpAgent ? (
+                  ) : orgId && isConnectable ? (
                     <Link
                       href={`/agents/${a.id}/credentials`}
                       className="text-[11px] underline"
@@ -423,7 +416,7 @@ export default async function AgentsPage() {
       </section>
 
       <div className="text-[11px]" style={{ color: 'var(--baw-muted)' }}>
-        <Link href="/admin" className="underline">L0 Platform admin</Link> · Catálogo de agentes solo editable por platform admins.
+        <Link href="/admin/agents" className="underline">L0 Platform admin</Link> · Catálogo de agentes solo editable por platform admins.
       </div>
     </div>
   )

--- a/src/app/api/admin/agents/[id]/route.ts
+++ b/src/app/api/admin/agents/[id]/route.ts
@@ -1,0 +1,123 @@
+// BaW OS — Admin (L0): editar un agente del catálogo
+// PATCH /api/admin/agents/[id] — actualiza campos editables de un agente
+//
+// Solo Platform Admin (L0). Alcance V1: editar metadata + mostrar/ocultar
+// (is_connectable). No crea ni elimina agentes (eso es una iteración aparte).
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { isPlatformAdmin } from '@/lib/platform-admin'
+
+export const dynamic = 'force-dynamic'
+
+interface RouteContext {
+  params: Promise<{ id: string }>
+}
+
+const VALID_STATUS = ['planned', 'beta', 'live', 'paused', 'deprecated']
+
+// Campos de texto editables: límite de longitud para evitar payloads abusivos.
+const TEXT_FIELDS: { key: 'display_name' | 'full_name' | 'description' | 'role_label' | 'domain' | 'family'; max: number; nullable: boolean }[] = [
+  { key: 'display_name', max: 60, nullable: false },
+  { key: 'full_name', max: 80, nullable: false },
+  { key: 'description', max: 400, nullable: true },
+  { key: 'role_label', max: 80, nullable: true },
+  { key: 'domain', max: 40, nullable: false },
+  { key: 'family', max: 40, nullable: false },
+]
+
+export async function PATCH(req: NextRequest, ctx: RouteContext) {
+  if (!(await isPlatformAdmin())) {
+    return NextResponse.json(
+      { success: false, error: 'Platform admin required' },
+      { status: 403 }
+    )
+  }
+
+  const { id } = await ctx.params
+
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const update: Record<string, unknown> = {}
+
+  // Campos de texto
+  for (const f of TEXT_FIELDS) {
+    if (!(f.key in body)) continue
+    const raw = body[f.key]
+    if (raw === null && f.nullable) {
+      update[f.key] = null
+      continue
+    }
+    if (typeof raw !== 'string') {
+      return NextResponse.json({ success: false, error: `${f.key} must be a string` }, { status: 400 })
+    }
+    const val = raw.trim()
+    if (!f.nullable && val.length === 0) {
+      return NextResponse.json({ success: false, error: `${f.key} no puede estar vacío` }, { status: 400 })
+    }
+    if (val.length > f.max) {
+      return NextResponse.json({ success: false, error: `${f.key} excede ${f.max} caracteres` }, { status: 400 })
+    }
+    // role_label/description vacíos → null (limpia el campo)
+    update[f.key] = f.nullable && val.length === 0 ? null : val
+  }
+
+  // capability_level / feedback_level (enteros 0-5)
+  for (const k of ['capability_level', 'feedback_level'] as const) {
+    if (!(k in body)) continue
+    const n = body[k]
+    if (typeof n !== 'number' || !Number.isInteger(n) || n < 0 || n > 5) {
+      return NextResponse.json({ success: false, error: `${k} debe ser un entero entre 0 y 5` }, { status: 400 })
+    }
+    update[k] = n
+  }
+
+  // status (enum)
+  if ('status' in body) {
+    if (typeof body.status !== 'string' || !VALID_STATUS.includes(body.status)) {
+      return NextResponse.json(
+        { success: false, error: `status inválido (válidos: ${VALID_STATUS.join(', ')})` },
+        { status: 400 }
+      )
+    }
+    update.status = body.status
+  }
+
+  // is_connectable (boolean)
+  if ('is_connectable' in body) {
+    if (typeof body.is_connectable !== 'boolean') {
+      return NextResponse.json({ success: false, error: 'is_connectable debe ser booleano' }, { status: 400 })
+    }
+    update.is_connectable = body.is_connectable
+  }
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json({ success: false, error: 'Nada que actualizar' }, { status: 400 })
+  }
+
+  update.updated_at = new Date().toISOString()
+
+  const service = createServiceClient()
+  const { data, error } = await service
+    .from('agents')
+    .update(update)
+    .eq('id', id)
+    .select(
+      'id, display_name, full_name, family, domain, description, role_label, capability_level, feedback_level, status, is_connectable, is_shared_zxy, updated_at'
+    )
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ success: false, error: 'Agente no encontrado' }, { status: 404 })
+  }
+
+  return NextResponse.json({ success: true, data })
+}

--- a/src/app/api/admin/agents/route.ts
+++ b/src/app/api/admin/agents/route.ts
@@ -1,0 +1,35 @@
+// BaW OS — Admin (L0): catálogo de agentes
+// GET /api/admin/agents — lista TODOS los agentes (catálogo completo)
+//
+// Solo Platform Admin (L0). La edición del catálogo es global/compartida entre
+// tenants, por eso no es una capacidad de tenant admin.
+
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { isPlatformAdmin } from '@/lib/platform-admin'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  if (!(await isPlatformAdmin())) {
+    return NextResponse.json(
+      { success: false, error: 'Platform admin required' },
+      { status: 403 }
+    )
+  }
+
+  const service = createServiceClient()
+  const { data, error } = await service
+    .from('agents')
+    .select(
+      'id, display_name, full_name, family, domain, description, role_label, capability_level, feedback_level, status, is_connectable, is_shared_zxy, updated_at'
+    )
+    .order('family')
+    .order('display_name')
+
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true, data: data || [] })
+}

--- a/supabase/migrations/20260620_02_agents_catalog_fields.sql
+++ b/supabase/migrations/20260620_02_agents_catalog_fields.sql
@@ -1,0 +1,31 @@
+-- BaW OS — Catálogo de agentes editable / autoservicio desde el admin L0.
+--
+-- Agrega dos columnas a `agents`:
+--   is_connectable — controla qué agentes se muestran en /agents (y a los que
+--     se les pueden emitir credenciales). Reemplaza el hardcode MVP_AGENT_IDS
+--     que vivía en src/app/agents/page.tsx.
+--   role_label     — línea de rol que se muestra en la tarjeta del agente
+--     (p.ej. "Operadora"). Reemplaza el hardcode MVP_AGENT_ROLES.
+--
+-- Editable solo por Platform Admin (L0): la RLS existente `agents_write_platform`
+-- ya restringe la escritura de esta tabla a platform_admins, así que no hace
+-- falta tocar políticas.
+--
+-- Aditiva e idempotente.
+
+ALTER TABLE public.agents
+  ADD COLUMN IF NOT EXISTS is_connectable BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS role_label TEXT;
+
+-- Preserva el comportamiento actual de la UI: Alicia + Hugo son los dos agentes
+-- conectables del MVP. Se siembran con los textos actuales; a partir de aquí son
+-- editables desde /admin/agents.
+UPDATE public.agents
+SET is_connectable = true,
+    role_label = 'Operadora · Mateos 809P'
+WHERE id = 'alicia-ops';
+
+UPDATE public.agents
+SET is_connectable = true,
+    role_label = 'Supervisor de Alicia · solo lectura'
+WHERE id = 'hugo-cos';


### PR DESCRIPTION
## Qué hace
Hace el catálogo de agentes **editable y autoservicio** desde la consola Platform Admin (L0), y vuelve `/agents` **DB-driven** (sin hardcodes).

### Alcance (acordado con Fran)
- **Quién edita:** solo Platform Admin (L0). El catálogo es global/compartido entre tenants.
- **V1:** editar metadata + mostrar/ocultar (`is_connectable`). **No** crea ni borra agentes (iteración aparte).

## Cambios
**1. Migración `20260620_02_agents_catalog_fields.sql`**
- Agrega `agents.is_connectable` (bool, default false) y `agents.role_label` (text).
- Siembra `alicia-ops` y `hugo-cos` como conectables con sus textos **actuales** → cero cambio visual en el deploy.

**2. `/agents` ahora DB-driven**
- Elimina los hardcodes `MVP_AGENT_IDS` y `MVP_AGENT_ROLES`.
- Muestra agentes por `is_connectable`; usa `role_label` en la tarjeta.

**3. `/admin/agents` — editor nuevo (L0)**
- Lista todos los agentes por familia. Editar: nombre, descripción, rol, dominio, familia, niveles L/F, estado.
- Toggle **Conectable / Oculto** (guarda al instante) que controla la visibilidad en `/agents`.
- Nueva pestaña "Agentes" en el nav de `/admin`.

**4. API `/api/admin/agents`**
- `GET` (lista) y `PATCH /[id]` (actualiza). Solo platform admin; validación de enum/niveles/longitudes.

## ⚠️ Orden de deploy (importante)
Esta migración es **obligatoria ANTES (o junto con) el deploy del código**. `/agents` ahora consulta `is_connectable`; si el código sale sin la columna en la DB, `/agents` y `/admin/agents` fallan. **Aplicar la migración primero, luego mergear.** (El preview de Vercel también necesita la columna en su DB para no romper.)

## Validación
- `npx tsc --noEmit` ✅
- `eslint` (archivos tocados) ✅

## Probar end-to-end (post-deploy)
1. `/admin/agents` → confirmar Alicia/Hugo conectables (y limpiar textos si se quiere).
2. `/agents` → emitir credencial para cada uno → el badge pasa a **Conectado**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_