### PR TITLE
fix(chat): botón visible + dock al ancho del sidebar + reflow del contenido

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,7 @@ html.dark {
   --baw-muted:        var(--text-2);
   --baw-faint:        var(--text-3);
   --baw-primary:      var(--brand-500);
+  --baw-accent:       var(--brand-500);
   --baw-agent:        var(--agent-500);
   --baw-agent-subtle: var(--agent-fill);
   --baw-human-subtle: var(--brand-fill);

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -245,7 +245,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             pasar la retícula del body.
           */}
           <main
-            className="relative min-h-screen md:transition-[padding] md:duration-200 md:[padding-left:var(--sidebar-effective-width,0px)]"
+            className="relative min-h-screen transition-[padding] duration-200 sm:[padding-right:var(--chat-dock-width,0px)] md:[padding-left:var(--sidebar-effective-width,0px)]"
           >
             <GlobalHeader pathname={pathname} />
             <SectionTopNav />

--- a/src/components/ChatDock.tsx
+++ b/src/components/ChatDock.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 // BaW OS — Dock de chat lateral (derecha), global y oscuro como el sidebar.
-// Permite chatear con agentes conectados sin abandonar la pantalla actual.
+// Mismo ancho que el menú izquierdo (240px). Al abrirse, empuja el contenido
+// central vía la variable --chat-dock-width (el <main> aplica padding-right).
 // Solo se monta si hay al menos un agente conectado en la org.
 
 import { useEffect, useState } from 'react'
 import { MessageSquare } from 'lucide-react'
 import ChatPanel from '@/app/chat/ChatPanel'
+
+const DOCK_WIDTH = 240 // = EXPANDED_WIDTH del sidebar
 
 export default function ChatDock() {
   const [open, setOpen] = useState(false)
@@ -25,27 +28,34 @@ export default function ChatDock() {
     }
   }, [])
 
+  // Empuja el contenido central cuando el dock está abierto (solo en sm+).
+  useEffect(() => {
+    const root = document.documentElement
+    root.style.setProperty('--chat-dock-width', open ? `${DOCK_WIDTH}px` : '0px')
+    return () => root.style.setProperty('--chat-dock-width', '0px')
+  }, [open])
+
   if (!hasAgents) return null
 
   return (
     <>
-      {/* Launcher flotante */}
+      {/* Launcher flotante — visible siempre */}
       {!open && (
         <button
           onClick={() => setOpen(true)}
-          className="fixed bottom-5 right-5 z-40 flex items-center gap-2 rounded-full px-4 py-3 shadow-lg text-white transition-transform hover:scale-105"
-          style={{ backgroundColor: 'var(--baw-accent)' }}
+          className="fixed bottom-5 right-5 z-40 flex items-center justify-center w-12 h-12 rounded-full shadow-xl text-white ring-2 ring-white/25 transition-transform hover:scale-105"
+          style={{ backgroundColor: 'var(--baw-primary)' }}
           title="Chat con agentes"
+          aria-label="Abrir chat con agentes"
         >
           <MessageSquare className="w-5 h-5" />
-          <span className="text-[13px] font-medium hidden sm:inline">Chat</span>
         </button>
       )}
 
-      {/* Panel acoplado a la derecha */}
+      {/* Panel acoplado a la derecha — mismo ancho que el sidebar */}
       {open && (
         <div
-          className="fixed top-0 right-0 z-50 h-[100dvh] w-full sm:w-[380px] shadow-2xl"
+          className="fixed top-0 right-0 z-50 h-[100dvh] w-full sm:w-[240px] shadow-2xl"
           style={{ borderLeft: '1px solid rgba(255,255,255,0.1)' }}
         >
           <ChatPanel dark onClose={() => setOpen(false)} />


### PR DESCRIPTION
## Arregla 3 cosas del dock de chat (feedback de Fran)

1. **Botón invisible** → el token **`--baw-accent` no estaba definido** en el CSS, así que el botón flotante y las burbujas del usuario salían **transparentes**. Lo defino (`= var(--brand-500)`). Bonus: también arregla usos previos del token en `/agents` y el catálogo de agentes.
2. **Dock muy ancho** → ahora **240px**, el mismo grosor que el menú izquierdo (antes 380).
3. **Contenido tapado** → el contenido central ahora **se encoge** cuando el dock abre: `ChatDock` setea `--chat-dock-width` y el `<main>` aplica `padding-right` (sm+) con transición. Ya no se lo come la ventana del chat.

También: el launcher es un **FAB circular sólido** con `ring`, siempre visible.

## Sin migración · solo UI
## Validación
- `npx tsc --noEmit` ✅
- `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_