### PR TITLE
fix(cobros): renombrar botón "Marcar pagado" → "Registrar pago"

### DIFF
--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -612,7 +612,7 @@ export default function CobrosPage() {
                             className="inline-flex items-center gap-1 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-xs font-medium transition-colors"
                           >
                             <Check className="w-3 h-3" />
-                            Marcar pagado
+                            Registrar pago
                           </button>
                         ) : (
                           <div className="flex items-center justify-center gap-2">


### PR DESCRIPTION
## UX: el botón engañaba

En **Cobros**, el botón verde decía **"Marcar pagado"**, pero **no marca pagado de inmediato** — abre el modal **"Registrar pago"** donde capturas renta, agua, **mora editable**, **pago parcial**, fecha, método y referencia.

El nombre hacía pensar que marcaba el mes como pagado de un clic, y escondía el flujo de pago parcial / mora. Ahora el botón dice **"Registrar pago"**, igual que el título del modal.

Cambio de una línea, sin lógica.

### Validación
- `npx tsc --noEmit` → 0 errores
- `npx eslint` → limpio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_