### PR TITLE
feat(lifecycle): Archivar/Restaurar/Eliminar uniforme + force-delete + agentes (archivar con aprobación)

### DIFF
--- a/src/app/agents/[id]/credentials/CredentialsManager.tsx
+++ b/src/app/agents/[id]/credentials/CredentialsManager.tsx
@@ -52,6 +52,7 @@ const COMMON_SCOPES = [
   'agents:read',
   'interactions:read',
   'interactions:write',
+  'lifecycle:archive',
 ]
 
 export default function CredentialsManager({

--- a/src/app/api/contracts/route.ts
+++ b/src/app/api/contracts/route.ts
@@ -71,13 +71,16 @@ export async function DELETE(request: NextRequest) {
   const id = searchParams.get('id')
   if (!id) return apiError('id query param is required')
 
-  // Delete linked payments first (foreign key constraint)
-  const { error: payErr } = await supabase
+  // Guard: NUNCA borrar pagos en silencio. Si el contrato tiene historia
+  // financiera, se rechaza (la vía correcta es archivar — ver /api/lifecycle).
+  const { count: payCount } = await supabase
     .from('payments')
-    .delete()
+    .select('id', { count: 'exact', head: true })
     .eq('contract_id', id)
 
-  if (payErr) return apiError(payErr.message, 500)
+  if ((payCount ?? 0) > 0) {
+    return apiError('No se puede eliminar: el contrato tiene pagos registrados. Archívalo en su lugar.', 409)
+  }
 
   const { error } = await supabase
     .from('contracts')

--- a/src/app/api/lifecycle/route.ts
+++ b/src/app/api/lifecycle/route.ts
@@ -1,0 +1,118 @@
+// BaW OS — API unificada de ciclo de vida (Archivar / Restaurar / Eliminar / Force-delete)
+//
+// GET  /api/lifecycle?entity=&id=        → preflight: qué bloquea el borrado
+// POST /api/lifecycle  { entity, id, action: 'archive'|'restore'|'delete'|'force_delete' }
+//
+// Solo owner/admin del tenant (o platform admin). Scoping estricto por org:
+// la entidad debe pertenecer a la org activa del caller.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { requireAdminCaller } from '@/lib/admin-auth'
+import {
+  archiveEntity,
+  restoreEntity,
+  deleteClean,
+  forceDelete,
+  checkBlockers,
+  ENTITY_TABLE,
+  LifecycleError,
+  type LifecycleEntity,
+} from '@/lib/lifecycle'
+
+export const dynamic = 'force-dynamic'
+
+const VALID_ENTITIES: LifecycleEntity[] = ['building', 'unit', 'contract', 'occupant']
+const VALID_ACTIONS = ['archive', 'restore', 'delete', 'force_delete'] as const
+type Action = (typeof VALID_ACTIONS)[number]
+
+function isEntity(v: unknown): v is LifecycleEntity {
+  return typeof v === 'string' && (VALID_ENTITIES as string[]).includes(v)
+}
+
+// Verifica que la entidad exista y pertenezca a la org del caller.
+async function assertOrgOwnership(
+  db: ReturnType<typeof createServiceClient>,
+  entity: LifecycleEntity,
+  id: string,
+  orgId: string
+): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+  const { data, error } = await db.from(ENTITY_TABLE[entity]).select('org_id').eq('id', id).maybeSingle()
+  if (error) return { ok: false, status: 500, message: error.message }
+  if (!data) return { ok: false, status: 404, message: `${entity} no encontrado` }
+  if ((data as { org_id: string }).org_id !== orgId) {
+    return { ok: false, status: 403, message: 'Entidad de otra organización' }
+  }
+  return { ok: true }
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAdminCaller()
+  if (!auth.ok) return NextResponse.json({ success: false, error: auth.message }, { status: auth.status })
+
+  const entity = req.nextUrl.searchParams.get('entity')
+  const id = req.nextUrl.searchParams.get('id')
+  if (!isEntity(entity) || !id) {
+    return NextResponse.json({ success: false, error: 'entity e id requeridos' }, { status: 400 })
+  }
+
+  const db = createServiceClient()
+  const owns = await assertOrgOwnership(db, entity, id, auth.orgId)
+  if (!owns.ok) return NextResponse.json({ success: false, error: owns.message }, { status: owns.status })
+
+  const preflight = await checkBlockers(db, entity, id)
+  return NextResponse.json({ success: true, data: preflight })
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAdminCaller()
+  if (!auth.ok) return NextResponse.json({ success: false, error: auth.message }, { status: auth.status })
+
+  let body: { entity?: unknown; id?: unknown; action?: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ success: false, error: 'JSON inválido' }, { status: 400 })
+  }
+
+  const { entity, id, action } = body
+  if (!isEntity(entity) || typeof id !== 'string' || !id) {
+    return NextResponse.json({ success: false, error: 'entity e id requeridos' }, { status: 400 })
+  }
+  if (typeof action !== 'string' || !(VALID_ACTIONS as readonly string[]).includes(action)) {
+    return NextResponse.json({ success: false, error: `action inválida (${VALID_ACTIONS.join(', ')})` }, { status: 400 })
+  }
+
+  const db = createServiceClient()
+  const owns = await assertOrgOwnership(db, entity, id, auth.orgId)
+  if (!owns.ok) return NextResponse.json({ success: false, error: owns.message }, { status: owns.status })
+
+  try {
+    switch (action as Action) {
+      case 'archive':
+        await archiveEntity(db, entity, id)
+        break
+      case 'restore':
+        await restoreEntity(db, entity, id)
+        break
+      case 'delete':
+        await deleteClean(db, entity, id)
+        break
+      case 'force_delete':
+        await forceDelete(db, entity, id)
+        break
+    }
+  } catch (e) {
+    if (e instanceof LifecycleError) {
+      // Borrado bloqueado por dependencias → 409 con detalle para la UI.
+      return NextResponse.json(
+        { success: false, error: e.message, blockers: e.blockers ?? [] },
+        { status: 409 }
+      )
+    }
+    const msg = e instanceof Error ? e.message : 'Error desconocido'
+    return NextResponse.json({ success: false, error: msg }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/v1/lifecycle/route.ts
+++ b/src/app/api/v1/lifecycle/route.ts
@@ -1,0 +1,51 @@
+// BaW OS v1 — POST /v1/lifecycle  (agentes: ARCHIVAR, nunca eliminar)
+//
+// Los agentes pueden archivar entidades (reversible) SIEMPRE con aprobación
+// humana — `lifecycle.archive` está en el guardrail duro del classifier, así que
+// nunca se ejecuta directo: encola una aprobación (202) y el dispatcher la corre
+// al ser concedida. NO hay borrado vía agentes.
+
+import { v1Write } from '@/lib/agents/v1/handler'
+import { v1Ok } from '@/lib/agents/v1/responses'
+import { createServiceClient } from '@/lib/supabase'
+import { archiveEntity, ENTITY_TABLE, type LifecycleEntity } from '@/lib/lifecycle'
+
+interface ArchiveBody {
+  entity: LifecycleEntity
+  id: string
+  action: 'archive'
+}
+
+export const POST = v1Write<ArchiveBody>({
+  scopes: ['lifecycle:archive'],
+  actionType: 'lifecycle.archive',
+  endpoint: '/v1/lifecycle',
+  validate: (raw) => {
+    if (typeof raw !== 'object' || raw === null) throw new Error('body must be object')
+    const b = raw as Record<string, unknown>
+    if (typeof b.entity !== 'string' || !(b.entity in ENTITY_TABLE)) {
+      throw new Error('entity inválido (building|unit|contract|occupant)')
+    }
+    if (typeof b.id !== 'string' || !b.id) throw new Error('id requerido')
+    if (b.action !== undefined && b.action !== 'archive') {
+      throw new Error("solo se soporta action 'archive' (los agentes no eliminan)")
+    }
+    return { entity: b.entity as LifecycleEntity, id: b.id, action: 'archive' }
+  },
+  // Nota: por el guardrail duro este handler casi nunca corre (la acción se encola
+  // siempre como aprobación → dispatcher). Se implementa por completitud.
+  handler: async ({ auth, body, recordAction }) => {
+    const db = createServiceClient()
+    await archiveEntity(db, body.entity, body.id)
+    await recordAction({
+      actionType: 'lifecycle.archive',
+      entityType: body.entity,
+      entityId: body.id,
+      payload: body as unknown as Record<string, unknown>,
+      result: { archived: body.id },
+      status: 'ok',
+    })
+    void auth
+    return v1Ok({ archived: body.id, entity: body.entity })
+  },
+})

--- a/src/app/buildings/page.tsx
+++ b/src/app/buildings/page.tsx
@@ -5,12 +5,13 @@
 // Cuenta unidades por building via relación inversa.
 
 import { useEffect, useMemo, useState } from 'react'
-import { Plus, Building2, Pencil, MapPin, Trash2 } from 'lucide-react'
+import { Plus, Building2, Pencil, MapPin } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import type { Building } from '@/types'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 import BuildingModal from './BuildingModal'
+import LifecycleActions, { ArchivedBadge } from '@/components/LifecycleActions'
 import { useActiveContext } from '@/lib/useActiveContext'
 
 interface BuildingWithCounts extends Building {
@@ -26,6 +27,7 @@ export default function BuildingsPage() {
   const [modalOpen, setModalOpen] = useState(false)
   const [editing, setEditing] = useState<Building | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [showArchived, setShowArchived] = useState(false)
 
   const activeOrg = useMemo(
     () => orgs.find((o) => o.id === activeOrgId) || null,
@@ -40,11 +42,13 @@ export default function BuildingsPage() {
     }
     setLoading(true)
 
-    const { data: bldgs, error: bErr } = await supabase
+    let bQuery = supabase
       .from('buildings')
       .select('*')
       .eq('org_id', activeOrgId)
       .order('name', { ascending: true })
+    if (!showArchived) bQuery = bQuery.is('archived_at', null)
+    const { data: bldgs, error: bErr } = await bQuery
 
     if (bErr) {
       setError(bErr.message)
@@ -103,7 +107,7 @@ export default function BuildingsPage() {
     if (ctxLoading) return
     fetchBuildings()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ctxLoading, activeOrgId])
+  }, [ctxLoading, activeOrgId, showArchived])
 
   async function handleSave(data: Partial<Building>) {
     if (!activeOrgId) return
@@ -134,50 +138,8 @@ export default function BuildingsPage() {
     refresh()
   }
 
-  async function deleteBuilding(building: Building) {
-    if (!activeOrgId) return
-    const current = buildings.find((item) => item.id === building.id)
-    const unitsCount = current?.units_count ?? 0
-
-    if (unitsCount > 0) {
-      setError(
-        `No se puede eliminar "${building.name}" porque todavía tiene ${unitsCount} unidades ligadas.`,
-      )
-      return
-    }
-
-    if (!confirm(`¿Eliminar el edificio "${building.name}"?`)) return
-
-    setError(null)
-
-    const { error: stakesErr } = await supabase
-      .from('ownership_stakes')
-      .delete()
-      .eq('org_id', activeOrgId)
-      .eq('building_id', building.id)
-
-    if (stakesErr) {
-      setError(stakesErr.message)
-      return
-    }
-
-    const { error: deleteErr } = await supabase
-      .from('buildings')
-      .delete()
-      .eq('org_id', activeOrgId)
-      .eq('id', building.id)
-
-    if (deleteErr) {
-      setError(deleteErr.message)
-      return
-    }
-
-    if (editing?.id === building.id) {
-      setModalOpen(false)
-      setEditing(null)
-    }
-
-    await fetchBuildings()
+  function onLifecycleChanged() {
+    fetchBuildings()
     refresh()
   }
 
@@ -216,16 +178,22 @@ export default function BuildingsPage() {
             unidades
           </p>
         </div>
-        <button
-          onClick={() => {
-            setEditing(null)
-            setModalOpen(true)
-          }}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-sm font-medium transition-colors"
-        >
-          <Plus className="w-4 h-4" />
-          Nuevo edificio
-        </button>
+        <div className="flex items-center gap-3">
+          <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none">
+            <input type="checkbox" checked={showArchived} onChange={(e) => setShowArchived(e.target.checked)} />
+            Ver archivados
+          </label>
+          <button
+            onClick={() => {
+              setEditing(null)
+              setModalOpen(true)
+            }}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            Nuevo edificio
+          </button>
+        </div>
       </div>
 
       {error && (
@@ -255,8 +223,9 @@ export default function BuildingsPage() {
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
-                    <div className="font-medium text-gray-900 dark:text-white truncate">
+                    <div className="font-medium text-gray-900 dark:text-white truncate flex items-center gap-2">
                       {b.name}
+                      {b.archived_at && <ArchivedBadge />}
                     </div>
                     {(b.address || b.city) && (
                       <div className="mt-1 flex items-start gap-1.5 text-xs text-gray-500 dark:text-gray-400">
@@ -290,13 +259,13 @@ export default function BuildingsPage() {
                     >
                       <Pencil className="w-4 h-4" />
                     </button>
-                    <button
-                      onClick={() => deleteBuilding(b)}
-                      className="text-gray-400 hover:text-red-600 dark:hover:text-red-400"
-                      title="Eliminar"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
+                    <LifecycleActions
+                      entity="building"
+                      id={b.id}
+                      name={b.name}
+                      archived={!!b.archived_at}
+                      onChanged={onLifecycleChanged}
+                    />
                   </div>
                 </div>
               </div>
@@ -321,8 +290,9 @@ export default function BuildingsPage() {
                     className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
                   >
                     <td className="px-4 py-3">
-                      <div className="font-medium text-gray-900 dark:text-white">
+                      <div className="font-medium text-gray-900 dark:text-white flex items-center gap-2">
                         {b.name}
+                        {b.archived_at && <ArchivedBadge />}
                       </div>
                       {b.notes && (
                         <div className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-xs">
@@ -366,13 +336,13 @@ export default function BuildingsPage() {
                         >
                           <Pencil className="w-4 h-4" />
                         </button>
-                        <button
-                          onClick={() => deleteBuilding(b)}
-                          className="text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
-                          title="Eliminar"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
+                        <LifecycleActions
+                          entity="building"
+                          id={b.id}
+                          name={b.name}
+                          archived={!!b.archived_at}
+                          onChanged={onLifecycleChanged}
+                        />
                       </div>
                     </td>
                   </tr>
@@ -387,7 +357,6 @@ export default function BuildingsPage() {
         <BuildingModal
           building={editing}
           onSave={handleSave}
-          onDelete={editing ? () => deleteBuilding(editing) : undefined}
           onClose={() => {
             setModalOpen(false)
             setEditing(null)

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { useEffect, useState, useMemo } from 'react'
-import { Plus, Users, Search, Pencil, Trash2, X, Save, Phone, Mail, CalendarDays, FileText, ChevronLeft, ChevronDown, ChevronUp } from 'lucide-react'
+import { Plus, Users, Search, Pencil, X, Save, Phone, Mail, CalendarDays, FileText, ChevronLeft, ChevronDown, ChevronUp } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { useOrgContext } from '@/hooks/useOrgContext'
 import { useToast } from '@/components/Toast'
 import { formatDate } from '@/lib/utils'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
+import LifecycleActions, { ArchivedBadge } from '@/components/LifecycleActions'
 import type { ContactType, Reservation, Contract } from '@/types'
 
 interface Contact {
@@ -24,6 +25,7 @@ interface Contact {
   cp_fiscal?: string
   email_factura?: string
   requiere_factura?: boolean
+  archived_at?: string | null
   created_at: string
   updated_at: string
   reservation_count?: number
@@ -50,9 +52,9 @@ export default function ContactsPage() {
   const [searchQuery, setSearchQuery] = useState('')
   const [showAddModal, setShowAddModal] = useState(false)
   const [editingContact, setEditingContact] = useState<Contact | null>(null)
-  const [deleteTarget, setDeleteTarget] = useState<Contact | null>(null)
   const [selectedContact, setSelectedContact] = useState<Contact | null>(null)
   const [saving, setSaving] = useState(false)
+  const [showArchived, setShowArchived] = useState(false)
 
   const { orgId } = useOrgContext()
   // Add / Edit form
@@ -79,11 +81,13 @@ export default function ContactsPage() {
   // ─── Fetch contacts ──────────────────────────────────────────────
   async function fetchContacts() {
     setLoading(true)
-    const { data } = await supabase
+    let oQuery = supabase
       .from('occupants')
       .select('*')
       .eq('org_id', orgId)
       .order('name')
+    if (!showArchived) oQuery = oQuery.is('archived_at', null)
+    const { data } = await oQuery
 
     // Enrich with reservation counts
     const { data: reservations } = await supabase
@@ -110,7 +114,8 @@ export default function ContactsPage() {
   useEffect(() => {
     if (!orgId) return
     fetchContacts()
-  }, [orgId])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId, showArchived])
 
   // ─── Filtered contacts ───────────────────────────────────────────
   const filtered = useMemo(() => {
@@ -198,26 +203,6 @@ export default function ContactsPage() {
   }
 
   // ─── Delete contact ──────────────────────────────────────────────
-  async function handleDelete() {
-    if (!deleteTarget) return
-    setSaving(true)
-    try {
-      const res = await fetch(`/api/contacts?id=${deleteTarget.id}`, { method: 'DELETE' })
-      const json = await res.json()
-      if (!json.success) {
-        toast.error('Error al eliminar contacto — intenta de nuevo')
-      } else {
-        toast.success('Contacto eliminado')
-      }
-    } catch {
-      toast.error('Error al eliminar contacto — intenta de nuevo')
-    }
-    setDeleteTarget(null)
-    setSaving(false)
-    if (selectedContact?.id === deleteTarget.id) setSelectedContact(null)
-    fetchContacts()
-  }
-
   // ─── Contact detail ──────────────────────────────────────────────
   async function openDetail(contact: Contact) {
     setSelectedContact(contact)
@@ -428,6 +413,7 @@ export default function ContactsPage() {
                 <h1 className="text-xl font-bold">
                   {selectedContact.name}
                 </h1>
+                {selectedContact.archived_at && <ArchivedBadge />}
                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${TYPE_BADGE[selectedContact.type || 'both']}`}>
                   {TYPE_LABELS[selectedContact.type || 'both']}
                 </span>
@@ -458,13 +444,13 @@ export default function ContactsPage() {
               >
                 <Pencil className="w-4 h-4" />
               </button>
-              <button
-                onClick={() => setDeleteTarget(selectedContact)}
-                title="Eliminar contacto"
-                className="p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition-colors"
-              >
-                <Trash2 className="w-4 h-4" />
-              </button>
+              <LifecycleActions
+                entity="occupant"
+                id={selectedContact.id}
+                name={selectedContact.name}
+                archived={!!selectedContact.archived_at}
+                onChanged={() => { setSelectedContact(null); fetchContacts() }}
+              />
             </div>
           </div>
         </div>
@@ -569,34 +555,6 @@ export default function ContactsPage() {
           handleSaveEdit,
           () => setEditingContact(null)
         )}
-
-        {/* Delete confirmation from detail view */}
-        {deleteTarget && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-            <div className="card w-full max-w-md mx-4">
-              <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-2">Eliminar contacto</h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
-                ¿Eliminar a <strong className="text-gray-900 dark:text-white">{deleteTarget.name}</strong>? Esta acción no se puede deshacer.
-              </p>
-              <div className="flex justify-end gap-3">
-                <button
-                  onClick={() => setDeleteTarget(null)}
-                  className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
-                >
-                  Cancelar
-                </button>
-                <button
-                  onClick={handleDelete}
-                  disabled={saving}
-                  className="flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
-                >
-                  <Trash2 className="w-4 h-4" />
-                  Eliminar
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
       </div>
     )
   }
@@ -621,15 +579,21 @@ export default function ContactsPage() {
       </div>
 
       {/* Search */}
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-        <input
-          type="text"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder="Buscar por nombre, teléfono o email..."
-          className="input-field pl-10"
-        />
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Buscar por nombre, teléfono o email..."
+            className="input-field pl-10 w-full"
+          />
+        </div>
+        <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none shrink-0">
+          <input type="checkbox" checked={showArchived} onChange={(e) => setShowArchived(e.target.checked)} />
+          Ver archivados
+        </label>
       </div>
 
       {loading ? (
@@ -656,6 +620,7 @@ export default function ContactsPage() {
                     <h3 className="font-medium text-gray-900 dark:text-white">
                       {contact.name}
                     </h3>
+                    {contact.archived_at && <ArchivedBadge />}
                     <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${TYPE_BADGE[contact.type || 'both']}`}>
                       {TYPE_LABELS[contact.type || 'both']}
                     </span>
@@ -692,13 +657,13 @@ export default function ContactsPage() {
                   >
                     <Pencil className="w-4 h-4" />
                   </button>
-                  <button
-                    onClick={() => setDeleteTarget(contact)}
-                    title="Eliminar contacto"
-                    className="p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition-colors"
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </button>
+                  <LifecycleActions
+                    entity="occupant"
+                    id={contact.id}
+                    name={contact.name}
+                    archived={!!contact.archived_at}
+                    onChanged={fetchContacts}
+                  />
                 </div>
               </div>
             </div>
@@ -720,33 +685,6 @@ export default function ContactsPage() {
         () => setEditingContact(null)
       )}
 
-      {/* Delete Confirmation */}
-      {deleteTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-          <div className="card w-full max-w-md mx-4">
-            <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-2">Eliminar contacto</h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
-              ¿Eliminar a <strong className="text-gray-900 dark:text-white">{deleteTarget.name}</strong>? Esta acción no se puede deshacer.
-            </p>
-            <div className="flex justify-end gap-3">
-              <button
-                onClick={() => setDeleteTarget(null)}
-                className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
-              >
-                Cancelar
-              </button>
-              <button
-                onClick={handleDelete}
-                disabled={saving}
-                className="flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
-              >
-                <Trash2 className="w-4 h-4" />
-                Eliminar
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Plus, FileText, AlertTriangle, Pencil, Trash2, X, Save, RefreshCw, ChevronDown, ChevronUp, PenTool, CheckCircle2, Clock } from 'lucide-react'
+import { Plus, FileText, AlertTriangle, Pencil, X, Save, RefreshCw, ChevronDown, ChevronUp, PenTool, CheckCircle2, Clock } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { formatCurrency, formatDate, daysUntil } from '@/lib/utils'
 import { useToast } from '@/components/Toast'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
+import LifecycleActions, { ArchivedBadge } from '@/components/LifecycleActions'
 import type { Contract, ContractStatus } from '@/types'
 import { getAlertLevel, getAlertColor, getAlertText } from '@/lib/contract-alerts'
 import Link from 'next/link'
@@ -30,8 +31,8 @@ export default function ContractsPage() {
     curp_arrendatario: '',
     domicilio_arrendatario: '',
   })
-  const [deleteTarget, setDeleteTarget] = useState<Contract | null>(null)
   const [saving, setSaving] = useState(false)
+  const [showArchived, setShowArchived] = useState(false)
   const [renewTarget, setRenewTarget] = useState<Contract | null>(null)
   const [renewForm, setRenewForm] = useState({
     monthly_amount: 0,
@@ -48,10 +49,12 @@ export default function ContractsPage() {
   async function fetchContracts() {
     setLoading(true)
     // Always fetch all for alerts computation
-    const { data: all } = await supabase
+    let q = supabase
       .from('contracts')
       .select('*, signature_status, mifiel_document_id, unit:units(number, floor, type), occupant:occupants(name, phone, email)')
       .order('created_at', { ascending: false })
+    if (!showArchived) q = q.is('archived_at', null)
+    const { data: all } = await q
 
     setAllContracts(all || [])
 
@@ -65,7 +68,8 @@ export default function ContractsPage() {
 
   useEffect(() => {
     fetchContracts()
-  }, [filterStatus])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterStatus, showArchived])
 
   function openEdit(contract: Contract) {
     setEditingContract(contract)
@@ -109,25 +113,6 @@ export default function ContractsPage() {
       })
       .eq('id', editingContract.id)
     setEditingContract(null)
-    setSaving(false)
-    fetchContracts()
-  }
-
-  async function handleDelete() {
-    if (!deleteTarget) return
-    setSaving(true)
-    try {
-      const res = await fetch(`/api/contracts?id=${deleteTarget.id}`, { method: 'DELETE' })
-      const json = await res.json()
-      if (!json.success) {
-        toast.error('Error al eliminar contrato — intenta de nuevo')
-      } else {
-        toast.success('Contrato eliminado')
-      }
-    } catch {
-      toast.error('Error al eliminar contrato — intenta de nuevo')
-    }
-    setDeleteTarget(null)
     setSaving(false)
     fetchContracts()
   }
@@ -308,6 +293,10 @@ export default function ContractsPage() {
             <option key={key} value={key}>{label}</option>
           ))}
         </select>
+        <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer select-none">
+          <input type="checkbox" checked={showArchived} onChange={(e) => setShowArchived(e.target.checked)} />
+          Ver archivados
+        </label>
       </div>
 
       {loading ? (
@@ -357,6 +346,7 @@ export default function ContractsPage() {
                           <span className={statusBadge[contract.status] || 'badge-expired'}>
                             {statusLabels[contract.status] || contract.status}
                           </span>
+                          {contract.archived_at && <ArchivedBadge />}
                           {alertLevel && days !== null && (
                             <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border ${getAlertColor(alertLevel)}`}>
                               <AlertTriangle className="w-3 h-3" />
@@ -418,13 +408,13 @@ export default function ContractsPage() {
                       >
                         <Pencil className="w-4 h-4" />
                       </button>
-                      <button
-                        onClick={() => setDeleteTarget(contract)}
-                        title="Eliminar contrato"
-                        className="p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition-colors"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
+                      <LifecycleActions
+                        entity="contract"
+                        id={contract.id}
+                        name={`Contrato de ${occupantName}`}
+                        archived={!!contract.archived_at}
+                        onChanged={fetchContracts}
+                      />
                     </div>
                   </div>
                 </div>
@@ -587,33 +577,6 @@ export default function ContractsPage() {
         </div>
       )}
 
-      {/* Delete Confirmation */}
-      {deleteTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-          <div className="card w-full max-w-md mx-4">
-            <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-2">Eliminar contrato</h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
-              ¿Eliminar contrato de <strong className="text-gray-900 dark:text-white">{(deleteTarget.occupant as { name: string } | null)?.name || 'Sin inquilino'}</strong>? Esta acción no se puede deshacer.
-            </p>
-            <div className="flex justify-end gap-3">
-              <button
-                onClick={() => setDeleteTarget(null)}
-                className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
-              >
-                Cancelar
-              </button>
-              <button
-                onClick={handleDelete}
-                disabled={saving}
-                className="flex items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
-              >
-                <Trash2 className="w-4 h-4" />
-                Eliminar
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Renew Modal */}
       {renewTarget && (

--- a/src/app/units/page.tsx
+++ b/src/app/units/page.tsx
@@ -14,6 +14,7 @@ import EmptyState from '@/components/EmptyState'
 import UnitModal from './UnitModal'
 import BulkUnitsModal from './BulkUnitsModal'
 import { StatusBadge, type StatusKind } from '@/components/ui/status'
+import LifecycleActions, { ArchivedBadge } from '@/components/LifecycleActions'
 import { useActiveContext } from '@/lib/useActiveContext'
 
 const statusLabels: Record<UnitStatus, string> = {
@@ -71,6 +72,7 @@ export default function UnitsPage() {
   // (ALL_BUILDINGS no permite bulk — Supabase requiere building_id NOT NULL).
   const [bulkOpen, setBulkOpen] = useState(false)
   const [bulkBanner, setBulkBanner] = useState<string | null>(null)
+  const [showArchived, setShowArchived] = useState(false)
 
   // Buildings de la org activa (lo que el user puede ver/elegir)
   const orgBuildings = useMemo(
@@ -103,6 +105,7 @@ export default function UnitsPage() {
     if (buildingFilter !== ALL_BUILDINGS) {
       query = query.eq('building_id', buildingFilter)
     }
+    if (!showArchived) query = query.is('archived_at', null)
 
     const { data } = await query
     setUnits((data as UnitWithBuilding[]) || [])
@@ -113,7 +116,7 @@ export default function UnitsPage() {
     if (ctxLoading) return
     fetchUnits()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ctxLoading, activeOrgId, buildingFilter])
+  }, [ctxLoading, activeOrgId, buildingFilter, showArchived])
 
   const counts = useMemo(() => {
     const c = { total: units.length, occupied: 0, vacant: 0, maintenance: 0, reserved: 0 }
@@ -207,6 +210,10 @@ export default function UnitsPage() {
           <p className="text-[13px] muted-text mt-0.5 truncate">{subtitle}</p>
         </div>
         <div className="flex items-center gap-2 self-start sm:self-auto">
+          <label className="flex items-center gap-1.5 text-[12px] muted-text cursor-pointer select-none mr-1">
+            <input type="checkbox" checked={showArchived} onChange={(e) => setShowArchived(e.target.checked)} />
+            Ver archivadas
+          </label>
           {/*
             Sprint 6 followup #2: botón "Generar varias" portado del wizard
             de onboarding (Cantidad / Prefijo / Empezar en / Tipo). Solo
@@ -366,7 +373,10 @@ export default function UnitsPage() {
                     className="px-4 py-2 font-medium tabular-nums"
                     style={{ color: 'var(--baw-text)' }}
                   >
-                    {unit.number}
+                    <span className="inline-flex items-center gap-2">
+                      {unit.number}
+                      {unit.archived_at && <ArchivedBadge />}
+                    </span>
                   </td>
                   {showBuildingColumn && (
                     <td className="px-4 py-2 muted-text">
@@ -428,6 +438,13 @@ export default function UnitsPage() {
                           </option>
                         ))}
                       </select>
+                      <LifecycleActions
+                        entity="unit"
+                        id={unit.id}
+                        name={`Unidad ${unit.number}`}
+                        archived={!!unit.archived_at}
+                        onChanged={fetchUnits}
+                      />
                     </div>
                   </td>
                 </tr>

--- a/src/components/LifecycleActions.tsx
+++ b/src/components/LifecycleActions.tsx
@@ -1,0 +1,349 @@
+'use client'
+
+// BaW OS — Acciones de ciclo de vida reusables (Archivar / Restaurar / Eliminar).
+// Uniforme para edificios, unidades, contratos e inquilinos. Habla con /api/lifecycle.
+
+import { useState, useRef, useEffect } from 'react'
+import { MoreHorizontal, Archive, ArchiveRestore, Trash2, AlertTriangle, Loader2 } from 'lucide-react'
+import { useToast } from '@/components/Toast'
+
+type Entity = 'building' | 'unit' | 'contract' | 'occupant'
+
+interface Blocker {
+  key: string
+  label: string
+  count: number
+  hardFloor: boolean
+}
+
+interface Preflight {
+  canDelete: boolean
+  canForce: boolean
+  blockers: Blocker[]
+}
+
+export default function LifecycleActions({
+  entity,
+  id,
+  name,
+  archived,
+  onChanged,
+}: {
+  entity: Entity
+  id: string
+  name: string
+  archived: boolean
+  onChanged: () => void
+}) {
+  const toast = useToast()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [dialog, setDialog] = useState<null | 'archive' | 'restore' | 'delete'>(null)
+  const [preflight, setPreflight] = useState<Preflight | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [confirmText, setConfirmText] = useState('')
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!menuOpen) return
+    const onClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [menuOpen])
+
+  async function post(action: 'archive' | 'restore' | 'delete' | 'force_delete') {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/lifecycle', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ entity, id, action }),
+      })
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        if (res.status === 409 && Array.isArray(json.blockers)) {
+          // Borrado bloqueado: mostramos el detalle en el diálogo.
+          setPreflight({
+            canDelete: false,
+            canForce: json.blockers.length > 0 && !json.blockers.some((b: Blocker) => b.hardFloor),
+            blockers: json.blockers,
+          })
+          setDialog('delete')
+          return
+        }
+        toast.error(json.error || `Error (${res.status})`)
+        return
+      }
+      const verb =
+        action === 'archive' ? 'archivado' : action === 'restore' ? 'restaurado' : 'eliminado'
+      toast.success(`${cap(LABEL[entity])} ${verb}`)
+      close()
+      onChanged()
+    } catch {
+      toast.error('Error de red — intenta de nuevo')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function openDelete() {
+    setMenuOpen(false)
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/lifecycle?entity=${entity}&id=${id}`)
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        toast.error(json.error || 'No se pudo verificar dependencias')
+        return
+      }
+      setPreflight(json.data as Preflight)
+      setConfirmText('')
+      setDialog('delete')
+    } catch {
+      toast.error('Error de red — intenta de nuevo')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function close() {
+    setDialog(null)
+    setPreflight(null)
+    setConfirmText('')
+  }
+
+  return (
+    <div className="relative inline-block" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setMenuOpen((o) => !o)}
+        className="p-1.5 rounded-lg transition-colors"
+        style={{ color: 'var(--baw-muted)' }}
+        title="Acciones"
+        aria-label="Acciones"
+      >
+        {loading && !dialog ? <Loader2 className="w-4 h-4 animate-spin" /> : <MoreHorizontal className="w-4 h-4" />}
+      </button>
+
+      {menuOpen && (
+        <div
+          className="absolute right-0 mt-1 w-44 rounded-lg shadow-lg z-30 overflow-hidden"
+          style={{ backgroundColor: 'var(--baw-elevated)', border: '1px solid var(--baw-border)' }}
+        >
+          {archived ? (
+            <MenuItem icon={<ArchiveRestore className="w-4 h-4" />} onClick={() => { setMenuOpen(false); setDialog('restore') }}>
+              Restaurar
+            </MenuItem>
+          ) : (
+            <MenuItem icon={<Archive className="w-4 h-4" />} onClick={() => { setMenuOpen(false); setDialog('archive') }}>
+              Archivar
+            </MenuItem>
+          )}
+          <MenuItem icon={<Trash2 className="w-4 h-4" />} danger onClick={openDelete}>
+            Eliminar
+          </MenuItem>
+        </div>
+      )}
+
+      {/* Diálogo archivar / restaurar */}
+      {(dialog === 'archive' || dialog === 'restore') && (
+        <Dialog onClose={close}>
+          <h3 className="text-[15px] font-semibold mb-2" style={{ color: 'var(--baw-text)' }}>
+            {dialog === 'archive' ? 'Archivar' : 'Restaurar'} {LABEL[entity]}
+          </h3>
+          <p className="text-[13px] mb-4" style={{ color: 'var(--baw-muted)' }}>
+            {dialog === 'archive' ? (
+              <>
+                <strong>{name}</strong> se ocultará de la operación pero conserva todo su historial y
+                vínculos. Puedes restaurarlo cuando quieras.
+                {entity === 'building' && ' Sus unidades también se archivarán.'}
+              </>
+            ) : (
+              <>
+                <strong>{name}</strong> volverá a aparecer en la operación.
+                {entity === 'building' && ' Sus unidades archivadas también se restaurarán.'}
+              </>
+            )}
+          </p>
+          <DialogButtons>
+            <button className="btn-secondary text-[13px] px-4 py-1.5" onClick={close} disabled={loading}>Cancelar</button>
+            <button
+              className="btn-primary text-[13px] px-4 py-1.5 disabled:opacity-50"
+              onClick={() => post(dialog === 'archive' ? 'archive' : 'restore')}
+              disabled={loading}
+            >
+              {loading ? 'Procesando…' : dialog === 'archive' ? 'Archivar' : 'Restaurar'}
+            </button>
+          </DialogButtons>
+        </Dialog>
+      )}
+
+      {/* Diálogo eliminar */}
+      {dialog === 'delete' && preflight && (
+        <Dialog onClose={close}>
+          {preflight.canDelete ? (
+            <>
+              <h3 className="text-[15px] font-semibold mb-2" style={{ color: 'var(--baw-danger-fg)' }}>
+                Eliminar {LABEL[entity]}
+              </h3>
+              <p className="text-[13px] mb-4" style={{ color: 'var(--baw-muted)' }}>
+                Vas a eliminar <strong>{name}</strong> de forma <strong>permanente</strong>. Esta acción
+                no se puede deshacer.
+              </p>
+              <DialogButtons>
+                <button className="btn-secondary text-[13px] px-4 py-1.5" onClick={close} disabled={loading}>Cancelar</button>
+                <button
+                  className="text-[13px] px-4 py-1.5 rounded-lg font-medium text-white disabled:opacity-50"
+                  style={{ backgroundColor: 'var(--baw-danger-fg)' }}
+                  onClick={() => post('delete')}
+                  disabled={loading}
+                >
+                  {loading ? 'Eliminando…' : 'Eliminar permanentemente'}
+                </button>
+              </DialogButtons>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-2 mb-2">
+                <AlertTriangle className="w-5 h-5" style={{ color: 'var(--baw-warning-fg)' }} />
+                <h3 className="text-[15px] font-semibold" style={{ color: 'var(--baw-text)' }}>
+                  No se puede eliminar directamente
+                </h3>
+              </div>
+              <p className="text-[13px] mb-2" style={{ color: 'var(--baw-muted)' }}>
+                <strong>{name}</strong> tiene registros ligados:
+              </p>
+              <ul className="text-[13px] mb-3 space-y-1">
+                {preflight.blockers.map((b) => (
+                  <li key={b.key} className="flex items-center gap-2">
+                    <span
+                      className="inline-block w-1.5 h-1.5 rounded-full"
+                      style={{ backgroundColor: b.hardFloor ? 'var(--baw-danger-fg)' : 'var(--baw-warning-fg)' }}
+                    />
+                    <span style={{ color: 'var(--baw-text)' }}>{b.label}</span>
+                    {b.hardFloor && <span className="text-[11px]" style={{ color: 'var(--baw-danger-fg)' }}>(no se puede borrar)</span>}
+                  </li>
+                ))}
+              </ul>
+
+              {preflight.blockers.some((b) => b.hardFloor) ? (
+                <p className="text-[13px] mb-4 p-2 rounded" style={{ backgroundColor: 'var(--baw-danger-bg-soft, var(--baw-elevated))', color: 'var(--baw-muted)' }}>
+                  Incluye <strong>pagos</strong> (historia financiera): no se puede eliminar ni a la fuerza.
+                  La opción correcta es <strong>archivar</strong>.
+                </p>
+              ) : (
+                <p className="text-[13px] mb-4" style={{ color: 'var(--baw-muted)' }}>
+                  Recomendado: <strong>archivar</strong> (conserva todo). Si de verdad necesitas borrarlo,
+                  el <strong>force-delete</strong> eliminará también esos registros en cascada —
+                  es <strong>permanente</strong>.
+                </p>
+              )}
+
+              {preflight.canForce && (
+                <div className="mb-4">
+                  <label className="block text-[11px] font-medium mb-1" style={{ color: 'var(--baw-muted)' }}>
+                    Para forzar el borrado, escribe <strong>ELIMINAR</strong>:
+                  </label>
+                  <input
+                    className="input-field w-full"
+                    value={confirmText}
+                    onChange={(e) => setConfirmText(e.target.value)}
+                    placeholder="ELIMINAR"
+                  />
+                </div>
+              )}
+
+              <DialogButtons>
+                <button className="btn-secondary text-[13px] px-4 py-1.5" onClick={close} disabled={loading}>Cancelar</button>
+                {!archived && (
+                  <button className="btn-primary text-[13px] px-4 py-1.5 disabled:opacity-50" onClick={() => post('archive')} disabled={loading}>
+                    {loading ? 'Procesando…' : 'Archivar'}
+                  </button>
+                )}
+                {preflight.canForce && (
+                  <button
+                    className="text-[13px] px-4 py-1.5 rounded-lg font-medium text-white disabled:opacity-40"
+                    style={{ backgroundColor: 'var(--baw-danger-fg)' }}
+                    onClick={() => post('force_delete')}
+                    disabled={loading || confirmText !== 'ELIMINAR'}
+                  >
+                    {loading ? 'Eliminando…' : 'Forzar borrado'}
+                  </button>
+                )}
+              </DialogButtons>
+            </>
+          )}
+        </Dialog>
+      )}
+    </div>
+  )
+}
+
+const LABEL: Record<Entity, string> = {
+  building: 'edificio',
+  unit: 'unidad',
+  contract: 'contrato',
+  occupant: 'inquilino',
+}
+
+function cap(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+function MenuItem({
+  icon,
+  children,
+  onClick,
+  danger,
+}: {
+  icon: React.ReactNode
+  children: React.ReactNode
+  onClick: () => void
+  danger?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-center gap-2 px-3 py-2 text-[13px] text-left transition-colors hover:opacity-80"
+      style={{ color: danger ? 'var(--baw-danger-fg)' : 'var(--baw-text)' }}
+    >
+      {icon}
+      {children}
+    </button>
+  )
+}
+
+function Dialog({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-xl p-5"
+        style={{ backgroundColor: 'var(--baw-surface)', border: '1px solid var(--baw-border)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function DialogButtons({ children }: { children: React.ReactNode }) {
+  return <div className="flex items-center justify-end gap-2 flex-wrap">{children}</div>
+}
+
+export function ArchivedBadge() {
+  return (
+    <span
+      className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded-full font-medium"
+      style={{ backgroundColor: 'var(--baw-neutral-bg-soft)', color: 'var(--baw-neutral-fg)' }}
+    >
+      Archivado
+    </span>
+  )
+}

--- a/src/lib/agents/v1/classifier.ts
+++ b/src/lib/agents/v1/classifier.ts
@@ -81,6 +81,10 @@ export const DEFAULT_ACTION_CLASSIFICATION: Record<string, Classification> = {
   // Agents
   'agent.run': 'LOG',
   'policy.modify': 'REQUIRE_APPROVAL',
+
+  // Lifecycle — archivado por agente (reversible, pero SIEMPRE con aprobación).
+  // Los agentes NUNCA eliminan (no existe endpoint de borrado para agentes).
+  'lifecycle.archive': 'REQUIRE_APPROVAL',
 }
 
 /**
@@ -100,6 +104,16 @@ const IRREVERSIBLE_EXTERNAL = new Set([
   'contract.sign',
   'contract.terminate',
   'policy.modify',
+])
+
+// Archivado por agente: reversible, pero por decisión SIEMPRE requiere aprobación
+// humana (no se degrada a AUTO ni por trigger humano ni por autonomía L4).
+const AGENT_ARCHIVE = new Set(['lifecycle.archive'])
+
+// Guardrail duro combinado: ni trigger humano ni L4 lo bajan a AUTO.
+const HARD_APPROVAL = new Set<string>([
+  ...Array.from(IRREVERSIBLE_EXTERNAL),
+  ...Array.from(AGENT_ARCHIVE),
 ])
 
 /**
@@ -139,7 +153,7 @@ export async function resolveActionClassification(
   if (
     triggerSource === 'human' &&
     resolved.classification === 'REQUIRE_APPROVAL' &&
-    !IRREVERSIBLE_EXTERNAL.has(actionType)
+    !HARD_APPROVAL.has(actionType)
   ) {
     return {
       classification: 'AUTO',
@@ -189,7 +203,7 @@ async function resolveBaseClassification(
   if (perAction[actionType]) {
     const override = perAction[actionType]
     if (
-      IRREVERSIBLE_EXTERNAL.has(actionType) &&
+      HARD_APPROVAL.has(actionType) &&
       override !== 'REQUIRE_APPROVAL'
     ) {
       // Locked: no se puede bajar el guardrail de irreversibles externos
@@ -220,7 +234,7 @@ async function resolveBaseClassification(
 
   // L4: REQUIRE_APPROVAL → AUTO, excepto irreversibles externos
   if (autonomyLevel === 4 && baseDefault === 'REQUIRE_APPROVAL') {
-    if (IRREVERSIBLE_EXTERNAL.has(actionType)) {
+    if (HARD_APPROVAL.has(actionType)) {
       return {
         classification: 'REQUIRE_APPROVAL',
         source: 'irreversible_lock',

--- a/src/lib/agents/v1/dispatcher.ts
+++ b/src/lib/agents/v1/dispatcher.ts
@@ -7,6 +7,7 @@
 // Mantener este dispatcher en sync con los handlers de cada endpoint write.
 
 import { createServiceClient } from '@/lib/supabase'
+import { archiveEntity, ENTITY_TABLE, type LifecycleEntity } from '@/lib/lifecycle'
 
 export interface DispatchContext {
   approvalId: string
@@ -234,6 +235,29 @@ export async function dispatchApprovedAction(ctx: DispatchContext): Promise<Disp
         entityType: 'message',
         entityId: messageId,
       }
+    }
+
+    // Lifecycle — archivar (agentes pueden archivar con aprobación, nunca eliminar).
+    case 'lifecycle.archive': {
+      const p = ctx.payload as { entity?: LifecycleEntity; id?: string }
+      if (!p.entity || !p.id || !(p.entity in ENTITY_TABLE)) {
+        return { ok: false, error: 'payload inválido: entity/id requeridos' }
+      }
+      // Scoping por org: el agente solo archiva entidades de su propia org.
+      const { data: row } = await supabase
+        .from(ENTITY_TABLE[p.entity])
+        .select('org_id')
+        .eq('id', p.id)
+        .maybeSingle()
+      if (!row || (row as { org_id: string }).org_id !== ctx.orgId) {
+        return { ok: false, error: 'entidad no encontrada en esta organización' }
+      }
+      try {
+        await archiveEntity(supabase, p.entity, p.id)
+      } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : 'archive failed' }
+      }
+      return { ok: true, result: { archived: p.id }, entityType: p.entity, entityId: p.id }
     }
 
     // Acciones que requieren aprobación pero deben ejecutarse mediante un runner

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -1,0 +1,242 @@
+// BaW OS — Motor de ciclo de vida (Archivar / Restaurar / Eliminar / Force-delete)
+//
+// Modelo (decisión de Fran):
+//   - Archivar  → reversible, conserva todo. Marca `archived_at`. Acción principal.
+//   - Eliminar  → permanente, SOLO si la entidad está "limpia" (sin historia ligada).
+//   - Force-delete → para casos extremos, borra en cascada lo dependiente, PERO
+//     nunca cruza el "piso duro": si hay PAGOS ligados, se rechaza siempre
+//     (la historia financiera no se destruye jamás, ni con force).
+//
+// Este módulo centraliza el conocimiento de las llaves foráneas (ver el mapa en
+// supabase/migrations) para que la UI y la API no lo dupliquen.
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DB = SupabaseClient<any, 'public', any>
+
+export type LifecycleEntity = 'building' | 'unit' | 'contract' | 'occupant'
+
+export const ENTITY_TABLE: Record<LifecycleEntity, string> = {
+  building: 'buildings',
+  unit: 'units',
+  contract: 'contracts',
+  occupant: 'occupants',
+}
+
+export const ENTITY_LABEL: Record<LifecycleEntity, string> = {
+  building: 'edificio',
+  unit: 'unidad',
+  contract: 'contrato',
+  occupant: 'inquilino',
+}
+
+export interface Blocker {
+  key: string
+  label: string // legible para el usuario (ej. "2 contratos")
+  count: number
+  hardFloor: boolean // true = ni siquiera force-delete puede pasarlo (pagos)
+}
+
+export interface DeletePreflight {
+  canDelete: boolean // sin bloqueadores → eliminar directo
+  canForce: boolean // hay bloqueadores pero ninguno es piso duro → force posible
+  blockers: Blocker[]
+}
+
+// ── helpers de conteo ────────────────────────────────────────────────────────
+
+async function countWhere(db: DB, table: string, col: string, val: string): Promise<number> {
+  const { count } = await db.from(table).select('id', { count: 'exact', head: true }).eq(col, val)
+  return count ?? 0
+}
+
+async function contractIdsForUnit(db: DB, unitId: string): Promise<string[]> {
+  const { data } = await db.from('contracts').select('id').eq('unit_id', unitId)
+  return (data || []).map((r: { id: string }) => r.id)
+}
+
+async function contractIdsForOccupant(db: DB, occupantId: string): Promise<string[]> {
+  const { data } = await db.from('contracts').select('id').eq('occupant_id', occupantId)
+  return (data || []).map((r: { id: string }) => r.id)
+}
+
+async function countPaymentsForContracts(db: DB, contractIds: string[]): Promise<number> {
+  if (contractIds.length === 0) return 0
+  const { count } = await db
+    .from('payments')
+    .select('id', { count: 'exact', head: true })
+    .in('contract_id', contractIds)
+  return count ?? 0
+}
+
+function plural(n: number, singular: string, plural_: string): string {
+  return `${n} ${n === 1 ? singular : plural_}`
+}
+
+// ── preflight: qué bloquea el borrado ────────────────────────────────────────
+
+export async function checkBlockers(
+  db: DB,
+  entity: LifecycleEntity,
+  id: string
+): Promise<DeletePreflight> {
+  const blockers: Blocker[] = []
+
+  if (entity === 'building') {
+    const units = await countWhere(db, 'units', 'building_id', id)
+    if (units > 0) blockers.push({ key: 'units', label: plural(units, 'unidad', 'unidades'), count: units, hardFloor: false })
+  } else if (entity === 'unit') {
+    const [contracts, reservations, incidents] = await Promise.all([
+      countWhere(db, 'contracts', 'unit_id', id),
+      countWhere(db, 'reservations', 'unit_id', id),
+      countWhere(db, 'incidents', 'unit_id', id),
+    ])
+    const contractIds = await contractIdsForUnit(db, id)
+    const payments = await countPaymentsForContracts(db, contractIds)
+    if (payments > 0) blockers.push({ key: 'payments', label: plural(payments, 'pago', 'pagos'), count: payments, hardFloor: true })
+    if (contracts > 0) blockers.push({ key: 'contracts', label: plural(contracts, 'contrato', 'contratos'), count: contracts, hardFloor: false })
+    if (reservations > 0) blockers.push({ key: 'reservations', label: plural(reservations, 'reserva', 'reservas'), count: reservations, hardFloor: false })
+    if (incidents > 0) blockers.push({ key: 'incidents', label: plural(incidents, 'incidencia', 'incidencias'), count: incidents, hardFloor: false })
+  } else if (entity === 'contract') {
+    const payments = await countPaymentsForContracts(db, [id])
+    if (payments > 0) blockers.push({ key: 'payments', label: plural(payments, 'pago', 'pagos'), count: payments, hardFloor: true })
+  } else if (entity === 'occupant') {
+    const [contracts, reservations, incidents] = await Promise.all([
+      countWhere(db, 'contracts', 'occupant_id', id),
+      countWhere(db, 'reservations', 'guest_id', id),
+      countWhere(db, 'incidents', 'reported_by', id),
+    ])
+    const contractIds = await contractIdsForOccupant(db, id)
+    const payments = await countPaymentsForContracts(db, contractIds)
+    if (payments > 0) blockers.push({ key: 'payments', label: plural(payments, 'pago', 'pagos'), count: payments, hardFloor: true })
+    if (contracts > 0) blockers.push({ key: 'contracts', label: plural(contracts, 'contrato', 'contratos'), count: contracts, hardFloor: false })
+    if (reservations > 0) blockers.push({ key: 'reservations', label: plural(reservations, 'reserva', 'reservas'), count: reservations, hardFloor: false })
+    if (incidents > 0) blockers.push({ key: 'incidents', label: plural(incidents, 'incidencia', 'incidencias'), count: incidents, hardFloor: false })
+  }
+
+  const hasHardFloor = blockers.some((b) => b.hardFloor)
+  return {
+    canDelete: blockers.length === 0,
+    canForce: blockers.length > 0 && !hasHardFloor,
+    blockers,
+  }
+}
+
+// ── archivar / restaurar ─────────────────────────────────────────────────────
+
+export async function archiveEntity(db: DB, entity: LifecycleEntity, id: string): Promise<void> {
+  const now = new Date().toISOString()
+  const { error } = await db.from(ENTITY_TABLE[entity]).update({ archived_at: now }).eq('id', id)
+  if (error) throw new Error(error.message)
+  // Archivar un edificio archiva en cascada sus unidades.
+  if (entity === 'building') {
+    await db.from('units').update({ archived_at: now }).eq('building_id', id).is('archived_at', null)
+  }
+}
+
+export async function restoreEntity(db: DB, entity: LifecycleEntity, id: string): Promise<void> {
+  const { error } = await db.from(ENTITY_TABLE[entity]).update({ archived_at: null }).eq('id', id)
+  if (error) throw new Error(error.message)
+  if (entity === 'building') {
+    await db.from('units').update({ archived_at: null }).eq('building_id', id)
+  }
+}
+
+// ── eliminar (limpio) ────────────────────────────────────────────────────────
+
+export class LifecycleError extends Error {
+  constructor(message: string, public blockers?: Blocker[]) {
+    super(message)
+  }
+}
+
+/** Borra una entidad SOLO si está limpia. Lanza LifecycleError con blockers si no. */
+export async function deleteClean(db: DB, entity: LifecycleEntity, id: string): Promise<void> {
+  const pre = await checkBlockers(db, entity, id)
+  if (!pre.canDelete) {
+    throw new LifecycleError(`La ${ENTITY_LABEL[entity]} tiene registros ligados`, pre.blockers)
+  }
+  await hardDelete(db, entity, id)
+}
+
+async function hardDelete(db: DB, entity: LifecycleEntity, id: string): Promise<void> {
+  if (entity === 'building') {
+    // ownership_stakes es CASCADE en DB, pero lo limpiamos explícito por claridad.
+    await db.from('ownership_stakes').delete().eq('building_id', id)
+  }
+  const { error } = await db.from(ENTITY_TABLE[entity]).delete().eq('id', id)
+  if (error) throw new LifecycleError(error.message)
+}
+
+// ── force-delete (cascada, con piso duro en pagos) ───────────────────────────
+
+/**
+ * Borra en cascada para casos extremos. Rechaza SIEMPRE si hay pagos ligados
+ * (piso duro: la historia financiera no se destruye). Borra explícitamente los
+ * dependientes operativos (reservas, incidencias, contratos sin pagos, etc.).
+ */
+export async function forceDelete(db: DB, entity: LifecycleEntity, id: string): Promise<void> {
+  if (entity === 'contract') {
+    if ((await countPaymentsForContracts(db, [id])) > 0) {
+      throw new LifecycleError('No se puede eliminar: el contrato tiene pagos registrados (historia financiera).')
+    }
+    await forceDeleteContract(db, id)
+    return
+  }
+
+  if (entity === 'unit') {
+    const contractIds = await contractIdsForUnit(db, id)
+    if ((await countPaymentsForContracts(db, contractIds)) > 0) {
+      throw new LifecycleError('No se puede eliminar: la unidad tiene pagos ligados a sus contratos.')
+    }
+    for (const cid of contractIds) await forceDeleteContract(db, cid)
+    await db.from('reservations').delete().eq('unit_id', id)
+    await db.from('incidents').delete().eq('unit_id', id)
+    // units: CASCADE limpia unit_spaces/media_assets/booking; SET NULL en expenses/crm/ancillary
+    const { error } = await db.from('units').delete().eq('id', id)
+    if (error) throw new LifecycleError(error.message)
+    return
+  }
+
+  if (entity === 'occupant') {
+    const contractIds = await contractIdsForOccupant(db, id)
+    if ((await countPaymentsForContracts(db, contractIds)) > 0) {
+      throw new LifecycleError('No se puede eliminar: el inquilino tiene pagos ligados a sus contratos.')
+    }
+    for (const cid of contractIds) await forceDeleteContract(db, cid)
+    await db.from('reservations').delete().eq('guest_id', id)
+    await db.from('incidents').delete().eq('reported_by', id)
+    await db.from('whatsapp_notifications').delete().eq('occupant_id', id)
+    const { error } = await db.from('occupants').delete().eq('id', id)
+    if (error) throw new LifecycleError(error.message)
+    return
+  }
+
+  if (entity === 'building') {
+    const { data: units } = await db.from('units').select('id').eq('building_id', id)
+    const unitIds = (units || []).map((u: { id: string }) => u.id)
+    // Pre-chequeo de piso duro en TODAS las unidades antes de borrar nada.
+    for (const uid of unitIds) {
+      const cids = await contractIdsForUnit(db, uid)
+      if ((await countPaymentsForContracts(db, cids)) > 0) {
+        throw new LifecycleError('No se puede eliminar: una unidad del edificio tiene pagos registrados.')
+      }
+    }
+    for (const uid of unitIds) await forceDelete(db, 'unit', uid)
+    await db.from('ownership_stakes').delete().eq('building_id', id)
+    const { error } = await db.from('buildings').delete().eq('id', id)
+    if (error) throw new LifecycleError(error.message)
+    return
+  }
+}
+
+// Contrato sin pagos: limpia dependientes con FK NO ACTION antes de borrar.
+async function forceDeleteContract(db: DB, contractId: string): Promise<void> {
+  await db.from('invoices').delete().eq('contract_id', contractId)
+  await db.from('payment_ledger').delete().eq('contract_id', contractId)
+  await db.from('whatsapp_notifications').delete().eq('contract_id', contractId)
+  // ancillary_charges es CASCADE; el contrato se borra al final.
+  const { error } = await db.from('contracts').delete().eq('id', contractId)
+  if (error) throw new LifecycleError(error.message)
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,7 @@ export interface Building {
   postal_code?: string | null
   parking_total?: number // pool de cajones del edificio
   notes?: string | null
+  archived_at?: string | null
   created_at: string
   updated_at: string
 }
@@ -118,6 +119,7 @@ export interface Unit {
   description_long?: string
   amenities?: string[] | AmenityItem[]
   notes?: string
+  archived_at?: string | null
   created_at: string
   updated_at: string
 }
@@ -183,6 +185,7 @@ export interface Occupant {
   cp_fiscal?: string
   email_factura?: string
   requiere_factura?: boolean
+  archived_at?: string | null
   created_at: string
   updated_at: string
   // CRM enrichment (joined)
@@ -216,6 +219,7 @@ export interface Contract {
   // Mifiel digital signature
   mifiel_document_id?: string
   signature_status?: 'none' | 'pending' | 'signed'
+  archived_at?: string | null
   created_at: string
   updated_at: string
   // Relations (joined)

--- a/supabase/migrations/20260622_archive_lifecycle.sql
+++ b/supabase/migrations/20260622_archive_lifecycle.sql
@@ -1,0 +1,20 @@
+-- BaW OS — Lifecycle: archivado uniforme (soft-delete) para entidades core.
+--
+-- Agrega `archived_at timestamptz` (NULL = activo) a las entidades que el feature
+-- de Archivar/Eliminar maneja. No se usa un enum de status para esto porque los
+-- status operativos (units.status='inactive', contracts.status='terminated', ...)
+-- significan cosas distintas a "archivado/oculto". `archived_at` es ortogonal y
+-- uniforme entre tablas.
+--
+-- Aditiva e idempotente. Las listas filtran archived_at IS NULL por defecto.
+
+ALTER TABLE public.buildings ADD COLUMN IF NOT EXISTS archived_at timestamptz;
+ALTER TABLE public.units     ADD COLUMN IF NOT EXISTS archived_at timestamptz;
+ALTER TABLE public.contracts ADD COLUMN IF NOT EXISTS archived_at timestamptz;
+ALTER TABLE public.occupants ADD COLUMN IF NOT EXISTS archived_at timestamptz;
+
+-- Índices parciales para listar "activos" rápido (la mayoría de las consultas).
+CREATE INDEX IF NOT EXISTS idx_buildings_active ON public.buildings (org_id) WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_units_active     ON public.units (org_id)     WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_contracts_active ON public.contracts (org_id) WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_occupants_active ON public.occupants (org_id) WHERE archived_at IS NULL;


### PR DESCRIPTION
## Qué hace
Feature uniforme de **Archivar / Restaurar / Eliminar** para las 4 entidades core (**edificios, unidades, contratos, inquilinos**), con el modelo que acordamos:
- **Archivar** (reversible, conserva todo) = acción principal.
- **Eliminar** permanente = solo si la entidad está "limpia" (sin historia ligada).
- **Force-delete** (casos extremos, con advertencia + type-to-confirm) que borra en cascada — **pero con piso duro en pagos**: si hay historia financiera, se rechaza siempre, ni a la fuerza.
- **Agentes:** pueden **archivar con aprobación**, **nunca eliminar**.

Resuelve el bug original (el edificio "2020" no se podía borrar porque no existía forma de quitar/archivar unidades).

## Arquitectura (motor, no parches por página)
- **`supabase/migrations/20260622_archive_lifecycle.sql`** — columna `archived_at` en buildings/units/contracts/occupants + índices parciales de "activos".
- **`src/lib/lifecycle.ts`** — núcleo: chequeo de bloqueadores por FK, archivar/restaurar (archivar edificio cascada a sus unidades), borrado limpio, y force-delete con cascada segura (limos reservas/incidencias/contratos-sin-pagos) y **piso duro en pagos**.
- **`/api/lifecycle`** (owner/admin, scoping estricto por org) — `GET` preflight de dependencias; `POST` archive/restore/delete/force_delete; 409 con detalle de bloqueadores.
- **`<LifecycleActions>`** — UI reusable (menú ⋯, diálogo que explica los bloqueadores, force-delete con type-to-confirm `ELIMINAR`). Cableado a las 4 páginas + toggle **"Ver archivados"** + badge **Archivado**.

## 🔒 Seguridad / fixes de paso
- **`/api/contracts` DELETE ya NO borra los pagos en silencio** (antes los eliminaba) — ahora rechaza con 409 si hay pagos.
- Force-delete jamás cruza el piso de pagos.

## 🤖 Agentes
- Nuevo `lifecycle.archive` en el **guardrail duro** del classifier → **siempre requiere aprobación** (ni trigger humano ni L4 lo degradan).
- Endpoint `POST /v1/lifecycle` (scope `lifecycle:archive`) + caso en el dispatcher con **scoping por org**. **No hay borrado vía agentes.**
- Scope `lifecycle:archive` agregado a la UI de credenciales.

## ⚠️ Orden de deploy (IMPORTANTE)
La migración es **obligatoria ANTES del deploy del código**: las 4 páginas ahora consultan `archived_at`. Si el código sale sin la columna, **/buildings, /units, /contracts y /contacts dan error**. Aplicar primero:
```sql
ALTER TABLE public.buildings ADD COLUMN IF NOT EXISTS archived_at timestamptz;
ALTER TABLE public.units     ADD COLUMN IF NOT EXISTS archived_at timestamptz;
ALTER TABLE public.contracts ADD COLUMN IF NOT EXISTS archived_at timestamptz;
ALTER TABLE public.occupants ADD COLUMN IF NOT EXISTS archived_at timestamptz;
```
(la migración incluye además los índices parciales).

## Validación
- `npx tsc --noEmit` ✅
- `eslint` (archivos tocados) ✅

## Fuera de alcance (anotado para después)
- Mejorar la administración de **STR / rentas cortas** + integración **Channex** → PR aparte (como hablamos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_