### PR TITLE
feat(crm): Party persona/empresa + pagador ≠ ocupante (Fase 2b)

### DIFF
--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, useMemo } from 'react'
-import { Plus, Users, Search, Pencil, X, Save, Phone, Mail, CalendarDays, FileText, ChevronLeft, ChevronDown, ChevronUp, AlertTriangle } from 'lucide-react'
+import { Plus, Users, Search, Pencil, X, Save, Phone, Mail, CalendarDays, FileText, ChevronLeft, ChevronDown, ChevronUp, AlertTriangle, Building2 } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { useOrgContext } from '@/hooks/useOrgContext'
 import { useToast } from '@/components/Toast'
@@ -9,7 +9,7 @@ import { formatDate } from '@/lib/utils'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 import LifecycleActions, { ArchivedBadge } from '@/components/LifecycleActions'
-import type { ContactType, Reservation, Contract } from '@/types'
+import type { ContactType, OccupantKind, Reservation, Contract } from '@/types'
 
 interface Contact {
   id: string
@@ -18,6 +18,7 @@ interface Contact {
   phone?: string
   email?: string
   type?: ContactType
+  kind?: OccupantKind
   notes?: string
   rfc?: string
   razon_social?: string
@@ -63,6 +64,7 @@ export default function ContactsPage() {
     phone: '',
     email: '',
     type: 'both' as ContactType,
+    kind: 'persona' as OccupantKind,
     notes: '',
     rfc: '',
     razon_social: '',
@@ -131,7 +133,7 @@ export default function ContactsPage() {
 
   // ─── Add contact ─────────────────────────────────────────────────
   function openAdd() {
-    setForm({ name: '', phone: '', email: '', type: 'both', notes: '', rfc: '', razon_social: '', regimen_fiscal: '', cp_fiscal: '', email_factura: '', requiere_factura: false })
+    setForm({ name: '', phone: '', email: '', type: 'both', kind: 'persona', notes: '', rfc: '', razon_social: '', regimen_fiscal: '', cp_fiscal: '', email_factura: '', requiere_factura: false })
     setShowFiscal(false)
     setShowAddModal(true)
   }
@@ -145,6 +147,7 @@ export default function ContactsPage() {
       phone: form.phone || null,
       email: form.email || null,
       type: form.type,
+      kind: form.kind,
       notes: form.notes || null,
       rfc: form.rfc || null,
       razon_social: form.razon_social || null,
@@ -166,6 +169,7 @@ export default function ContactsPage() {
       phone: contact.phone || '',
       email: contact.email || '',
       type: (contact.type as ContactType) || 'both',
+      kind: (contact.kind as OccupantKind) || 'persona',
       notes: contact.notes || '',
       rfc: contact.rfc || '',
       razon_social: contact.razon_social || '',
@@ -187,6 +191,7 @@ export default function ContactsPage() {
         phone: form.phone || null,
         email: form.email || null,
         type: form.type,
+        kind: form.kind,
         notes: form.notes || null,
         rfc: form.rfc || null,
         razon_social: form.razon_social || null,
@@ -256,12 +261,33 @@ export default function ContactsPage() {
           <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">{title}</h2>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Nombre *</label>
+              <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Tipo de persona</label>
+              <div className="grid grid-cols-2 gap-2">
+                {(['persona', 'empresa'] as OccupantKind[]).map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => setForm({ ...form, kind: k })}
+                    className={`px-3 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                      form.kind === k
+                        ? 'bg-indigo-600 border-indigo-600 text-white'
+                        : 'border-gray-300 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
+                    }`}
+                  >
+                    {k === 'persona' ? 'Persona' : 'Empresa'}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">
+                {form.kind === 'empresa' ? 'Razón social / Nombre *' : 'Nombre *'}
+              </label>
               <input
                 type="text"
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
-                placeholder="Nombre completo"
+                placeholder={form.kind === 'empresa' ? 'Razón social de la empresa' : 'Nombre completo'}
                 className="input-field w-full"
               />
             </div>
@@ -658,6 +684,12 @@ export default function ContactsPage() {
                       {contact.name}
                     </h3>
                     {contact.archived_at && <ArchivedBadge />}
+                    {contact.kind === 'empresa' && (
+                      <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20">
+                        <Building2 className="w-3 h-3" />
+                        Empresa
+                      </span>
+                    )}
                     <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${TYPE_BADGE[contact.type || 'both']}`}>
                       {TYPE_LABELS[contact.type || 'both']}
                     </span>

--- a/src/app/contracts/[id]/page.tsx
+++ b/src/app/contracts/[id]/page.tsx
@@ -17,6 +17,9 @@ export default function ContractDetailPage() {
   const router = useRouter()
   const [contract, setContract] = useState<Contract | null>(null)
   const [payments, setPayments] = useState<Payment[]>([])
+  // Pagador (Fase 2b): se carga aparte porque payer_occupant_id es columna simple
+  // sin FK (evita ambigüedad de embeds en PostgREST).
+  const [payer, setPayer] = useState<{ name: string; phone: string | null; email: string | null; kind: string | null } | null>(null)
   const [loading, setLoading] = useState(true)
   const [deleteOccupantTarget, setDeleteOccupantTarget] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -50,6 +53,19 @@ export default function ContractDetailPage() {
     setContract(contractRes.data)
     setPayments(paymentsRes.data || [])
     setDriveFolderUrl(contractRes.data?.drive_folder_url || '')
+
+    // Cargar el pagador solo si es distinto del inquilino.
+    const payerId = contractRes.data?.payer_occupant_id
+    if (payerId && payerId !== contractRes.data?.occupant_id) {
+      const { data: payerData } = await supabase
+        .from('occupants')
+        .select('name, phone, email, kind')
+        .eq('id', payerId)
+        .single()
+      setPayer(payerData ?? null)
+    } else {
+      setPayer(null)
+    }
     setLoading(false)
   }
 
@@ -277,6 +293,16 @@ export default function ContractDetailPage() {
           <p className="text-gray-900 dark:text-white font-medium">{occupant?.name || '—'}</p>
           {occupant?.phone && <p className="text-sm text-gray-500 dark:text-gray-400">{occupant.phone}</p>}
           {occupant?.email && <p className="text-sm text-gray-500 dark:text-gray-400">{occupant.email}</p>}
+          {payer && (
+            <div className="mt-3 pt-3 border-t border-gray-100 dark:border-gray-800">
+              <p className="text-xs font-medium text-amber-600 dark:text-amber-400 uppercase tracking-wider">
+                Paga {payer.kind === 'empresa' ? '(empresa)' : ''}
+              </p>
+              <p className="text-gray-900 dark:text-white font-medium">{payer.name}</p>
+              {payer.phone && <p className="text-sm text-gray-500 dark:text-gray-400">{payer.phone}</p>}
+              {payer.email && <p className="text-sm text-gray-500 dark:text-gray-400">{payer.email}</p>}
+            </div>
+          )}
         </div>
         <div className="card space-y-3">
           <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">

--- a/src/app/contracts/new/page.tsx
+++ b/src/app/contracts/new/page.tsx
@@ -17,6 +17,9 @@ export default function NewContractPage() {
   const toast = useToast()
   const [units, setUnits] = useState<Unit[]>([])
   const [tenant, setTenant] = useState<PickedPerson | null>(null)
+  // Pagador ≠ inquilino (Fase 2b): ej. una empresa paga el contrato de su empleado.
+  const [otherPayer, setOtherPayer] = useState(false)
+  const [payer, setPayer] = useState<PickedPerson | null>(null)
   const [saving, setSaving] = useState(false)
 
   const [form, setForm] = useState({
@@ -54,12 +57,20 @@ export default function NewContractPage() {
       toast.error('Selecciona o crea un inquilino')
       return
     }
+    if (otherPayer && !payer) {
+      toast.error('Selecciona quién paga, o desmarca "Paga alguien más"')
+      return
+    }
     setSaving(true)
+
+    // Pagador: solo se guarda si está activo, hay alguien y es distinto al inquilino.
+    const payerId = otherPayer && payer && payer.id !== tenant.id ? payer.id : null
 
     const { error } = await supabase.from('contracts').insert({
       org_id: orgId,
       unit_id: form.unit_id,
       occupant_id: tenant.id,
+      payer_occupant_id: payerId,
       start_date: form.start_date,
       end_date: form.end_date || null,
       monthly_amount: Number(form.monthly_amount),
@@ -154,6 +165,35 @@ export default function NewContractPage() {
           <p className="mt-1 text-xs text-gray-400">
             Busca primero; si no existe, créalo desde aquí (se agrega al directorio y al CRM).
           </p>
+        </div>
+
+        <div>
+          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={otherPayer}
+              onChange={(e) => {
+                setOtherPayer(e.target.checked)
+                if (!e.target.checked) setPayer(null)
+              }}
+              className="rounded border-gray-300 bg-gray-100 text-indigo-600 dark:border-gray-700 dark:bg-gray-800"
+            />
+            Paga alguien más (ej. una empresa)
+          </label>
+          {otherPayer && (
+            <div className="mt-2">
+              <PersonPicker
+                orgId={activeOrgId}
+                value={payer}
+                onChange={setPayer}
+                newType="ltr"
+                placeholder="Buscar pagador (persona o empresa)…"
+              />
+              <p className="mt-1 text-xs text-gray-400">
+                Quien paga y factura. Puede ser una empresa; los datos fiscales van en su ficha de Contactos.
+              </p>
+            </div>
+          )}
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,8 @@ export type BookingMode = 'full' | 'room' | 'bed'
 // occupants.type en la BD: CHECK IN ('ltr','str','both') — modalidad de renta
 // del contacto, no un rol. (migration 20260330_occupants_type.sql)
 export type OccupantType = 'ltr' | 'str' | 'both'
+// Party: la identidad durable puede ser persona física o empresa (Fase 2b).
+export type OccupantKind = 'persona' | 'empresa'
 export type AncillaryKind = 'parking' | 'billboard' | 'storage' | 'antenna' | 'other'
 export type AncillaryCadence = 'monthly' | 'annual'
 export type AncillaryOwnership = 'ours' | 'third_party'
@@ -176,6 +178,7 @@ export interface Occupant {
   id_type?: string
   id_number?: string
   type: OccupantType
+  kind?: OccupantKind // persona | empresa (Fase 2b); default 'persona'
   contact_type?: ContactType
   notes?: string
   // Fiscal data (#9, #10)
@@ -198,6 +201,7 @@ export interface Contract {
   org_id: string
   unit_id?: string | null // NULL = contrato independiente (standalone)
   occupant_id: string
+  payer_occupant_id?: string | null // quién paga si ≠ inquilino (Fase 2b); NULL = el inquilino
   start_date: string
   end_date?: string
   monthly_amount: number

--- a/supabase/migrations/20260627_party_kind_payer.sql
+++ b/supabase/migrations/20260627_party_kind_payer.sql
@@ -1,0 +1,36 @@
+-- BaW OS — Fase 2b: Party persona/empresa + separar pagador ≠ ocupante.
+--
+-- Cimiento del caso corporativo: una empresa puede ser una "Party" de primera
+-- clase (la que paga y factura) distinta de quien ocupa el inmueble.
+--
+-- Idempotente. NO destructivo (solo agrega columnas, defaults seguros).
+
+-- 1. occupants.kind — la Party puede ser persona física o empresa.
+--    Default 'persona' para no tocar nada existente; las empresas se marcan en UI.
+ALTER TABLE public.occupants
+  ADD COLUMN IF NOT EXISTS kind text NOT NULL DEFAULT 'persona';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'occupants_kind_check'
+  ) THEN
+    ALTER TABLE public.occupants
+      ADD CONSTRAINT occupants_kind_check CHECK (kind IN ('persona', 'empresa'));
+  END IF;
+END $$;
+
+-- 2. contracts.payer_occupant_id — quién paga, si es ≠ del inquilino (ej. la
+--    empresa paga el contrato de su empleado). NULL ⇒ paga el propio inquilino
+--    (comportamiento actual, intacto).
+--
+--    IMPORTANTE: columna uuid SIN foreign key a propósito. Una segunda FK
+--    contracts→occupants volvería AMBIGUOS los embeds `occupant:occupants(...)`
+--    de PostgREST en ~25 lugares de la app (finanzas, cobros, facturas, etc.),
+--    rompiéndolos. El PersonPicker garantiza ids válidos; la FK formal queda como
+--    follow-up junto con un sweep que desambigüe esos embeds (occupant_id).
+ALTER TABLE public.contracts
+  ADD COLUMN IF NOT EXISTS payer_occupant_id uuid;
+
+CREATE INDEX IF NOT EXISTS idx_contracts_payer_occupant
+  ON public.contracts (payer_occupant_id);


### PR DESCRIPTION
## Fase 2b — Cimiento del caso corporativo

Separa **quién paga** de **quién ocupa**, y permite registrar **empresas** como Party de primera clase. Continúa `docs/specs/people-crm-stays-model.md` (§6 corporativo).

### Migración `20260627_party_kind_payer.sql` (idempotente, no destructiva)
- **`occupants.kind`** = `'persona' | 'empresa'` (default `'persona'`, con CHECK).
- **`contracts.payer_occupant_id`** = `uuid` indexado. **Sin FK a propósito** ⚠️ — ver nota abajo.

### ⚠️ Por qué `payer_occupant_id` NO tiene foreign key
Una **segunda FK** `contracts→occupants` volvería **ambiguos** los embeds `occupant:occupants(...)` de PostgREST en **~25 lugares** de la app (finanzas, cobros, facturas, payments, dashboard…) y los rompería en runtime (error 300 "more than one relationship"). El `PersonPicker` ya garantiza ids válidos. La FK formal queda como **follow-up** junto con un sweep que desambigüe esos embeds a `occupant:occupants!occupant_id(...)`. Es la decisión de menor blast-radius para producción.

### UI
- **Contactos** — toggle **Persona / Empresa** al crear/editar, badge **"Empresa"** en la lista, y el label del nombre se adapta a *"Razón social"* para empresas. (Reusa los datos fiscales que ya existían.)
- **Contrato nuevo** — casilla **"Paga alguien más (ej. una empresa)"** que revela un `PersonPicker` para el pagador. Se guarda solo si es **≠** del inquilino; valida que elijas a alguien si marcas la casilla.
- **Detalle de contrato** — muestra al **pagador** cuando es distinto del inquilino (cargado con un query aparte, ya que la columna no tiene FK).

### Tipos
`OccupantKind`, `Occupant.kind`, `Contract.payer_occupant_id`.

### Fuera de alcance (va a Fase 3)
La **rotación de ocupantes** (`stay_occupants` con rangos de fecha) necesita el modelo de Estancias por debajo, así que se construye en la Fase 3 (Estancias unificadas + engagements corporativos).

### Validación
- `npx tsc --noEmit` → 0 errores
- `npx eslint` → 0 errores (2 warnings exhaustive-deps **pre-existentes** en el detalle de contrato, ajenos a este cambio)
- `npm run build` → ✅ exitoso

### ⚠️ Para Fran (antes/junto al merge)
Corre la migración en Supabase. **El SQL completo va en el chat.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_