### PR TITLE
feat(crm): PersonPicker "buscar antes de crear" (contratos + reservas)

### DIFF
--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, useMemo } from 'react'
-import { Plus, Users, Search, Pencil, X, Save, Phone, Mail, CalendarDays, FileText, ChevronLeft, ChevronDown, ChevronUp } from 'lucide-react'
+import { Plus, Users, Search, Pencil, X, Save, Phone, Mail, CalendarDays, FileText, ChevronLeft, ChevronDown, ChevronUp, AlertTriangle } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { useOrgContext } from '@/hooks/useOrgContext'
 import { useToast } from '@/components/Toast'
@@ -228,7 +228,22 @@ export default function ContactsPage() {
   }
 
   // ─── Form modal (shared for add/edit) ────────────────────────────
-  function renderFormModal(title: string, onSave: () => void, onClose: () => void) {
+  function renderFormModal(title: string, onSave: () => void, onClose: () => void, isAdd = false) {
+    // Buscar-antes-de-crear: al dar de alta, avisar si ya hay alguien con el
+    // mismo teléfono/email (exacto) o un nombre muy parecido. No bloquea — solo
+    // alerta para evitar duplicar a la misma persona.
+    const phone = form.phone.trim()
+    const email = form.email.trim().toLowerCase()
+    const name = form.name.trim().toLowerCase()
+    const dupMatches = isAdd
+      ? contacts.filter((c) => {
+          if (phone && c.phone && c.phone.trim() === phone) return true
+          if (email && c.email && c.email.trim().toLowerCase() === email) return true
+          if (name.length >= 3 && c.name.trim().toLowerCase() === name) return true
+          return false
+        }).slice(0, 4)
+      : []
+
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
         <div className="card w-full max-w-lg mx-4 relative">
@@ -250,6 +265,28 @@ export default function ContactsPage() {
                 className="input-field w-full"
               />
             </div>
+
+            {dupMatches.length > 0 && (
+              <div className="rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-3">
+                <p className="flex items-center gap-1.5 text-xs font-medium text-amber-800 dark:text-amber-300">
+                  <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+                  Ya existe gente con datos similares
+                </p>
+                <ul className="mt-1.5 space-y-1">
+                  {dupMatches.map((c) => (
+                    <li key={c.id} className="text-xs text-amber-700 dark:text-amber-400">
+                      {c.name}
+                      {(c.phone || c.email) && (
+                        <span className="text-amber-600/70 dark:text-amber-400/70"> · {[c.phone, c.email].filter(Boolean).join(' · ')}</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-1.5 text-[11px] text-amber-600/80 dark:text-amber-400/70">
+                  Si es la misma persona, ciérralo y edita la existente para no duplicar.
+                </p>
+              </div>
+            )}
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Teléfono</label>
@@ -675,14 +712,16 @@ export default function ContactsPage() {
       {showAddModal && renderFormModal(
         'Nuevo contacto',
         handleAdd,
-        () => setShowAddModal(false)
+        () => setShowAddModal(false),
+        true,
       )}
 
       {/* Edit Modal */}
       {editingContact && renderFormModal(
         `Editar contacto — ${editingContact.name}`,
         handleSaveEdit,
-        () => setEditingContact(null)
+        () => setEditingContact(null),
+        false,
       )}
 
     </div>

--- a/src/app/contracts/new/page.tsx
+++ b/src/app/contracts/new/page.tsx
@@ -7,7 +7,8 @@ import { supabase } from '@/lib/supabase'
 import { useActiveContext } from '@/lib/useActiveContext'
 import { useToast } from '@/components/Toast'
 import Breadcrumbs from '@/components/Breadcrumbs'
-import type { Unit, Occupant } from '@/types'
+import PersonPicker, { type PickedPerson } from '@/components/PersonPicker'
+import type { Unit } from '@/types'
 import Link from 'next/link'
 
 export default function NewContractPage() {
@@ -15,13 +16,11 @@ export default function NewContractPage() {
   const { activeOrgId } = useActiveContext()
   const toast = useToast()
   const [units, setUnits] = useState<Unit[]>([])
-  const [occupants, setOccupants] = useState<Occupant[]>([])
+  const [tenant, setTenant] = useState<PickedPerson | null>(null)
   const [saving, setSaving] = useState(false)
-  const [newOccupant, setNewOccupant] = useState(false)
 
   const [form, setForm] = useState({
     unit_id: '',
-    occupant_id: '',
     start_date: '',
     end_date: '',
     monthly_amount: '',
@@ -33,20 +32,12 @@ export default function NewContractPage() {
     drive_folder_url: '',
   })
 
-  const [occupantForm, setOccupantForm] = useState({
-    name: '',
-    phone: '',
-    email: '',
-  })
-
   useEffect(() => {
-    Promise.all([
-      supabase.from('units').select('*').order('number'),
-      supabase.from('occupants').select('*').order('name'),
-    ]).then(([unitsRes, occupantsRes]) => {
-      setUnits(unitsRes.data || [])
-      setOccupants(occupantsRes.data || [])
-    })
+    supabase
+      .from('units')
+      .select('*')
+      .order('number')
+      .then(({ data }) => setUnits(data || []))
   }, [])
 
   async function handleSubmit(e: React.FormEvent) {
@@ -59,44 +50,16 @@ export default function NewContractPage() {
       toast.error('No se pudo resolver tu organización; recarga la página e intenta de nuevo')
       return
     }
-    setSaving(true)
-
-    let occupantId = form.occupant_id
-
-    if (newOccupant) {
-      // occupants.type solo admite 'ltr' | 'str' | 'both' (modalidad de renta del
-      // contacto), no roles. Lo derivamos del tipo de renta del contrato.
-      const occupantType = form.rent_type === 'STR' ? 'str' : 'ltr'
-      const { data: occ, error: occError } = await supabase
-        .from('occupants')
-        .insert({
-          org_id: orgId,
-          name: occupantForm.name,
-          phone: occupantForm.phone || null,
-          email: occupantForm.email || null,
-          type: occupantType,
-        })
-        .select()
-        .single()
-
-      if (occError || !occ) {
-        setSaving(false)
-        toast.error(`Error al crear el inquilino${occError ? `: ${occError.message}` : ''}`)
-        return
-      }
-      occupantId = occ.id
-    }
-
-    if (!occupantId) {
-      setSaving(false)
+    if (!tenant) {
       toast.error('Selecciona o crea un inquilino')
       return
     }
+    setSaving(true)
 
     const { error } = await supabase.from('contracts').insert({
       org_id: orgId,
       unit_id: form.unit_id,
-      occupant_id: occupantId,
+      occupant_id: tenant.id,
       start_date: form.start_date,
       end_date: form.end_date || null,
       monthly_amount: Number(form.monthly_amount),
@@ -180,58 +143,17 @@ export default function NewContractPage() {
         </div>
 
         <div>
-          <div className="flex items-center justify-between mb-1">
-            <label className="text-sm text-gray-500 dark:text-gray-400">Inquilino</label>
-            <button
-              type="button"
-              onClick={() => setNewOccupant(!newOccupant)}
-              className="text-xs text-indigo-400 hover:text-indigo-300"
-            >
-              {newOccupant ? 'Seleccionar existente' : 'Crear nuevo'}
-            </button>
-          </div>
-          {newOccupant ? (
-            <div className="space-y-3 p-4 bg-gray-100 dark:bg-gray-800/50 rounded-lg border border-gray-300 dark:border-gray-700">
-              <input
-                type="text"
-                required
-                placeholder="Nombre completo"
-                value={occupantForm.name}
-                onChange={(e) => setOccupantForm({ ...occupantForm, name: e.target.value })}
-                className="input-field"
-              />
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <input
-                  type="tel"
-                  placeholder="Teléfono (+52...)"
-                  value={occupantForm.phone}
-                  onChange={(e) => setOccupantForm({ ...occupantForm, phone: e.target.value })}
-                  className="input-field"
-                />
-                <input
-                  type="email"
-                  placeholder="Email"
-                  value={occupantForm.email}
-                  onChange={(e) => setOccupantForm({ ...occupantForm, email: e.target.value })}
-                  className="input-field"
-                />
-              </div>
-            </div>
-          ) : (
-            <select
-              required={!newOccupant}
-              value={form.occupant_id}
-              onChange={(e) => setForm({ ...form, occupant_id: e.target.value })}
-              className="input-field"
-            >
-              <option value="">Seleccionar inquilino...</option>
-              {occupants.map((o) => (
-                <option key={o.id} value={o.id}>
-                  {o.name} {o.phone ? `(${o.phone})` : ''}
-                </option>
-              ))}
-            </select>
-          )}
+          <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Inquilino</label>
+          <PersonPicker
+            orgId={activeOrgId}
+            value={tenant}
+            onChange={setTenant}
+            newType={form.rent_type === 'STR' ? 'str' : 'ltr'}
+            placeholder="Buscar inquilino por nombre, teléfono o email…"
+          />
+          <p className="mt-1 text-xs text-gray-400">
+            Busca primero; si no existe, créalo desde aquí (se agrega al directorio y al CRM).
+          </p>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { SkeletonTable } from '@/components/Skeleton'
+import PersonPicker, { type PickedPerson } from '@/components/PersonPicker'
 import { formatCurrency, formatDate } from '@/lib/utils'
 import type { Unit, Reservation, BookingMode, ReservationStatus, ReservationPaymentStatus } from '@/types'
 
@@ -126,12 +127,9 @@ export default function ReservationsPage() {
   const [houseRules, setHouseRules] = useState('')
   const [checkInInstructions, setCheckInInstructions] = useState('')
 
-  // Autocomplete state
-  const [allContacts, setAllContacts] = useState<{ id: string; name: string; phone?: string; email?: string }[]>([])
-  const [acResults, setAcResults] = useState<{ id: string; name: string; phone?: string; email?: string }[]>([])
-  const [showAc, setShowAc] = useState(false)
-  const [saveAsContact, setSaveAsContact] = useState(false)
-  const [selectedContactId, setSelectedContactId] = useState<string | null>(null)
+  // Persona ligada (Party). Si es null, el huésped queda solo como texto libre
+  // (caso STR de una noche que no queremos meter al directorio).
+  const [guestPerson, setGuestPerson] = useState<PickedPerson | null>(null)
 
   // List filters
   const [filterUnit, setFilterUnit] = useState<string>('all')
@@ -139,14 +137,12 @@ export default function ReservationsPage() {
 
   // ─── Data loading ────────────────────────────────────────────────
   const loadData = useCallback(async () => {
-    const [unitsRes, resRes, contactsRes] = await Promise.all([
+    const [unitsRes, resRes] = await Promise.all([
       supabase.from('units').select('*').order('number'),
       supabase.from('reservations').select('*, unit:units(*)').order('check_in', { ascending: false }),
-      supabase.from('occupants').select('id, name, phone, email').order('name'),
     ])
     setUnits(unitsRes.data || [])
     setReservations(resRes.data || [])
-    setAllContacts(contactsRes.data || [])
     setLoading(false)
   }, [])
 
@@ -216,28 +212,14 @@ export default function ReservationsPage() {
     }
   }
 
-  // ─── Autocomplete handler ──────────────────────────────────────
-  function handleGuestNameChange(value: string) {
-    setGuestName(value)
-    setSelectedContactId(null)
-    if (value.length >= 2) {
-      const q = value.toLowerCase()
-      const matches = allContacts.filter((c) => c.name.toLowerCase().includes(q))
-      setAcResults(matches.slice(0, 5))
-      setShowAc(matches.length > 0)
-    } else {
-      setAcResults([])
-      setShowAc(false)
+  // Persona seleccionada/creada desde el PersonPicker → llena los datos del huésped.
+  function handlePersonChange(person: PickedPerson | null) {
+    setGuestPerson(person)
+    if (person) {
+      setGuestName(person.name)
+      setGuestPhone(person.phone || '')
+      setGuestEmail(person.email || '')
     }
-  }
-
-  function selectContact(contact: { id: string; name: string; phone?: string; email?: string }) {
-    setGuestName(contact.name)
-    setGuestPhone(contact.phone || '')
-    setGuestEmail(contact.email || '')
-    setSelectedContactId(contact.id)
-    setShowAc(false)
-    setSaveAsContact(false)
   }
 
   // ─── Save reservation ──────────────────────────────────────────
@@ -274,17 +256,9 @@ export default function ReservationsPage() {
     if (error) {
       alert('Error al guardar: ' + error.message)
     } else {
-      // Create contact if checkbox was checked
-      if (saveAsContact && !selectedContactId && guestName) {
-        await supabase.from('occupants').insert({
-          org_id: orgId,
-          name: guestName,
-          phone: guestPhone || null,
-          email: guestEmail || null,
-          type: 'str',
-        })
-      }
-      // Reset form
+      // El huésped ya quedó (o no) en el directorio vía el PersonPicker; aquí no
+      // se crea nada a ciegas. Reset del form.
+      setGuestPerson(null)
       setGuestName('')
       setGuestPhone('')
       setGuestEmail('')
@@ -298,8 +272,6 @@ export default function ReservationsPage() {
       setNotes('')
       setStatus('confirmed')
       setPaymentStatus('pending')
-      setSaveAsContact(false)
-      setSelectedContactId(null)
       setPlatform('')
       setCheckInCode('')
       setWifiName('')
@@ -586,43 +558,22 @@ export default function ReservationsPage() {
           </h2>
 
           <div className="space-y-4">
-            <div className="relative">
+            <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Nombre del huésped *</label>
-              <input
-                type="text"
-                value={guestName}
-                onChange={(e) => handleGuestNameChange(e.target.value)}
-                onBlur={() => setTimeout(() => setShowAc(false), 200)}
-                onFocus={() => { if (guestName.length >= 2 && acResults.length > 0) setShowAc(true) }}
-                placeholder="Nombre completo"
-                className="input-field"
-                autoComplete="off"
+              <PersonPicker
+                orgId={orgId}
+                value={guestPerson}
+                onChange={handlePersonChange}
+                allowFreeText
+                freeText={guestName}
+                onFreeTextChange={setGuestName}
+                newType="str"
+                placeholder="Buscar huésped o escribir nombre…"
               />
-              {showAc && acResults.length > 0 && (
-                <div className="absolute z-20 top-full left-0 right-0 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg overflow-hidden">
-                  {acResults.map((c) => (
-                    <button
-                      key={c.id}
-                      type="button"
-                      onMouseDown={() => selectContact(c)}
-                      className="w-full text-left px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                    >
-                      <p className="text-sm font-medium text-gray-900 dark:text-white">{c.name}</p>
-                      {c.phone && <p className="text-xs text-gray-500 dark:text-gray-400">{c.phone}</p>}
-                    </button>
-                  ))}
-                </div>
-              )}
-              {!selectedContactId && guestName.length >= 2 && (
-                <label className="flex items-center gap-2 mt-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={saveAsContact}
-                    onChange={(e) => setSaveAsContact(e.target.checked)}
-                    className="rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500"
-                  />
-                  Guardar como contacto
-                </label>
+              {!guestPerson && guestName.trim().length >= 2 && (
+                <p className="mt-1 text-xs text-gray-400">
+                  Huésped sin ligar al directorio (queda solo en la reservación).
+                </p>
               )}
             </div>
 

--- a/src/components/PersonPicker.tsx
+++ b/src/components/PersonPicker.tsx
@@ -1,0 +1,396 @@
+'use client'
+
+// BaW OS — PersonPicker: "buscar antes de crear".
+//
+// Componente único de selección de personas para todos los formularios que
+// necesitan ligar a alguien del directorio (contratos, reservaciones, etc.).
+// Busca sobre `occupants` (la identidad durable / Party) por nombre, teléfono o
+// email; si la persona ya existe la reusa (no duplica). Solo cuando NO hay match
+// ofrece crearla, avisando antes si el teléfono/email ya pertenece a alguien.
+//
+// El alta nueva dispara el trigger de DB que mantiene el CRM 1:1 (migración
+// 20260625_crm_occupant_sync), así que toda persona creada aquí aparece sola en
+// Contactos y en el CRM.
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { Search, UserPlus, X, AlertTriangle, Check } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import type { OccupantType } from '@/types'
+
+export type PickedPerson = {
+  id: string
+  name: string
+  phone: string | null
+  email: string | null
+}
+
+type Props = {
+  orgId: string | null | undefined
+  /** Persona ligada actualmente (null = ninguna). */
+  value: PickedPerson | null
+  onChange: (person: PickedPerson | null) => void
+  /**
+   * Texto libre tecleado cuando aún no se liga a una persona del directorio.
+   * Para casos STR donde un huésped de una noche no debe ensuciar el directorio:
+   * el consumidor conserva el nombre aunque no haya Party ligada.
+   */
+  allowFreeText?: boolean
+  freeText?: string
+  onFreeTextChange?: (name: string) => void
+  /** Tipo de renta que se asigna al occupant si se crea uno nuevo. */
+  newType?: OccupantType
+  placeholder?: string
+  inputId?: string
+}
+
+// Limpia el texto para el filtro .or() de PostgREST (la coma separa filtros).
+function sanitize(s: string): string {
+  return s.replace(/[,%()]/g, ' ').trim()
+}
+
+export default function PersonPicker({
+  orgId,
+  value,
+  onChange,
+  allowFreeText = false,
+  freeText = '',
+  onFreeTextChange,
+  newType = 'both',
+  placeholder = 'Buscar por nombre, teléfono o email…',
+  inputId,
+}: Props) {
+  // En modo free-text el texto lo posee el consumidor; si no, es interno.
+  const [internalQuery, setInternalQuery] = useState('')
+  const query = allowFreeText ? freeText : internalQuery
+  const setQuery = useCallback(
+    (v: string) => {
+      if (allowFreeText) onFreeTextChange?.(v)
+      else setInternalQuery(v)
+    },
+    [allowFreeText, onFreeTextChange],
+  )
+
+  const [results, setResults] = useState<PickedPerson[]>([])
+  const [open, setOpen] = useState(false)
+  const [searching, setSearching] = useState(false)
+
+  // Panel de "crear persona"
+  const [createOpen, setCreateOpen] = useState(false)
+  const [createForm, setCreateForm] = useState({ name: '', phone: '', email: '' })
+  const [creating, setCreating] = useState(false)
+  const [dup, setDup] = useState<PickedPerson | null>(null)
+  const [createErr, setCreateErr] = useState<string | null>(null)
+
+  const wrapRef = useRef<HTMLDivElement>(null)
+  // Contador de petición: descarta respuestas que llegan fuera de orden.
+  const reqRef = useRef(0)
+
+  // ─── Búsqueda (debounced, org-scoped, sin archivados) ─────────────
+  const runSearch = useCallback(
+    async (raw: string, reqId: number) => {
+      const q = sanitize(raw)
+      if (!orgId || q.length < 2) {
+        if (reqRef.current === reqId) {
+          setResults([])
+          setSearching(false)
+        }
+        return
+      }
+      const { data } = await supabase
+        .from('occupants')
+        .select('id, name, phone, email')
+        .eq('org_id', orgId)
+        .is('archived_at', null)
+        .or(`name.ilike.%${q}%,phone.ilike.%${q}%,email.ilike.%${q}%`)
+        .order('name')
+        .limit(8)
+      if (reqRef.current !== reqId) return // respuesta obsoleta
+      setResults((data as PickedPerson[]) ?? [])
+      setSearching(false)
+    },
+    [orgId],
+  )
+
+  useEffect(() => {
+    if (value) return // ya hay persona ligada; no buscamos
+    const q = sanitize(query)
+    if (q.length < 2) {
+      setResults([])
+      setSearching(false)
+      return
+    }
+    setSearching(true)
+    const reqId = ++reqRef.current
+    const t = setTimeout(() => runSearch(query, reqId), 220)
+    return () => clearTimeout(t)
+  }, [query, value, runSearch])
+
+  // Cerrar dropdown al hacer click fuera.
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false)
+        setCreateOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDocClick)
+    return () => document.removeEventListener('mousedown', onDocClick)
+  }, [])
+
+  const trimmed = sanitize(query)
+  const exactNameMatch = results.some(
+    (r) => r.name.trim().toLowerCase() === query.trim().toLowerCase(),
+  )
+
+  function pick(person: PickedPerson) {
+    onChange(person)
+    if (allowFreeText) onFreeTextChange?.(person.name)
+    setOpen(false)
+    setResults([])
+  }
+
+  function clear() {
+    const keep = value?.name ?? ''
+    onChange(null)
+    if (allowFreeText) onFreeTextChange?.(keep)
+    else setInternalQuery('')
+  }
+
+  function openCreate() {
+    setCreateForm({ name: query.trim(), phone: '', email: '' })
+    setDup(null)
+    setCreateErr(null)
+    setCreateOpen(true)
+    setOpen(false)
+  }
+
+  // Busca un occupant con el mismo teléfono o email exacto (para no duplicar).
+  async function findDuplicate(): Promise<PickedPerson | null> {
+    if (!orgId) return null
+    const phone = createForm.phone.trim()
+    const email = createForm.email.trim()
+    const ors: string[] = []
+    if (phone) ors.push(`phone.eq.${phone}`)
+    if (email) ors.push(`email.eq.${email}`)
+    if (!ors.length) return null
+    const { data } = await supabase
+      .from('occupants')
+      .select('id, name, phone, email')
+      .eq('org_id', orgId)
+      .is('archived_at', null)
+      .or(ors.join(','))
+      .limit(1)
+    return (data?.[0] as PickedPerson) ?? null
+  }
+
+  async function insertPerson() {
+    if (!orgId) return
+    const name = createForm.name.trim()
+    const { data, error } = await supabase
+      .from('occupants')
+      .insert({
+        org_id: orgId,
+        name,
+        phone: createForm.phone.trim() || null,
+        email: createForm.email.trim() || null,
+        type: newType,
+      })
+      .select('id, name, phone, email')
+      .single()
+    if (error || !data) {
+      setCreateErr(error?.message ?? 'No se pudo crear la persona')
+      return
+    }
+    setCreateOpen(false)
+    pick(data as PickedPerson)
+  }
+
+  async function handleCreate() {
+    const name = createForm.name.trim()
+    if (!name || !orgId) return
+    setCreating(true)
+    setCreateErr(null)
+    const found = await findDuplicate()
+    if (found) {
+      setDup(found)
+      setCreating(false)
+      return
+    }
+    await insertPerson()
+    setCreating(false)
+  }
+
+  async function forceCreate() {
+    setCreating(true)
+    setDup(null)
+    await insertPerson()
+    setCreating(false)
+  }
+
+  // ─── Persona ya ligada → chip ─────────────────────────────────────
+  if (value) {
+    return (
+      <div
+        ref={wrapRef}
+        className="flex items-center justify-between gap-2 rounded-lg border border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/20 px-3 py-2"
+      >
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{value.name}</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+            {value.phone || value.email || 'Sin datos de contacto'}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={clear}
+          className="shrink-0 p-1 rounded-md text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-black/5 dark:hover:bg-white/10"
+          aria-label="Quitar persona seleccionada"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    )
+  }
+
+  // ─── Sin ligar → buscador (+ crear) ──────────────────────────────
+  return (
+    <div ref={wrapRef} className="relative">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+        <input
+          id={inputId}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value)
+            setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          placeholder={placeholder}
+          autoComplete="off"
+          className="input-field w-full pl-9"
+        />
+      </div>
+
+      {open && !createOpen && trimmed.length >= 2 && (
+        <div className="absolute z-30 top-full left-0 right-0 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg overflow-hidden">
+          {results.map((r) => (
+            <button
+              key={r.id}
+              type="button"
+              onClick={() => pick(r)}
+              className="w-full text-left px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            >
+              <p className="text-sm font-medium text-gray-900 dark:text-white">{r.name}</p>
+              {(r.phone || r.email) && (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {[r.phone, r.email].filter(Boolean).join(' · ')}
+                </p>
+              )}
+            </button>
+          ))}
+
+          {results.length === 0 && (
+            <p className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+              {searching ? 'Buscando…' : 'Sin coincidencias en el directorio.'}
+            </p>
+          )}
+
+          {!exactNameMatch && (
+            <button
+              type="button"
+              onClick={openCreate}
+              className="w-full flex items-center gap-2 px-3 py-2 border-t border-gray-100 dark:border-gray-700 text-sm text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-colors"
+            >
+              <UserPlus className="w-4 h-4" />
+              Crear persona «{query.trim()}»
+            </button>
+          )}
+        </div>
+      )}
+
+      {createOpen && (
+        <div className="absolute z-30 top-full left-0 right-0 mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 space-y-3">
+          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+            Nueva persona
+          </p>
+          <input
+            type="text"
+            value={createForm.name}
+            onChange={(e) => setCreateForm({ ...createForm, name: e.target.value })}
+            placeholder="Nombre completo"
+            className="input-field w-full"
+            autoFocus
+          />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <input
+              type="tel"
+              value={createForm.phone}
+              onChange={(e) => setCreateForm({ ...createForm, phone: e.target.value })}
+              placeholder="Teléfono (+52…)"
+              className="input-field w-full"
+            />
+            <input
+              type="email"
+              value={createForm.email}
+              onChange={(e) => setCreateForm({ ...createForm, email: e.target.value })}
+              placeholder="Email"
+              className="input-field w-full"
+            />
+          </div>
+
+          {dup && (
+            <div className="rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-2.5 space-y-2">
+              <p className="flex items-start gap-1.5 text-xs text-amber-800 dark:text-amber-300">
+                <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                <span>
+                  Ya existe <strong>{dup.name}</strong> con ese teléfono/email. ¿Es la misma persona?
+                </span>
+              </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => pick(dup)}
+                  className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-medium"
+                >
+                  <Check className="w-3.5 h-3.5" />
+                  Usar a {dup.name}
+                </button>
+                <button
+                  type="button"
+                  onClick={forceCreate}
+                  disabled={creating}
+                  className="px-2.5 py-1 rounded-md border border-amber-400 dark:border-amber-600 text-amber-800 dark:text-amber-300 text-xs font-medium disabled:opacity-50"
+                >
+                  Crear otra de todos modos
+                </button>
+              </div>
+            </div>
+          )}
+
+          {createErr && <p className="text-xs text-red-500">{createErr}</p>}
+
+          {!dup && (
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setCreateOpen(false)}
+                className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={handleCreate}
+                disabled={creating || !createForm.name.trim()}
+                className="px-3 py-1.5 rounded-md bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white text-xs font-medium"
+              >
+                {creating ? 'Creando…' : 'Crear y seleccionar'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Buscar-antes-de-crear — un solo componente de personas

Tras unificar el directorio (PR #114), esto ataca el **origen** del duplicado: cada formulario que liga a una persona usaba su propio mecanismo (dropdown, autocomplete, "guardar como contacto") y varios **insertaban a ciegas**. Ahora todos reusan el mismo `PersonPicker`.

### `src/components/PersonPicker.tsx` (nuevo)
- **Busca** sobre `occupants` (org-scoped, sin archivados) por **nombre / teléfono / email**.
- Si la persona ya existe → la **reusa** (no duplica). Solo si **no hay match** ofrece crearla.
- Al crear, **avisa si el teléfono/email ya pertenece a alguien** y deja elegir *"Usar a X"* o *"Crear otra de todos modos"*.
- Modo `allowFreeText` para **huéspedes STR de una noche** que no deben ensuciar el directorio (el consumidor conserva el nombre como texto libre, sin Party ligada).
- Robusto ante respuestas de búsqueda **fuera de orden** (contador de petición) y cierra al click-fuera.

### Integraciones
- **`/contracts/new`** — reemplaza el `<select>` de todos los occupants + toggle *"crear nuevo"* (que insertaba a ciegas) por el picker. La selección del inquilino es **requerida**.
- **`/reservations`** — reemplaza el autocomplete por-nombre + checkbox *"Guardar como contacto"* (que insertaba a ciegas) por el picker en modo free-text. Las reservaciones siguen guardando al huésped denormalizado (no hay `occupant_id` en `reservations` — ver follow-up).
- **`/contacts`** — aviso **no-bloqueante** de posibles duplicados al dar de alta (mismo teléfono/email exacto o nombre idéntico), calculado contra el directorio ya cargado.

### Por qué importa
Crear una persona desde el picker dispara el trigger de la migración #114 → aparece **sola** en Contactos y en el CRM. Una persona = un `occupant` (Party), siempre.

### Validación
- `npx tsc --noEmit` → 0 errores
- `npx eslint` (4 archivos) → 0 warnings
- `npm run build` → ✅ exitoso
- Revisión adversarial del diff (lógica, hooks/race conditions, org-scoping, UX) → se endureció el manejo de respuestas fuera de orden; resto sin defectos reales.

### Sin tocar DB
Puro frontend sobre el modelo que ya unificamos. **No requiere migración.**

### Follow-up sugerido (no en este PR)
Agregar `reservations.occupant_id` para **ligar** la reservación a la Party (hoy solo se evita el duplicado en el alta; el huésped ligado no queda persistido en la reservación). Es una migración pequeña que encaja en la Fase 3 (Estancias unificadas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_