### PR TITLE
fix(contracts): editar contrato no guardaba (columna inexistente + error silencioso)

### DIFF
--- a/src/app/api/v1/contracts/route.ts
+++ b/src/app/api/v1/contracts/route.ts
@@ -16,7 +16,7 @@ export const GET = v1Read({
     let q = supabase
       .from('contracts')
       .select(
-        'id, org_id, unit_id, occupant_id, start_date, end_date, monthly_amount, deposit_amount, deposit_paid, payment_day, status, contract_url, created_at, updated_at'
+        'id, org_id, unit_id, occupant_id, start_date, end_date, monthly_amount, deposit_amount, deposit_paid, payment_day, status, drive_folder_url, created_at, updated_at'
       )
       .eq('org_id', auth.orgId)
       .order('created_at', { ascending: false })

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -96,7 +96,8 @@ export default function ContractsPage() {
     if (editForm.drive_link) {
       notesValue = notesValue ? `${notesValue}\n📎 ${editForm.drive_link}` : `📎 ${editForm.drive_link}`
     }
-    await supabase
+    // .select() para detectar updates de 0 filas (RLS que bloquea en silencio).
+    const { data, error } = await supabase
       .from('contracts')
       .update({
         monthly_amount: editForm.monthly_amount,
@@ -112,8 +113,20 @@ export default function ContractsPage() {
         contract_url: editForm.drive_link || null,
       })
       .eq('id', editingContract.id)
-    setEditingContract(null)
+      .select('id')
     setSaving(false)
+    if (error) {
+      toast.error(`No se pudo guardar: ${error.message}`)
+      return
+    }
+    if (!data || data.length === 0) {
+      // El UPDATE no afectó filas: típicamente RLS (tu rol de miembro no tiene
+      // permiso de escritura sobre contratos). Ver issue #23 (roles legacy).
+      toast.error('No se guardó: sin permiso de escritura sobre este contrato.')
+      return
+    }
+    setEditingContract(null)
+    toast.success('Contrato actualizado')
     fetchContracts()
   }
 

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -73,7 +73,7 @@ export default function ContractsPage() {
 
   function openEdit(contract: Contract) {
     setEditingContract(contract)
-    const existingLink = contract.contract_url || contract.notes?.match(/📎 (https?:\/\/\S+)/)?.[1] || ''
+    const existingLink = contract.drive_folder_url || contract.contract_url || contract.notes?.match(/📎 (https?:\/\/\S+)/)?.[1] || ''
     setEditForm({
       monthly_amount: contract.monthly_amount,
       payment_day: contract.payment_day,
@@ -92,11 +92,9 @@ export default function ContractsPage() {
   async function handleSaveEdit() {
     if (!editingContract) return
     setSaving(true)
-    let notesValue = editForm.notes || ''
-    if (editForm.drive_link) {
-      notesValue = notesValue ? `${notesValue}\n📎 ${editForm.drive_link}` : `📎 ${editForm.drive_link}`
-    }
     // .select() para detectar updates de 0 filas (RLS que bloquea en silencio).
+    // El link de Drive va a drive_folder_url (la columna real); contract_url no
+    // existe en la tabla y rompía el UPDATE entero.
     const { data, error } = await supabase
       .from('contracts')
       .update({
@@ -105,12 +103,12 @@ export default function ContractsPage() {
         status: editForm.status,
         rent_type: editForm.rent_type,
         start_date: editForm.start_date || null,
-        notes: notesValue || null,
+        notes: editForm.notes || null,
         end_date: editForm.end_date || null,
         aval: editForm.aval || null,
         curp_arrendatario: editForm.curp_arrendatario || null,
         domicilio_arrendatario: editForm.domicilio_arrendatario || null,
-        contract_url: editForm.drive_link || null,
+        drive_folder_url: editForm.drive_link || null,
       })
       .eq('id', editingContract.id)
       .select('id')


### PR DESCRIPTION
## Bug: editar un contrato no guarda nada

**Reportado:** al corregir la *fecha fin* (2026 → 2027) y dar "Guardar", el modal cierra pero el cambio **no persiste** — al reabrir sigue igual y el contrato sigue "vencido". De hecho **ningún** campo del editor se guardaba.

## Causa raíz (confirmada)
El `UPDATE` de edición escribía a la columna **`contract_url`**, que **no existe** en la tabla `contracts` (verificado en `information_schema` → 0 filas). Postgres rechaza el UPDATE completo, y como el código **se tragaba el error**, el modal cerraba como si todo bien.

La columna real del link de Drive es **`drive_folder_url`** (la que usa `/contracts/new`).

## Fix
**1. No fallar en silencio** (`handleSaveEdit`):
- el `UPDATE` ahora usa `.select()` y revisa el resultado → **error** = toast con el mensaje real; **0 filas** = aviso de permisos (RLS); **éxito** = confirmación.

**2. Escribir a la columna correcta:**
- el link de Drive va a **`drive_folder_url`**; se elimina `contract_url` del UPDATE (y el hack de meter el link en `notes`).
- `openEdit` lee el link desde `drive_folder_url` (con fallback a `notes` legacy).

**3. Bonus — mismo bug latente:**
- `/api/v1/contracts` seleccionaba `contract_url` por nombre → el endpoint daba **500**; ahora selecciona `drive_folder_url`.

### Validación
- `npx tsc --noEmit` → 0 errores
- `npx eslint` → limpio
- `npm run build` → ✅
- No requiere migración (la columna `drive_folder_url` ya existe).

### Para probar (después del merge)
Edita un contrato, cambia la fecha fin y guarda → ahora persiste y sale toast de confirmación. Reabre para verificar. Si algo fallara, ahora el sistema te dice por qué en vez de cerrar callado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)