### PR TITLE
fix(ui): sincronizar los toggles Human/Agent (sidebar + header)

### DIFF
--- a/src/components/ViewModeSwitch.tsx
+++ b/src/components/ViewModeSwitch.tsx
@@ -3,13 +3,23 @@
 // BaW OS — Switch Human ↔ Agent
 // Drop-in: monta donde quieras (sidebar, navbar, header).
 // Persiste vía POST /api/me/view-mode → cookie baw_view_mode (preferencia de UI).
+// El estado visual es COMPARTIDO entre todas las instancias vía view-mode-store,
+// para que los dos toggles (sidebar + header) nunca se desincronicen.
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import { useRouter } from 'next/navigation'
 import { User2, Bot } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import {
+  getViewModeSnapshot,
+  isViewModeInitialized,
+  seedViewMode,
+  setViewModeLocal,
+  subscribeViewMode,
+  type ViewMode,
+} from '@/lib/agents/view-mode-store'
 
-export type ViewMode = 'human' | 'agent'
+export type { ViewMode }
 
 interface Props {
   initialMode?: ViewMode
@@ -23,25 +33,38 @@ export default function ViewModeSwitch({
   size = 'md',
 }: Props) {
   const router = useRouter()
-  const [mode, setMode] = useState<ViewMode>(initialMode || 'human')
   const [saving, setSaving] = useState(false)
 
-  // Si no llegó initialMode, lo cargamos client-side
+  // Siembra el store con el valor del servidor (si llegó) una sola vez.
+  useState(() => {
+    if (initialMode) seedViewMode(initialMode)
+    return null
+  })
+
+  // Estado COMPARTIDO: cambiar una instancia re-renderiza todas (fin del desync).
+  const mode = useSyncExternalStore(
+    subscribeViewMode,
+    getViewModeSnapshot,
+    () => initialMode || 'human' // snapshot para SSR
+  )
+
+  // Si nadie sembró el modo (ninguna instancia recibió initialMode), lo cargamos
+  // client-side una vez.
   useEffect(() => {
-    if (initialMode) return
+    if (isViewModeInitialized()) return
     fetch('/api/me/view-mode')
       .then((r) => r.json())
       .then((j) => {
-        if (j?.success && j.data?.mode) setMode(j.data.mode as ViewMode)
+        setViewModeLocal(j?.success && j.data?.mode ? (j.data.mode as ViewMode) : 'human')
       })
-      .catch(() => {})
-  }, [initialMode])
+      .catch(() => setViewModeLocal('human'))
+  }, [])
 
   const apply = async (next: ViewMode) => {
     if (next === mode) return
     const prev = mode
     setSaving(true)
-    setMode(next)
+    setViewModeLocal(next) // actualiza TODAS las instancias al instante
     try {
       const res = await fetch('/api/me/view-mode', {
         method: 'POST',
@@ -50,12 +73,12 @@ export default function ViewModeSwitch({
       })
       // Si el guardado no persistió, revertimos para no mentir en el UI.
       if (!res.ok) {
-        setMode(prev)
+        setViewModeLocal(prev)
         return
       }
       router.refresh()
     } catch {
-      setMode(prev)
+      setViewModeLocal(prev)
     } finally {
       setSaving(false)
     }

--- a/src/lib/agents/view-mode-store.ts
+++ b/src/lib/agents/view-mode-store.ts
@@ -1,0 +1,47 @@
+'use client'
+
+// BaW OS — Store compartido del view mode (Human ↔ Agent) en el cliente.
+//
+// Problema que resuelve: hay 2+ instancias de <ViewModeSwitch> (sidebar inferior
+// + header de Agentes). Antes cada una tenía su propio useState, así que cambiar
+// una NO actualizaba la otra (se desincronizaban). Este store es un único origen
+// de verdad en el cliente: cualquier instancia que cambie el modo notifica a
+// todas las demás vía useSyncExternalStore.
+//
+// La persistencia real sigue siendo la cookie `baw_view_mode` (vía
+// POST /api/me/view-mode); este store solo mantiene la UI sincronizada.
+
+export type ViewMode = 'human' | 'agent'
+
+let mode: ViewMode = 'human'
+let initialized = false
+const subscribers = new Set<() => void>()
+
+export function getViewModeSnapshot(): ViewMode {
+  return mode
+}
+
+export function isViewModeInitialized(): boolean {
+  return initialized
+}
+
+/** Siembra el modo inicial (p.ej. el valor que el servidor ya leyó de la cookie).
+ *  Solo aplica la primera vez para no pisar cambios del usuario. */
+export function seedViewMode(initial: ViewMode): void {
+  if (!initialized) {
+    mode = initial
+    initialized = true
+  }
+}
+
+/** Cambia el modo y notifica a TODAS las instancias suscritas (sincronización). */
+export function setViewModeLocal(next: ViewMode): void {
+  mode = next
+  initialized = true
+  subscribers.forEach((fn) => fn())
+}
+
+export function subscribeViewMode(fn: () => void): () => void {
+  subscribers.add(fn)
+  return () => subscribers.delete(fn)
+}


### PR DESCRIPTION
## Bug
Los dos toggles **Human/Agent** (el del sidebar inferior izquierdo y el del header de Agentes) **se desincronizaban**: cambiar uno no actualizaba el otro.

## Causa
Ambos son instancias del mismo `<ViewModeSwitch>`, pero **cada una tenía su propio `useState` local**. Al cambiar uno se hacía `router.refresh()` (que re-renderiza el contenido del servidor) pero **no tocaba el estado del otro toggle** → quedaban en valores distintos.

## Fix
Estado **compartido** en un store de cliente (`src/lib/agents/view-mode-store.ts`) consumido vía `useSyncExternalStore`. Cualquier instancia que cambie el modo **notifica a todas** → siempre sincronizadas (incluye también la 3ª instancia en la vista Agent). La persistencia sigue en la cookie `baw_view_mode` (sin cambios de backend).

## Validación
- `npx tsc --noEmit` ✅
- `eslint` ✅

> Nota: la rama partió de un `main` local desactualizado, pero solo toca `ViewModeSwitch.tsx` + el store nuevo (archivos que el PR #105 no tocó), así que mergea limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_