### PR TITLE
feat(estancias): ocupantes por estancia + rotación (Fase 3b)

### DIFF
--- a/src/app/contracts/[id]/page.tsx
+++ b/src/app/contracts/[id]/page.tsx
@@ -8,6 +8,7 @@ import { formatCurrency, formatDate, daysUntil } from '@/lib/utils'
 import { useToast } from '@/components/Toast'
 import Breadcrumbs from '@/components/Breadcrumbs'
 import { SkeletonDashboard } from '@/components/Skeleton'
+import StayOccupants from '@/components/StayOccupants'
 import type { Contract, Payment } from '@/types'
 import { getAlertLevel, getAlertColor, getAlertText } from '@/lib/contract-alerts'
 import Link from 'next/link'
@@ -314,6 +315,8 @@ export default function ContractDetailPage() {
           <p className="text-sm text-gray-500 dark:text-gray-400">Tipo: {unit?.type || '—'}</p>
         </div>
       </div>
+
+      <StayOccupants contractId={contract.id} orgId={contract.org_id} />
 
       <div className="card">
         <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">

--- a/src/components/StayOccupants.tsx
+++ b/src/components/StayOccupants.tsx
@@ -1,0 +1,235 @@
+'use client'
+
+// BaW OS — Ocupantes de una estancia (Fase 3b).
+//
+// Lista y administra quién OCUPA un contrato (o reservación), aparte del titular
+// y del pagador. Soporta varios ocupantes y rangos de fecha para rotación (ej.
+// una empresa cuyos empleados se turnan semana a semana). Usa el PersonPicker
+// para no duplicar personas.
+
+import { useCallback, useEffect, useState } from 'react'
+import { Users, Trash2, Plus, X } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { useToast } from '@/components/Toast'
+import PersonPicker, { type PickedPerson } from '@/components/PersonPicker'
+import { formatDate } from '@/lib/utils'
+
+type StayRole = 'titular' | 'ocupante' | 'dependiente'
+
+type Row = {
+  id: string
+  role: StayRole
+  start_date: string | null
+  end_date: string | null
+  occupant: { name: string; phone: string | null } | null
+}
+
+const ROLE_LABELS: Record<StayRole, string> = {
+  titular: 'Titular',
+  ocupante: 'Ocupante',
+  dependiente: 'Dependiente',
+}
+
+function one<T>(rel: T | T[] | null | undefined): T | null {
+  if (Array.isArray(rel)) return rel[0] ?? null
+  return rel ?? null
+}
+
+export default function StayOccupants({
+  contractId,
+  orgId,
+}: {
+  contractId: string
+  orgId: string | null | undefined
+}) {
+  const toast = useToast()
+  const [rows, setRows] = useState<Row[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [adding, setAdding] = useState(false)
+  const [person, setPerson] = useState<PickedPerson | null>(null)
+  const [role, setRole] = useState<StayRole>('ocupante')
+  const [start, setStart] = useState('')
+  const [end, setEnd] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    const { data } = await supabase
+      .from('stay_occupants')
+      .select('id, role, start_date, end_date, occupant:occupants(name, phone)')
+      .eq('contract_id', contractId)
+      .order('created_at')
+    const normalized: Row[] = (data ?? []).map((r) => ({
+      id: r.id,
+      role: r.role as StayRole,
+      start_date: r.start_date ?? null,
+      end_date: r.end_date ?? null,
+      occupant: one<{ name: string; phone: string | null }>(r.occupant),
+    }))
+    setRows(normalized)
+    setLoading(false)
+  }, [contractId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  function resetForm() {
+    setPerson(null)
+    setRole('ocupante')
+    setStart('')
+    setEnd('')
+    setAdding(false)
+  }
+
+  async function handleAdd() {
+    if (!person || !orgId) return
+    if (start && end && end < start) {
+      toast.error('La fecha de fin no puede ser anterior a la de inicio')
+      return
+    }
+    setSaving(true)
+    const { error } = await supabase.from('stay_occupants').insert({
+      org_id: orgId,
+      contract_id: contractId,
+      occupant_id: person.id,
+      role,
+      start_date: start || null,
+      end_date: end || null,
+    })
+    setSaving(false)
+    if (error) {
+      // Violación de UNIQUE (misma persona dos veces en la estancia) u otra.
+      toast.error(
+        error.code === '23505'
+          ? 'Esa persona ya está en la estancia'
+          : `No se pudo agregar: ${error.message}`,
+      )
+      return
+    }
+    resetForm()
+    load()
+  }
+
+  async function handleRemove(id: string) {
+    const { error } = await supabase.from('stay_occupants').delete().eq('id', id)
+    if (error) {
+      toast.error('No se pudo quitar')
+      return
+    }
+    load()
+  }
+
+  return (
+    <div className="card space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider flex items-center gap-2">
+          <Users className="w-4 h-4" />
+          Ocupantes de la estancia
+        </h3>
+        {!adding && (
+          <button
+            onClick={() => setAdding(true)}
+            className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Agregar
+          </button>
+        )}
+      </div>
+
+      <p className="text-xs text-gray-400">
+        Quién usa la unidad (aparte del titular y del pagador). Soporta varios y rotación por fechas.
+      </p>
+
+      {loading ? (
+        <p className="text-sm text-gray-400">Cargando…</p>
+      ) : rows.length === 0 && !adding ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Sin ocupantes declarados.</p>
+      ) : (
+        <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+          {rows.map((r) => (
+            <li key={r.id} className="flex items-center justify-between gap-2 py-2">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                  {r.occupant?.name ?? '—'}
+                  <span className="ml-2 inline-flex px-1.5 py-0.5 rounded text-[11px] font-medium bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                    {ROLE_LABELS[r.role]}
+                  </span>
+                </p>
+                <p className="text-xs text-gray-400">
+                  {r.start_date || r.end_date
+                    ? `${r.start_date ? formatDate(r.start_date) : '…'} → ${r.end_date ? formatDate(r.end_date) : '…'}`
+                    : 'Sin rango de fechas'}
+                  {r.occupant?.phone ? ` · ${r.occupant.phone}` : ''}
+                </p>
+              </div>
+              <button
+                onClick={() => handleRemove(r.id)}
+                title="Quitar ocupante"
+                className="shrink-0 p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition-colors"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {adding && (
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              Nuevo ocupante
+            </p>
+            <button onClick={resetForm} className="p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+          <PersonPicker
+            orgId={orgId}
+            value={person}
+            onChange={setPerson}
+            newType="ltr"
+            placeholder="Buscar o crear ocupante…"
+          />
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value as StayRole)}
+              className="input-field text-sm"
+            >
+              <option value="ocupante">Ocupante</option>
+              <option value="titular">Titular</option>
+              <option value="dependiente">Dependiente</option>
+            </select>
+            <input
+              type="date"
+              value={start}
+              onChange={(e) => setStart(e.target.value)}
+              className="input-field text-sm"
+              title="Desde (opcional)"
+            />
+            <input
+              type="date"
+              value={end}
+              onChange={(e) => setEnd(e.target.value)}
+              className="input-field text-sm"
+              title="Hasta (opcional)"
+            />
+          </div>
+          <div className="flex justify-end">
+            <button
+              onClick={handleAdd}
+              disabled={saving || !person}
+              className="px-3 py-1.5 rounded-md bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white text-xs font-medium"
+            >
+              {saving ? 'Agregando…' : 'Agregar a la estancia'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/supabase/migrations/20260627_stay_occupants.sql
+++ b/supabase/migrations/20260627_stay_occupants.sql
@@ -1,0 +1,52 @@
+-- BaW OS — Fase 3b: ocupantes por estancia (rotación).
+--
+-- Una estancia (contrato o reservación) puede tener VARIOS ocupantes y rotar en
+-- el tiempo (distinta gente en distintas semanas). El que paga (contracts
+-- .payer_occupant_id, Fase 2b) puede ser ≠ de los que ocupan. Esto modela "la
+-- empresa firma, los empleados ocupan y rotan".
+--
+-- Tabla polimórfica: cuelga de UN contrato O de UNA reservación (no hay tabla
+-- `stays` unificada todavía; eso es Fase 3c). occupant_id apunta al Party
+-- (occupants). Idempotente, no destructiva.
+
+CREATE TABLE IF NOT EXISTS public.stay_occupants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  contract_id uuid REFERENCES public.contracts(id) ON DELETE CASCADE,
+  reservation_id uuid REFERENCES public.reservations(id) ON DELETE CASCADE,
+  occupant_id uuid NOT NULL REFERENCES public.occupants(id) ON DELETE CASCADE,
+  role text NOT NULL DEFAULT 'ocupante',
+  start_date date,
+  end_date date,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  -- Exactamente un padre: contrato XOR reservación.
+  CONSTRAINT stay_occupants_one_parent CHECK (
+    (contract_id IS NOT NULL AND reservation_id IS NULL) OR
+    (contract_id IS NULL AND reservation_id IS NOT NULL)
+  ),
+  CONSTRAINT stay_occupants_role_check CHECK (role IN ('titular', 'ocupante', 'dependiente')),
+  -- Una misma persona no se repite en la misma estancia.
+  CONSTRAINT stay_occupants_unique_contract UNIQUE (contract_id, occupant_id),
+  CONSTRAINT stay_occupants_unique_reservation UNIQUE (reservation_id, occupant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stay_occupants_contract
+  ON public.stay_occupants (contract_id) WHERE contract_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_stay_occupants_reservation
+  ON public.stay_occupants (reservation_id) WHERE reservation_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_stay_occupants_occupant
+  ON public.stay_occupants (occupant_id);
+
+-- RLS: mismo patrón que el resto (miembros de la org).
+ALTER TABLE public.stay_occupants ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS stay_occupants_member ON public.stay_occupants;
+CREATE POLICY stay_occupants_member ON public.stay_occupants FOR ALL
+  USING (EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = stay_occupants.org_id AND om.user_id = auth.uid()
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = stay_occupants.org_id AND om.user_id = auth.uid()
+  ));


### PR DESCRIPTION
## Fase 3b — Ocupantes por estancia (la rotación)

El cimiento que faltó de la 2b: una estancia puede tener **varios ocupantes** y **rotar** en el tiempo (distinta gente, distintas semanas). El que **paga** (`payer_occupant_id`, Fase 2b) puede ser **≠** de los que **ocupan**. Esto completa el caso corporativo: *la empresa firma y paga, los empleados ocupan y se turnan.*

### Migración `20260627_stay_occupants.sql` (idempotente, no destructiva)
Tabla **`stay_occupants`**, polimórfica:
- Cuelga de **`contract_id` XOR `reservation_id`** (no hay tabla `stays` unificada todavía — eso es 3c). `occupant_id` → `occupants` (el Party).
- `role` = `titular | ocupante | dependiente`; `start_date` / `end_date` para la rotación.
- `UNIQUE (contract|reservation, occupant)` → una persona no se repite en la misma estancia.
- Índices + **RLS por org** (mismo patrón `org_members` + `auth.uid()` que el resto).

### UI — componente `StayOccupants`
En el **detalle de contrato**, una sección **"Ocupantes de la estancia"**:
- Lista los ocupantes (nombre, rol, rango de fechas).
- **Agrega** vía `PersonPicker` (sin duplicar personas), con rol y rango opcional.
- **Quita** ocupantes. Valida `fin ≥ inicio` y avisa si la persona ya está en la estancia.
- Es **aparte** del titular (`occupant_id`) y del pagador.

Por ahora solo se conecta la UI de **contratos**; la tabla ya soporta `reservation_id` para una fase posterior.

### Validación
- `npx tsc --noEmit` → 0 errores
- `npx eslint` → 0 errores (2 warnings exhaustive-deps **pre-existentes** en el detalle de contrato)
- `npm run build` → ✅

### ⚠️ Para Fran (antes/junto al merge)
Corre la migración en Supabase. **El SQL completo va en el chat.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_