### PR TITLE
feat(nav): Fase 1 — reorden Inquilinos + Clientes→CRM

### DIFF
--- a/src/app/clientes/page.tsx
+++ b/src/app/clientes/page.tsx
@@ -149,7 +149,7 @@ export default function ClientesPage() {
         <div className="flex items-center gap-3">
           <Users className="w-6 h-6 text-indigo-500" />
           <div>
-            <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">Clientes</h1>
+            <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">CRM</h1>
             <p className="text-sm text-gray-500 dark:text-gray-400">
               {clientCount} clientes · {leadCount} leads · {opps.length} oportunidades
             </p>

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -107,8 +107,8 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     subNav: [
       { href: '/contacts', label: 'Contactos' },
       { href: '/contracts', label: 'Contratos' },
-      { href: '/clientes', label: 'Clientes', matchPrefix: '/clientes' },
       { href: '/applications', label: 'Expedientes' },
+      { href: '/clientes', label: 'CRM', matchPrefix: '/clientes' },
     ],
   },
   {


### PR DESCRIPTION
## Fase 1 del modelo de Personas/CRM/Estancias (spec #112)
Aterriza el **lenguaje** del spec en la UI, **sin tocar datos** — la pieza barata y reversible.

- **Inquilinos** reordenado: `Contactos · Contratos · Expedientes · CRM` (antes "Clientes" iba en 3ª posición).
- **"Clientes" → "CRM"** (pestaña + H1 de la página): deja explícito que es el **embudo comercial**, separado del **directorio operativo** (Contactos). Esto resuelve la confusión Contactos-vs-Clientes que disparó todo.

## Lo que NO toca (a propósito)
- "Contactos" se queda igual (renombrarlo a "Personas" viene en la **Fase 2** con el modelo Party).
- Unificar Contratos+Reservas en "Estancias" = **Fase 3**.
- Todo lo de datos depende de las **5 decisiones abiertas** del spec.

## Validación
- `npx tsc --noEmit` ✅
- `eslint` ✅ · solo navegación + un título.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_