### PR TITLE
feat(chat): identidad de agente + quitar toggle confuso del sidebar

### DIFF
--- a/src/app/api/chat/conversations/route.ts
+++ b/src/app/api/chat/conversations/route.ts
@@ -11,7 +11,15 @@ import { requireMemberCaller } from '@/lib/admin-auth'
 
 export const dynamic = 'force-dynamic'
 
-async function connectedAgents(db: ReturnType<typeof createServiceClient>, orgId: string) {
+interface AgentLite {
+  id: string
+  display_name: string
+  full_name: string
+  role_label: string | null
+  domain: string | null
+}
+
+async function connectedAgents(db: ReturnType<typeof createServiceClient>, orgId: string): Promise<AgentLite[]> {
   const { data: creds } = await db
     .from('agent_credentials')
     .select('agent_id')
@@ -21,9 +29,9 @@ async function connectedAgents(db: ReturnType<typeof createServiceClient>, orgId
   if (ids.length === 0) return []
   const { data: agents } = await db
     .from('agents')
-    .select('id, display_name, full_name')
+    .select('id, display_name, full_name, role_label, domain')
     .in('id', ids)
-  return (agents || []) as { id: string; display_name: string; full_name: string }[]
+  return (agents || []) as AgentLite[]
 }
 
 export async function GET() {
@@ -42,9 +50,11 @@ export async function GET() {
   ])
 
   const nameById = new Map(agents.map((a) => [a.id, a.full_name || a.display_name]))
+  const roleById = new Map(agents.map((a) => [a.id, a.role_label || a.domain || null]))
   const conversations = (convs || []).map((c) => ({
     ...c,
     agent_name: nameById.get(c.agent_id as string) ?? (c.agent_id as string),
+    agent_role: roleById.get(c.agent_id as string) ?? null,
   }))
 
   return NextResponse.json({ success: true, data: { conversations, agents } })

--- a/src/app/chat/ChatPanel.tsx
+++ b/src/app/chat/ChatPanel.tsx
@@ -5,13 +5,14 @@
 // SIEMPRE visible (flex + min-h-0). Soporta tema claro u oscuro (dock).
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Bot, Plus, Send, Loader2, MessageSquare, ChevronLeft, X } from 'lucide-react'
+import { Plus, Send, Loader2, MessageSquare, ChevronLeft, X } from 'lucide-react'
 import { useToast } from '@/components/Toast'
+import { ActorAvatar } from '@/components/ui/status'
 
 const STALE_MS = 45000 // si el agente no responde en 45s, lo marcamos como sin respuesta
 
-interface AgentLite { id: string; display_name: string; full_name: string }
-interface Conversation { id: string; agent_id: string; agent_name?: string; title: string | null; last_message_at: string }
+interface AgentLite { id: string; display_name: string; full_name: string; role_label?: string | null; domain?: string | null }
+interface Conversation { id: string; agent_id: string; agent_name?: string; agent_role?: string | null; title: string | null; last_message_at: string }
 interface Message { id: string; user_text: string; agent_text: string | null; status: string; created_at: string }
 
 function palette(dark: boolean) {
@@ -143,8 +144,11 @@ export default function ChatPanel({ dark = false, onClose }: { dark?: boolean; o
             <button onClick={() => setSelectedId(null)} className="p-1 rounded hover:opacity-70" style={{ color: c.muted }} title="Volver">
               <ChevronLeft className="w-4 h-4" />
             </button>
-            <Bot className="w-4 h-4" style={{ color: 'var(--baw-agent-fg)' }} />
-            <span className="text-[13px] font-semibold truncate">{selectedConv?.agent_name || selectedConv?.agent_id}</span>
+            <ActorAvatar type="agent" name={selectedConv?.agent_name || selectedConv?.agent_id || 'Agente'} size={26} />
+            <span className="min-w-0">
+              <span className="block text-[13px] font-semibold truncate">{selectedConv?.agent_name || selectedConv?.agent_id}</span>
+              {selectedConv?.agent_role && <span className="block text-[11px] truncate" style={{ color: c.muted }}>{selectedConv.agent_role}</span>}
+            </span>
           </>
         ) : (
           <>
@@ -169,9 +173,12 @@ export default function ChatPanel({ dark = false, onClose }: { dark?: boolean; o
             <div className="p-2 space-y-1" style={{ borderBottom: `1px solid ${c.border}` }}>
               <p className="text-[11px] px-1 mb-1" style={{ color: c.muted }}>Chatear con:</p>
               {agents.map((a) => (
-                <button key={a.id} onClick={() => startConversation(a.id)} className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-[13px] text-left" style={{ backgroundColor: c.elevated }}>
-                  <Bot className="w-4 h-4" style={{ color: 'var(--baw-agent-fg)' }} />
-                  {a.full_name || a.display_name}
+                <button key={a.id} onClick={() => startConversation(a.id)} className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-left" style={{ backgroundColor: c.elevated }}>
+                  <ActorAvatar type="agent" name={a.full_name || a.display_name} size={24} />
+                  <span className="min-w-0">
+                    <span className="block text-[13px] truncate">{a.full_name || a.display_name}</span>
+                    {(a.role_label || a.domain) && <span className="block text-[11px] truncate" style={{ color: c.muted }}>{a.role_label || a.domain}</span>}
+                  </span>
                 </button>
               ))}
             </div>
@@ -184,11 +191,11 @@ export default function ChatPanel({ dark = false, onClose }: { dark?: boolean; o
             </p>
           ) : (
             conversations.map((cv) => (
-              <button key={cv.id} onClick={() => setSelectedId(cv.id)} className="w-full text-left px-3 py-2.5 flex items-center gap-2" style={{ borderBottom: `1px solid ${c.border}` }}>
-                <Bot className="w-4 h-4 shrink-0" style={{ color: 'var(--baw-agent-fg)' }} />
+              <button key={cv.id} onClick={() => setSelectedId(cv.id)} className="w-full text-left px-3 py-2.5 flex items-center gap-2.5" style={{ borderBottom: `1px solid ${c.border}` }}>
+                <ActorAvatar type="agent" name={cv.agent_name || cv.agent_id} size={30} />
                 <span className="min-w-0">
                   <span className="block text-[13px] font-medium truncate">{cv.agent_name || cv.agent_id}</span>
-                  {cv.title && <span className="block text-[11px] truncate" style={{ color: c.muted }}>{cv.title}</span>}
+                  {(cv.agent_role || cv.title) && <span className="block text-[11px] truncate" style={{ color: c.muted }}>{cv.agent_role || cv.title}</span>}
                 </span>
               </button>
             ))

--- a/src/components/ChatDock.tsx
+++ b/src/components/ChatDock.tsx
@@ -6,7 +6,7 @@
 // Solo se monta si hay al menos un agente conectado en la org.
 
 import { useEffect, useState } from 'react'
-import { MessageSquare } from 'lucide-react'
+import { Bot } from 'lucide-react'
 import ChatPanel from '@/app/chat/ChatPanel'
 
 const DOCK_WIDTH = 240 // = EXPANDED_WIDTH del sidebar
@@ -43,12 +43,13 @@ export default function ChatDock() {
       {!open && (
         <button
           onClick={() => setOpen(true)}
-          className="fixed bottom-5 right-5 z-40 flex items-center justify-center w-12 h-12 rounded-full shadow-xl text-white ring-2 ring-white/25 transition-transform hover:scale-105"
+          className="fixed bottom-5 right-5 z-40 flex items-center gap-2 rounded-full px-4 py-3 shadow-xl text-white ring-2 ring-white/20 transition-transform hover:scale-105"
           style={{ backgroundColor: 'var(--baw-primary)' }}
-          title="Chat con agentes"
-          aria-label="Abrir chat con agentes"
+          title="Chat con tus agentes"
+          aria-label="Abrir chat con tus agentes"
         >
-          <MessageSquare className="w-5 h-5" />
+          <Bot className="w-5 h-5" />
+          <span className="text-[13px] font-medium">Agentes</span>
         </button>
       )}
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,11 +19,9 @@ import {
 import { cn } from '@/lib/utils'
 import WorkspaceSwitcher from '@/components/WorkspaceSwitcher'
 import BawMark from '@/components/BawMark'
-import ViewModeSwitch from '@/components/ViewModeSwitch'
 import { useOrgContext } from '@/hooks/useOrgContext'
 import {
   SIDEBAR_SECTIONS,
-  ORG_ADMIN_ROLES,
   isSectionActive,
   filterSectionsByRole,
 } from '@/lib/navigation'
@@ -49,8 +47,6 @@ export default function Sidebar() {
   const [hovering, setHovering] = useState(false)
   const [pinned, setPinned] = useState(false)
   const [unreadCount, setUnreadCount] = useState(0)
-
-  const isOrgAdmin = !!role && ORG_ADMIN_ROLES.includes(role)
 
   const expanded = pinned || hovering || mobileOpen
 
@@ -274,16 +270,9 @@ export default function Sidebar() {
           {footerSections.map((s) => renderEntry(s))}
         </div>
 
-        {/* View mode switch (Human / Agent) — solo admins de la cuenta.
-            Operadores/viewers no gestionan agentes, así que no ven el toggle. */}
-        {expanded && isOrgAdmin && (
-          <div
-            className="shrink-0 px-3 py-2"
-            style={{ borderTop: '1px solid var(--baw-sidebar-border)' }}
-          >
-            <ViewModeSwitch size="sm" />
-          </div>
-        )}
+        {/* El toggle Human/Agent vive solo en la pantalla de Agentes (donde sí
+            cambia la vista). Antes estaba aquí pero confundía: en otras secciones
+            no hacía nada. */}
 
         {/* Workspace switcher */}
         <div className="shrink-0 py-2" style={{ borderTop: '1px solid var(--baw-sidebar-border)' }}>


### PR DESCRIPTION
## Dos ajustes de feedback de Fran

### 1. Quitar el toggle Human/Agent del sidebar (resuelve el conflicto)
El modo Human/Agent **solo cambia la pantalla de Agentes**; en cualquier otra sección el toggle no hacía nada → confundía. Lo **quito del sidebar** (y limpio sus dependencias). El toggle sigue **donde sí tiene efecto**: en la propia pantalla de Agentes (header de Catálogo y de la consola Agent).

### 2. El chat ya no parece "customer service" — ahora tiene identidad de agente
- **Avatar del agente** (`ActorAvatar`) + **nombre** + **rol** en la lista de conversaciones, el encabezado del hilo y el selector de "nueva conversación" → sabes con quién hablas.
- El **launcher** dice **"Agentes"** con icono de bot (no una burbuja genérica de soporte).
- La API de chat ahora incluye `role_label`/`domain` del agente para mostrar el rol.

## Sin migración · solo UI
## Validación
- `npx tsc --noEmit` ✅
- `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_