### PR TITLE
feat(chat): canal de chat in-app con agentes conectados

### DIFF
--- a/src/app/api/chat/conversations/[id]/messages/route.ts
+++ b/src/app/api/chat/conversations/[id]/messages/route.ts
@@ -1,0 +1,75 @@
+// BaW OS — Chat in-app · enviar mensaje
+// POST /api/chat/conversations/[id]/messages  { text }
+//
+// Crea una interacción channel='app' status='deferred' que el agente recoge por
+// su long-poll (GET /v1/interactions) y responde (PATCH response + completed).
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { requireMemberCaller } from '@/lib/admin-auth'
+
+export const dynamic = 'force-dynamic'
+
+interface RouteContext {
+  params: Promise<{ id: string }>
+}
+
+export async function POST(req: NextRequest, ctx: RouteContext) {
+  const auth = await requireMemberCaller()
+  if (!auth.ok) return NextResponse.json({ success: false, error: auth.message }, { status: auth.status })
+
+  const { id } = await ctx.params
+
+  let body: { text?: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ success: false, error: 'JSON inválido' }, { status: 400 })
+  }
+  const text = typeof body.text === 'string' ? body.text.trim() : ''
+  if (!text) return NextResponse.json({ success: false, error: 'text requerido' }, { status: 400 })
+  if (text.length > 4000) return NextResponse.json({ success: false, error: 'mensaje demasiado largo' }, { status: 400 })
+
+  const db = createServiceClient()
+  const { data: conv } = await db
+    .from('agent_conversations')
+    .select('id, org_id, agent_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (!conv || (conv as { org_id: string }).org_id !== auth.orgId) {
+    return NextResponse.json({ success: false, error: 'Conversación no encontrada' }, { status: 404 })
+  }
+
+  const { data: interaction, error } = await db
+    .from('agent_interactions')
+    .insert({
+      agent_id: (conv as { agent_id: string }).agent_id,
+      org_id: auth.orgId,
+      channel: 'app',
+      channel_id: id,
+      interaction_type: 'chat_message',
+      payload: { text, conversation_id: id },
+      status: 'deferred', // lo recoge el long-poll del agente
+      conversation_id: id,
+      created_by_user_id: auth.userId,
+    })
+    .select('id, payload, response, status, created_at')
+    .single()
+
+  if (error || !interaction) {
+    return NextResponse.json({ success: false, error: error?.message || 'No se pudo enviar' }, { status: 500 })
+  }
+
+  await db.from('agent_conversations').update({ last_message_at: new Date().toISOString() }).eq('id', id)
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      id: interaction.id,
+      user_text: text,
+      agent_text: null,
+      status: interaction.status,
+      created_at: interaction.created_at,
+    },
+  })
+}

--- a/src/app/api/chat/conversations/[id]/route.ts
+++ b/src/app/api/chat/conversations/[id]/route.ts
@@ -1,0 +1,55 @@
+// BaW OS — Chat in-app · hilo de una conversación
+// GET /api/chat/conversations/[id] → conversación + sus mensajes (interacciones)
+//
+// Cada "turno" es una interacción channel='app': payload.text = mensaje del
+// usuario; response.text = respuesta del agente (cuando status='completed').
+
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { requireMemberCaller } from '@/lib/admin-auth'
+
+export const dynamic = 'force-dynamic'
+
+interface RouteContext {
+  params: Promise<{ id: string }>
+}
+
+export async function GET(_req: Request, ctx: RouteContext) {
+  const auth = await requireMemberCaller()
+  if (!auth.ok) return NextResponse.json({ success: false, error: auth.message }, { status: auth.status })
+
+  const { id } = await ctx.params
+  const db = createServiceClient()
+
+  const { data: conv } = await db
+    .from('agent_conversations')
+    .select('id, org_id, agent_id, title, created_at, last_message_at')
+    .eq('id', id)
+    .maybeSingle()
+  if (!conv || (conv as { org_id: string }).org_id !== auth.orgId) {
+    return NextResponse.json({ success: false, error: 'Conversación no encontrada' }, { status: 404 })
+  }
+
+  const { data: rows, error } = await db
+    .from('agent_interactions')
+    .select('id, payload, response, status, error, created_at, completed_at')
+    .eq('conversation_id', id)
+    .order('created_at', { ascending: true })
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+
+  const messages = (rows || []).map((r) => {
+    const payload = (r.payload as { text?: string }) || {}
+    const response = (r.response as { text?: string } | null) || null
+    return {
+      id: r.id,
+      user_text: payload.text ?? '',
+      agent_text: response?.text ?? null,
+      status: r.status,
+      error: r.error,
+      created_at: r.created_at,
+      completed_at: r.completed_at,
+    }
+  })
+
+  return NextResponse.json({ success: true, data: { conversation: conv, messages } })
+}

--- a/src/app/api/chat/conversations/route.ts
+++ b/src/app/api/chat/conversations/route.ts
@@ -1,0 +1,89 @@
+// BaW OS — Chat in-app · conversaciones
+// GET  /api/chat/conversations  → lista de hilos + agentes conectados (para iniciar)
+// POST /api/chat/conversations  → crea un hilo con un agente conectado
+//
+// Cualquier miembro del tenant. Solo se puede chatear con agentes CONECTADOS
+// (con credencial activa en la org).
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { requireMemberCaller } from '@/lib/admin-auth'
+
+export const dynamic = 'force-dynamic'
+
+async function connectedAgents(db: ReturnType<typeof createServiceClient>, orgId: string) {
+  const { data: creds } = await db
+    .from('agent_credentials')
+    .select('agent_id')
+    .eq('org_id', orgId)
+    .eq('status', 'active')
+  const ids = Array.from(new Set((creds || []).map((c) => c.agent_id as string)))
+  if (ids.length === 0) return []
+  const { data: agents } = await db
+    .from('agents')
+    .select('id, display_name, full_name')
+    .in('id', ids)
+  return (agents || []) as { id: string; display_name: string; full_name: string }[]
+}
+
+export async function GET() {
+  const auth = await requireMemberCaller()
+  if (!auth.ok) return NextResponse.json({ success: false, error: auth.message }, { status: auth.status })
+
+  const db = createServiceClient()
+  const [{ data: convs }, agents] = await Promise.all([
+    db
+      .from('agent_conversations')
+      .select('id, agent_id, title, created_at, last_message_at')
+      .eq('org_id', auth.orgId)
+      .order('last_message_at', { ascending: false })
+      .limit(100),
+    connectedAgents(db, auth.orgId),
+  ])
+
+  const nameById = new Map(agents.map((a) => [a.id, a.full_name || a.display_name]))
+  const conversations = (convs || []).map((c) => ({
+    ...c,
+    agent_name: nameById.get(c.agent_id as string) ?? (c.agent_id as string),
+  }))
+
+  return NextResponse.json({ success: true, data: { conversations, agents } })
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireMemberCaller()
+  if (!auth.ok) return NextResponse.json({ success: false, error: auth.message }, { status: auth.status })
+
+  let body: { agent_id?: unknown; title?: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ success: false, error: 'JSON inválido' }, { status: 400 })
+  }
+  const agentId = body.agent_id
+  if (typeof agentId !== 'string' || !agentId) {
+    return NextResponse.json({ success: false, error: 'agent_id requerido' }, { status: 400 })
+  }
+
+  const db = createServiceClient()
+  // Solo agentes conectados (credencial activa) son chateables.
+  const agents = await connectedAgents(db, auth.orgId)
+  if (!agents.some((a) => a.id === agentId)) {
+    return NextResponse.json(
+      { success: false, error: 'Ese agente no está conectado en esta organización' },
+      { status: 400 }
+    )
+  }
+
+  const title = typeof body.title === 'string' && body.title.trim() ? body.title.trim().slice(0, 120) : null
+  const { data, error } = await db
+    .from('agent_conversations')
+    .insert({ org_id: auth.orgId, agent_id: agentId, created_by: auth.userId, title })
+    .select('id, agent_id, title, created_at, last_message_at')
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ success: false, error: error?.message || 'No se pudo crear' }, { status: 500 })
+  }
+  return NextResponse.json({ success: true, data })
+}

--- a/src/app/chat/ChatView.tsx
+++ b/src/app/chat/ChatView.tsx
@@ -1,0 +1,283 @@
+'use client'
+
+// BaW OS — Chat in-app con agentes conectados.
+// Cada mensaje crea una interacción channel='app' que el agente recoge por su
+// long-poll y responde. La UI hace polling del hilo para mostrar la respuesta.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Bot, Plus, Send, Loader2, MessageSquare } from 'lucide-react'
+import { useToast } from '@/components/Toast'
+
+interface AgentLite {
+  id: string
+  display_name: string
+  full_name: string
+}
+interface Conversation {
+  id: string
+  agent_id: string
+  agent_name?: string
+  title: string | null
+  last_message_at: string
+}
+interface Message {
+  id: string
+  user_text: string
+  agent_text: string | null
+  status: string
+  created_at: string
+}
+
+export default function ChatView() {
+  const toast = useToast()
+  const [conversations, setConversations] = useState<Conversation[]>([])
+  const [agents, setAgents] = useState<AgentLite[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState('')
+  const [loadingList, setLoadingList] = useState(true)
+  const [sending, setSending] = useState(false)
+  const [picking, setPicking] = useState(false)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const loadConversations = useCallback(async () => {
+    try {
+      const res = await fetch('/api/chat/conversations')
+      const json = await res.json()
+      if (json.success) {
+        setConversations(json.data.conversations)
+        setAgents(json.data.agents)
+      }
+    } catch {
+      /* noop */
+    } finally {
+      setLoadingList(false)
+    }
+  }, [])
+
+  const loadThread = useCallback(async (id: string) => {
+    try {
+      const res = await fetch(`/api/chat/conversations/${id}`)
+      const json = await res.json()
+      if (json.success) setMessages(json.data.messages)
+    } catch {
+      /* noop */
+    }
+  }, [])
+
+  useEffect(() => {
+    loadConversations()
+  }, [loadConversations])
+
+  // Carga + polling del hilo seleccionado (para ver la respuesta del agente).
+  useEffect(() => {
+    if (!selectedId) return
+    loadThread(selectedId)
+    const t = setInterval(() => loadThread(selectedId), 3000)
+    return () => clearInterval(t)
+  }, [selectedId, loadThread])
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
+  }, [messages])
+
+  async function startConversation(agentId: string) {
+    setPicking(false)
+    try {
+      const res = await fetch('/api/chat/conversations', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ agent_id: agentId }),
+      })
+      const json = await res.json()
+      if (!json.success) {
+        toast.error(json.error || 'No se pudo crear la conversación')
+        return
+      }
+      await loadConversations()
+      setSelectedId(json.data.id)
+      setMessages([])
+    } catch {
+      toast.error('Error de red')
+    }
+  }
+
+  async function send() {
+    const text = input.trim()
+    if (!text || !selectedId || sending) return
+    setSending(true)
+    setInput('')
+    // Optimista: muestra el mensaje del usuario de inmediato.
+    setMessages((prev) => [
+      ...prev,
+      { id: `tmp-${Date.now()}`, user_text: text, agent_text: null, status: 'deferred', created_at: new Date().toISOString() },
+    ])
+    try {
+      const res = await fetch(`/api/chat/conversations/${selectedId}/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ text }),
+      })
+      const json = await res.json()
+      if (!json.success) {
+        toast.error(json.error || 'No se pudo enviar')
+      } else {
+        loadThread(selectedId)
+      }
+    } catch {
+      toast.error('Error de red')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const selectedConv = conversations.find((c) => c.id === selectedId)
+  const noAgents = !loadingList && agents.length === 0
+
+  return (
+    <div className="flex h-[calc(100vh-7rem)] gap-3">
+      {/* Lista de conversaciones */}
+      <div
+        className="w-72 shrink-0 rounded-lg flex flex-col overflow-hidden"
+        style={{ backgroundColor: 'var(--baw-surface)', border: '1px solid var(--baw-border)' }}
+      >
+        <div className="p-3 flex items-center justify-between" style={{ borderBottom: '1px solid var(--baw-border)' }}>
+          <span className="text-[13px] font-semibold" style={{ color: 'var(--baw-text)' }}>Conversaciones</span>
+          <button
+            onClick={() => setPicking((p) => !p)}
+            disabled={noAgents}
+            className="p-1 rounded disabled:opacity-40"
+            style={{ color: 'var(--baw-accent)' }}
+            title="Nueva conversación"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+        </div>
+
+        {picking && (
+          <div className="p-2 space-y-1" style={{ borderBottom: '1px solid var(--baw-border)' }}>
+            <p className="text-[11px] px-1 mb-1" style={{ color: 'var(--baw-muted)' }}>Chatear con:</p>
+            {agents.map((a) => (
+              <button
+                key={a.id}
+                onClick={() => startConversation(a.id)}
+                className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-[13px] text-left hover:opacity-80"
+                style={{ color: 'var(--baw-text)', backgroundColor: 'var(--baw-elevated)' }}
+              >
+                <Bot className="w-4 h-4" style={{ color: 'var(--baw-agent-fg)' }} />
+                {a.full_name || a.display_name}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto">
+          {loadingList ? (
+            <div className="p-4 text-center"><Loader2 className="w-4 h-4 animate-spin inline" /></div>
+          ) : conversations.length === 0 ? (
+            <p className="p-4 text-[12px] text-center" style={{ color: 'var(--baw-muted)' }}>
+              {noAgents ? 'No tienes agentes conectados. Conéctalos en /agents.' : 'Sin conversaciones. Empieza una con +.'}
+            </p>
+          ) : (
+            conversations.map((c) => (
+              <button
+                key={c.id}
+                onClick={() => setSelectedId(c.id)}
+                className="w-full text-left px-3 py-2.5 flex items-center gap-2 transition-colors"
+                style={{
+                  backgroundColor: c.id === selectedId ? 'var(--baw-elevated)' : 'transparent',
+                  borderBottom: '1px solid var(--baw-border)',
+                }}
+              >
+                <Bot className="w-4 h-4 shrink-0" style={{ color: 'var(--baw-agent-fg)' }} />
+                <span className="min-w-0">
+                  <span className="block text-[13px] font-medium truncate" style={{ color: 'var(--baw-text)' }}>
+                    {c.agent_name || c.agent_id}
+                  </span>
+                  {c.title && <span className="block text-[11px] truncate" style={{ color: 'var(--baw-muted)' }}>{c.title}</span>}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Hilo */}
+      <div
+        className="flex-1 rounded-lg flex flex-col overflow-hidden"
+        style={{ backgroundColor: 'var(--baw-surface)', border: '1px solid var(--baw-border)' }}
+      >
+        {!selectedId ? (
+          <div className="flex-1 flex flex-col items-center justify-center gap-2" style={{ color: 'var(--baw-muted)' }}>
+            <MessageSquare className="w-8 h-8" />
+            <p className="text-[13px]">Elige o inicia una conversación con un agente conectado.</p>
+          </div>
+        ) : (
+          <>
+            <div className="px-4 py-3 flex items-center gap-2" style={{ borderBottom: '1px solid var(--baw-border)' }}>
+              <Bot className="w-4 h-4" style={{ color: 'var(--baw-agent-fg)' }} />
+              <span className="text-[14px] font-semibold" style={{ color: 'var(--baw-text)' }}>
+                {selectedConv?.agent_name || selectedConv?.agent_id}
+              </span>
+            </div>
+
+            <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-3">
+              {messages.length === 0 ? (
+                <p className="text-center text-[12px]" style={{ color: 'var(--baw-muted)' }}>Escribe el primer mensaje.</p>
+              ) : (
+                messages.map((m) => (
+                  <div key={m.id} className="space-y-2">
+                    {/* Usuario */}
+                    <div className="flex justify-end">
+                      <div className="max-w-[75%] rounded-lg px-3 py-2 text-[13px]" style={{ backgroundColor: 'var(--baw-accent)', color: 'white' }}>
+                        {m.user_text}
+                      </div>
+                    </div>
+                    {/* Agente */}
+                    <div className="flex justify-start">
+                      {m.agent_text ? (
+                        <div className="max-w-[75%] rounded-lg px-3 py-2 text-[13px]" style={{ backgroundColor: 'var(--baw-elevated)', color: 'var(--baw-text)', border: '1px solid var(--baw-border)' }}>
+                          {m.agent_text}
+                        </div>
+                      ) : m.status === 'failed' ? (
+                        <div className="text-[12px] px-3 py-2" style={{ color: 'var(--baw-danger-fg)' }}>El agente no pudo responder.</div>
+                      ) : (
+                        <div className="flex items-center gap-1.5 text-[12px] px-3 py-2" style={{ color: 'var(--baw-muted)' }}>
+                          <Loader2 className="w-3 h-3 animate-spin" /> pensando…
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <div className="p-3 flex items-end gap-2" style={{ borderTop: '1px solid var(--baw-border)' }}>
+              <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault()
+                    send()
+                  }
+                }}
+                rows={1}
+                placeholder="Escribe un mensaje…"
+                className="input-field flex-1 resize-none"
+              />
+              <button
+                onClick={send}
+                disabled={sending || !input.trim()}
+                className="btn-primary px-3 py-2 disabled:opacity-50"
+                title="Enviar"
+              >
+                {sending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,8 @@
+// BaW OS — Chat in-app con agentes conectados.
+import ChatView from './ChatView'
+
+export const dynamic = 'force-dynamic'
+
+export default function ChatPage() {
+  return <ChatView />
+}

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -68,3 +68,51 @@ export async function requireAdminCaller(): Promise<AdminCallerOk | AdminCallerE
 
   return { ok: true, userId: user.id, orgId, isPlatformAdmin }
 }
+
+/**
+ * Igual que requireAdminCaller pero solo exige ser MIEMBRO activo de la org
+ * (cualquier rol). Para features que cualquier usuario del tenant puede usar,
+ * como el chat con agentes.
+ */
+export async function requireMemberCaller(): Promise<AdminCallerOk | AdminCallerErr> {
+  const supabase = createSupabaseServer()
+  const {
+    data: { user },
+    error: userErr,
+  } = await supabase.auth.getUser()
+  if (userErr || !user) {
+    return { ok: false, status: 401, message: 'No authenticated user' }
+  }
+
+  let orgId: string
+  try {
+    orgId = await resolveOrgId()
+  } catch (e) {
+    if (e instanceof OrgContextError) {
+      return { ok: false, status: 401, message: e.message }
+    }
+    throw e
+  }
+
+  const service = createServiceClient()
+  const { data: pa } = await service
+    .from('platform_admins')
+    .select('user_id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  const isPlatformAdmin = !!pa
+
+  if (!isPlatformAdmin) {
+    const { data: membership } = await service
+      .from('org_members')
+      .select('user_id')
+      .eq('user_id', user.id)
+      .eq('org_id', orgId)
+      .maybeSingle()
+    if (!membership) {
+      return { ok: false, status: 403, message: 'Not a member of this organization' }
+    }
+  }
+
+  return { ok: true, userId: user.id, orgId, isPlatformAdmin }
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -161,7 +161,11 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     href: '/agents',
     icon: 'Bot',
     placement: 'footer',
-    routes: ['/agents'],
+    routes: ['/agents', '/chat'],
+    subNav: [
+      { href: '/agents', label: 'Catálogo' },
+      { href: '/chat', label: 'Chat' },
+    ],
     // Conectar/configurar agentes y sus credenciales = admin de la cuenta.
     visibleToRoles: ORG_ADMIN_ROLES,
   },

--- a/supabase/migrations/20260623_agent_chat.sql
+++ b/supabase/migrations/20260623_agent_chat.sql
@@ -1,0 +1,41 @@
+-- BaW OS — Chat in-app con agentes conectados.
+--
+-- Reusa los rieles de agent_interactions (mismo long-poll + PATCH que ya usa
+-- Alicia para Discord): un mensaje del usuario = una interacción channel='app',
+-- status='deferred', que el agente recoge por su long-poll y responde
+-- (PATCH response + completed). Cambio mínimo del lado del agente: manejar el
+-- canal 'app' igual que maneja 'discord'.
+
+-- 1. Permitir el canal 'app' en agent_interactions.
+ALTER TABLE public.agent_interactions DROP CONSTRAINT IF EXISTS agent_interactions_channel_check;
+ALTER TABLE public.agent_interactions ADD CONSTRAINT agent_interactions_channel_check
+  CHECK (channel IN ('discord','slack','whatsapp','telegram','signal','imessage','api','app'));
+
+-- 2. Hilo + autor humano para el chat in-app.
+ALTER TABLE public.agent_interactions
+  ADD COLUMN IF NOT EXISTS conversation_id UUID,
+  ADD COLUMN IF NOT EXISTS created_by_user_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_agent_interactions_conversation
+  ON public.agent_interactions (conversation_id, created_at)
+  WHERE conversation_id IS NOT NULL;
+
+-- 3. Conversaciones (hilos de chat humano ↔ agente).
+CREATE TABLE IF NOT EXISTS public.agent_conversations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL REFERENCES public.agents(id) ON DELETE RESTRICT,
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  title TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_message_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_org
+  ON public.agent_conversations (org_id, last_message_at DESC);
+
+ALTER TABLE public.agent_conversations ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS agent_conversations_member ON public.agent_conversations;
+CREATE POLICY agent_conversations_member ON public.agent_conversations FOR ALL
+  USING (EXISTS (SELECT 1 FROM public.org_members om WHERE om.org_id = agent_conversations.org_id AND om.user_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.org_members om WHERE om.org_id = agent_conversations.org_id AND om.user_id = auth.uid()));


### PR DESCRIPTION
## Qué hace
La **fundación** para chatear con tus agentes conectados (Alicia, y mañana Andrés) **dentro de la plataforma**, sin Discord. Y es la misma plomería sobre la que montará el sistema de planeación.

Reusa los rieles que **ya funcionan** con Alicia: un mensaje de chat = una interacción `channel='app'` que el agente recoge por su **long-poll** y responde por **PATCH** (igual que Discord). **Cambio mínimo del lado del agente.**

## Cómo funciona
```
Tú escribes en /chat → interacción channel='app' status='deferred'
  → el agente la recoge (GET /v1/interactions) → piensa (flat rate MK2)
  → PATCH { status:'completed', response:{ text } } → la UI muestra la respuesta (polling)
```

## Cambios
- **Migración `20260623_agent_chat.sql`**: canal `'app'` en `agent_interactions` + columnas `conversation_id`/`created_by_user_id` + tabla **`agent_conversations`** (hilos) con RLS por miembro.
- **API de chat** (sesión de usuario, scope por org, cualquier miembro):
  - `GET/POST /api/chat/conversations` (listar/crear; solo agentes **conectados** son chateables)
  - `GET /api/chat/conversations/[id]` (hilo)
  - `POST /api/chat/conversations/[id]/messages` (enviar → crea la interacción)
- **UI `/chat`**: lista de conversaciones + hilo + composer, con **polling** para mostrar la respuesta del agente.
- **Nav**: `Chat` como sub-item de la sección Agentes (`Catálogo | Chat`).
- Helper `requireMemberCaller` (auth a nivel miembro).

## 🔌 Contrato lado agente (MK2 / OpenClaw)
Para que Alicia/Andrés respondan en el chat, la skill debe **manejar el canal `'app'`** igual que `'discord'`:
1. Su long-poll (`GET /v1/interactions`) ya recibe estas interacciones (vienen con `channel:'app'`, `payload.text`, `payload.conversation_id`).
2. Responde con `PATCH /v1/interactions/:id` → `{ "status":"completed", "response": { "text": "..." } }`.

## ⚠️ Orden de deploy
La migración va **antes** del deploy (la pantalla `/chat` consulta `agent_conversations`). Solo afecta a `/chat`; el resto de la app no.

## Validación
- `npx tsc --noEmit` ✅
- `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_