### PR TITLE
fix(v1): POST /v1/incidents 500 — agent id (string) en columna uuid reported_by

### DIFF
--- a/src/app/api/v1/incidents/route.ts
+++ b/src/app/api/v1/incidents/route.ts
@@ -80,7 +80,10 @@ export const POST = v1Write<IncidentCreateBody>({
         description: body.description ?? null,
         priority: body.priority ?? 'normal',
         estimated_cost: body.estimated_cost ?? null,
-        reported_by: body.reported_by ?? `agent:${auth.agentId}`,
+        // reported_by es uuid FK a occupants(id). Para incidencias creadas por un
+        // agente no hay occupant reportante → null. La autoría del agente queda
+        // registrada vía recordAction() en agent_actions/audit (no en esta columna).
+        reported_by: body.reported_by ?? null,
         status: 'open',
       })
       .select('id, org_id, unit_id, title, description, status, priority, created_at')

--- a/src/lib/agents/v1/dispatcher.ts
+++ b/src/lib/agents/v1/dispatcher.ts
@@ -47,7 +47,9 @@ export async function dispatchApprovedAction(ctx: DispatchContext): Promise<Disp
           description: p.description ?? null,
           priority: p.priority ?? 'normal',
           estimated_cost: p.estimated_cost ?? null,
-          reported_by: p.reported_by ?? `agent:${ctx.agentId}`,
+          // reported_by es uuid FK a occupants(id); para incidencias de un agente
+          // va null (la autoría se registra en agent_actions/audit, no aquí).
+          reported_by: p.reported_by ?? null,
           status: 'open',
         })
         .select('id')


### PR DESCRIPTION
## Bug
`POST /api/v1/incidents` devolvía **500** en el camino directo (`x-baw-trigger: human`):
```
{"success":false,"error":{"code":"insert_error",
 "message":"invalid input syntax for type uuid: \"agent:alicia-ops\""}}
```

## Causa raíz
`incidents.reported_by` es `UUID REFERENCES occupants(id)`. El código metía el id del actor `agent:<agent_id>` (string) como default → Postgres rechaza el string no-uuid.
- Camino **human** (ejecución directa) → INSERT directo → **500**.
- Camino **auto** (202) no lo pegaba porque encola en `agent_approvals` (texto), no inserta directo. **El mismo bug estaba latente en el dispatcher** (al aprobar la acción habría fallado igual).

## Fix
`reported_by = null` para incidencias originadas por agente, en los **dos** lugares que insertan:
- `src/app/api/v1/incidents/route.ts` (camino directo)
- `src/lib/agents/v1/dispatcher.ts` (camino de aprobación)

La autoría del agente **no se pierde**: ya se registra vía `recordAction()` en `agent_actions`/audit. Sin dependencia de migración nueva (no se toca el schema).

## Verificación
- `npx tsc --noEmit` ✅
- Detectado por smoke test real (curl directo a la API, sin el plugin): paso 2 lectura `200`, paso 4 auto `202`, paso 3 human `500` → ahora `200`.
- Otros endpoints revisados: `tasks.created_by` y `payments.notes` son TEXT (sin bug); solo `incidents.reported_by` era uuid.

## Cómo reprobar (post-merge)
Re-correr el paso 3 del smoke (curl `x-baw-trigger: human`) → debe dar `200` y la incidencia aparece en `/incidents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_