### PR TITLE
feat(contracts): "Facturar desde" — separar facturación de la fecha real del contrato

### DIFF
--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -21,6 +21,7 @@ interface ContractRow {
   payment_day: number
   status: string
   start_date: string | null
+  billing_start_date: string | null
   unit: { number: string } | null
   occupant: { name: string } | null
 }
@@ -178,7 +179,7 @@ export default function CobrosPage() {
     const contractsRes = await supabase
       .from('contracts')
       .select(
-        'id, unit_id, occupant_id, monthly_amount, payment_day, status, start_date, unit:units(number), occupant:occupants(name)',
+        'id, unit_id, occupant_id, monthly_amount, payment_day, status, start_date, billing_start_date, unit:units(number), occupant:occupants(name)',
       )
       .in('status', ['active', 'en_renovacion'])
       .eq('org_id', orgId)
@@ -212,7 +213,7 @@ export default function CobrosPage() {
     const billingRows: BillingRow[] = []
     for (const c of contracts) {
       const day = c.payment_day || 1
-      for (const month of scheduleMonths(c.start_date, selectedMonth)) {
+      for (const month of scheduleMonths(c.billing_start_date ?? c.start_date, selectedMonth)) {
         const dueDate = `${month}-${pad2(day)}`
         const payment = paymentByKey.get(`${c.id}|${month}`) || null
 

--- a/src/app/contracts/new/page.tsx
+++ b/src/app/contracts/new/page.tsx
@@ -25,6 +25,7 @@ export default function NewContractPage() {
   const [form, setForm] = useState({
     unit_id: '',
     start_date: '',
+    billing_start_date: '',
     end_date: '',
     monthly_amount: '',
     deposit_amount: '',
@@ -72,6 +73,7 @@ export default function NewContractPage() {
       occupant_id: tenant.id,
       payer_occupant_id: payerId,
       start_date: form.start_date,
+      billing_start_date: form.billing_start_date || null,
       end_date: form.end_date || null,
       monthly_amount: Number(form.monthly_amount),
       deposit_amount: form.deposit_amount ? Number(form.deposit_amount) : null,
@@ -216,6 +218,22 @@ export default function NewContractPage() {
               className="input-field"
             />
           </div>
+        </div>
+
+        <div>
+          <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">
+            Facturar desde <span className="text-gray-400 font-normal">(opcional)</span>
+          </label>
+          <input
+            type="date"
+            value={form.billing_start_date}
+            onChange={(e) => setForm({ ...form, billing_start_date: e.target.value })}
+            className="input-field"
+          />
+          <p className="mt-1 text-xs text-gray-400">
+            Mes desde el que Cobros genera cargos. Déjalo vacío para facturar desde la fecha de inicio.
+            Útil en contratos viejos que siguen vigentes: registras su fecha real pero solo cobras el periodo reciente.
+          </p>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -203,6 +203,7 @@ export interface Contract {
   occupant_id: string
   payer_occupant_id?: string | null // quién paga si ≠ inquilino (Fase 2b); NULL = el inquilino
   start_date: string
+  billing_start_date?: string | null // Cobros factura desde aquí; NULL = desde start_date
   end_date?: string
   monthly_amount: number
   deposit_amount?: number

--- a/supabase/migrations/20260628_contracts_billing_start.sql
+++ b/supabase/migrations/20260628_contracts_billing_start.sql
@@ -1,0 +1,13 @@
+-- BaW OS — Separar la fecha de facturación de la fecha real del contrato.
+--
+-- Caso: contratos viejos (2023/2024) que siguen vigentes mes a mes. Queremos
+-- registrar su fecha REAL de inicio (historial, antigüedad, CRM) sin que Cobros
+-- genere 2 años de adeudo no verificado. `billing_start_date` controla desde qué
+-- mes se generan los cobros; si es NULL, se factura desde `start_date` (igual que
+-- hoy). Aditiva, no destructiva.
+
+ALTER TABLE public.contracts
+  ADD COLUMN IF NOT EXISTS billing_start_date date;
+
+COMMENT ON COLUMN public.contracts.billing_start_date IS
+  'Mes desde el que Cobros genera cargos. NULL = desde start_date. Permite registrar la fecha real del contrato sin facturar todo el histórico.';


### PR DESCRIPTION
## Registrar contratos viejos sin generar 2 años de adeudo falso

Para dar de alta los contratos del edificio 809: varios arrancaron en **2023/2024** y siguen vigentes mes a mes. Queremos su **fecha real** (historial, antigüedad, CRM) pero **sin** que Cobros genere ~24 meses de adeudo que aún no está verificado con el conserje.

### Solución
Separar **la fecha del contrato** de **desde cuándo se factura**:
- **Migración `20260628_contracts_billing_start.sql`**: `contracts.billing_start_date` (date, nullable).
- **Cobros**: `scheduleMonths(billing_start_date ?? start_date, …)` — si está vacío, factura desde `start_date` (igual que hoy).
- **`/contracts/new`**: campo **"Facturar desde (opcional)"**.

Así registras el contrato con su inicio real de 2023, pero Cobros solo genera renglones **desde 2026**. Cuando el conserje verifique pagos viejos, bajas la fecha y aparece más historial.

### Validación
- `npx tsc --noEmit` → 0 · `npx eslint` → limpio · `npm run build` → ✅

### ⚠️ Para Fran (antes/junto al merge)
```sql
ALTER TABLE public.contracts ADD COLUMN IF NOT EXISTS billing_start_date date;
COMMENT ON COLUMN public.contracts.billing_start_date IS
  'Mes desde el que Cobros genera cargos. NULL = desde start_date.';
```
Aditiva, no destructiva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_