### PR TITLE
feat(crm): unificar directorio CRM con occupants (Fase 2a)

### DIFF
--- a/src/app/clientes/page.tsx
+++ b/src/app/clientes/page.tsx
@@ -64,7 +64,6 @@ export default function ClientesPage() {
 
   const [selected, setSelected] = useState<CrmContact | null>(null)
   const [showNew, setShowNew] = useState(false)
-  const [importing, setImporting] = useState(false)
 
   const fetchData = useCallback(async () => {
     if (!orgId) return
@@ -83,41 +82,9 @@ export default function ClientesPage() {
     fetchData()
   }, [orgId, fetchData])
 
-  // Importa inquilinos (occupants) que aún no están en el CRM como clientes.
-  async function importOccupants() {
-    if (!orgId) return
-    setImporting(true)
-    const [occRes, existingRes] = await Promise.all([
-      supabase.from('occupants').select('id, name, phone, email').eq('org_id', orgId),
-      supabase.from('crm_contacts').select('occupant_id').eq('org_id', orgId).not('occupant_id', 'is', null),
-    ])
-    const existing = new Set(((existingRes.data as { occupant_id: string }[]) || []).map((r) => r.occupant_id))
-    const occupants = ((occRes.data as { id: string; name: string; phone: string | null; email: string | null }[]) || [])
-      .filter((o) => !existing.has(o.id))
-    if (occupants.length === 0) {
-      setImporting(false)
-      toast.success('No hay inquilinos nuevos por importar')
-      return
-    }
-    const rows = occupants.map((o) => ({
-      org_id: orgId,
-      occupant_id: o.id,
-      name: o.name,
-      phone: o.phone,
-      email: o.email,
-      source: 'manual' as CrmSource,
-      is_client: true,
-      status: 'activo' as CrmStatus,
-    }))
-    const { error } = await supabase.from('crm_contacts').insert(rows)
-    setImporting(false)
-    if (error) {
-      toast.error('Error al importar inquilinos')
-    } else {
-      toast.success(`${rows.length} inquilino(s) importados como clientes`)
-      fetchData()
-    }
-  }
+  // El CRM y el directorio (occupants) se mantienen 1:1 automáticamente vía
+  // trigger en la DB (ver migración 20260625_crm_occupant_sync). Ya no hace falta
+  // "importar" — toda persona aparece sola.
 
   const filtered = contacts.filter((c) => {
     if (typeFilter === 'clientes' && !c.is_client) return false
@@ -156,14 +123,6 @@ export default function ClientesPage() {
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <button
-            onClick={importOccupants}
-            disabled={importing}
-            className="inline-flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
-          >
-            <Download className="w-4 h-4" />
-            {importing ? 'Importando…' : 'Importar inquilinos'}
-          </button>
           <button
             onClick={() => setShowNew(true)}
             className="inline-flex items-center gap-2 px-3 py-2 text-sm rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white font-medium transition-colors"

--- a/supabase/migrations/20260625_crm_occupant_sync.sql
+++ b/supabase/migrations/20260625_crm_occupant_sync.sql
@@ -1,0 +1,54 @@
+-- BaW OS — Fase 2a: unificar el directorio de personas (CRM ↔ occupants).
+--
+-- Problema: había DOS directorios paralelos — Contactos (`occupants`) y el
+-- "Directorio" del CRM (`crm_contacts`) — y un botón que COPIABA personas de uno
+-- a otro, generando la sensación de duplicado.
+--
+-- Solución (Party único): cada persona es UN `occupant` (la identidad durable), y
+-- `crm_contacts` se vuelve su **capa comercial** 1:1 (estado, fuente, oportunidades).
+-- Quedan en sync automáticamente; el botón de importar se elimina del UI.
+--
+-- Idempotente. NO destruye datos (solo crea/enlaza).
+
+-- 1. crm_contacts "huérfanos" (sin occupant) → crear su occupant y enlazarlo.
+--    Así todo registro de CRM existe también en el directorio.
+DO $$
+DECLARE r RECORD; new_id uuid;
+BEGIN
+  FOR r IN SELECT * FROM public.crm_contacts WHERE occupant_id IS NULL LOOP
+    INSERT INTO public.occupants (org_id, name, phone, email)
+    VALUES (r.org_id, COALESCE(NULLIF(r.name, ''), 'Sin nombre'), r.phone, r.email)
+    RETURNING id INTO new_id;
+    UPDATE public.crm_contacts SET occupant_id = new_id WHERE id = r.id;
+  END LOOP;
+END $$;
+
+-- 2. 1:1 — un occupant no puede estar dos veces en el CRM de una org.
+--    (Si esto falla, hay registros CRM duplicados para una persona; avisar para limpiarlos.)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_crm_contacts_org_occupant
+  ON public.crm_contacts (org_id, occupant_id);
+
+-- 3. Backfill: cada occupant que aún no tiene registro CRM → crearlo.
+--    is_client = true si la persona ya tiene al menos un contrato.
+INSERT INTO public.crm_contacts (org_id, occupant_id, name, phone, email, source, status, is_client)
+SELECT o.org_id, o.id, COALESCE(NULLIF(o.name, ''), 'Sin nombre'), o.phone, o.email, 'manual', 'nuevo',
+       EXISTS (SELECT 1 FROM public.contracts c WHERE c.occupant_id = o.id)
+FROM public.occupants o
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.crm_contacts cc WHERE cc.org_id = o.org_id AND cc.occupant_id = o.id
+);
+
+-- 4. A futuro: cada occupant nuevo crea su registro CRM automáticamente (queda en sync).
+CREATE OR REPLACE FUNCTION public.crm_contact_for_occupant() RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.crm_contacts (org_id, occupant_id, name, phone, email, source, status, is_client)
+  VALUES (NEW.org_id, NEW.id, COALESCE(NULLIF(NEW.name, ''), 'Sin nombre'), NEW.phone, NEW.email, 'manual', 'nuevo', false)
+  ON CONFLICT (org_id, occupant_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_crm_contact_for_occupant ON public.occupants;
+CREATE TRIGGER trg_crm_contact_for_occupant
+  AFTER INSERT ON public.occupants
+  FOR EACH ROW EXECUTE FUNCTION public.crm_contact_for_occupant();


### PR DESCRIPTION
## Fase 2a — Unificar el directorio de personas (CRM ↔ occupants)

Continúa el modelo de `docs/specs/people-crm-stays-model.md` (Fase 2: Party único, ligar no duplicar).

### Problema
Había **dos directorios de personas paralelos**:
- **Contactos** → tabla `occupants`
- **"Directorio" del CRM** → tabla `crm_contacts`

…conectados por un botón **"Importar inquilinos"** que *copiaba* personas de uno a otro. Resultado: sensación de duplicado, dos fuentes de verdad, y registros que se desincronizaban.

### Solución (Party único, 1:1 por DB)
En vez de reescribir el page del CRM (riesgoso en prod, ~560 líneas), unifico **por debajo**:
- Cada persona es **UN `occupant`** = la identidad durable (Party).
- `crm_contacts` se vuelve su **capa comercial 1:1** (estado, fuente, oportunidades).
- Se mantienen en sync **automáticamente** vía la base de datos.

### Cambios

**Migración** `supabase/migrations/20260625_crm_occupant_sync.sql` (idempotente, **no destructiva**):
1. `crm_contacts` huérfanos (sin `occupant_id`) → crea su `occupant` y lo enlaza.
2. **Índice único** `uq_crm_contacts_org_occupant (org_id, occupant_id)` → garantiza el 1:1.
3. Backfill: cada `occupant` sin registro CRM → lo crea (`is_client = true` si ya tiene contrato).
4. **Trigger** `AFTER INSERT ON occupants` → crea su `crm_contacts` automáticamente (`ON CONFLICT DO NOTHING`).

**Frontend** `src/app/clientes/page.tsx`:
- Elimina la función `importOccupants`, su estado `importing` y el botón **"Importar inquilinos"** (ya no hace falta — toda persona aparece sola).

### Validación
- `npx tsc --noEmit` → 0 errores
- `npx eslint src/app/clientes/page.tsx` → 0 warnings

### ⚠️ Para Fran (antes/junto al merge)
Aplicar la migración manualmente en Supabase SQL Editor. **El SQL completo va en el chat.**
Si el paso 2 (índice único) falla, significa que ya existen `crm_contacts` duplicados para una misma persona en una org → avísame y los deduplicamos antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_