### PR TITLE
fix(nav): reordenar sub-tabs de Inquilinos en dos grupos

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -105,11 +105,13 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     placement: 'top',
     routes: ['/contacts', '/estancias', '/contracts', '/applications', '/clientes'],
     subNav: [
+      // Grupo "gente" (uso diario): directorio → ocupación → relación comercial.
       { href: '/contacts', label: 'Contactos' },
       { href: '/estancias', label: 'Estancias' },
+      { href: '/clientes', label: 'CRM', matchPrefix: '/clientes' },
+      // Grupo "papeleo": acuerdos firmados → filtro de aprobación.
       { href: '/contracts', label: 'Contratos' },
       { href: '/applications', label: 'Expedientes' },
-      { href: '/clientes', label: 'CRM', matchPrefix: '/clientes' },
     ],
   },
   {


### PR DESCRIPTION
## Sub-tabs de Inquilinos: agrupar por uso

Estaban intercalados (`Contactos · Estancias · Contratos · Expedientes · CRM`). Se reagrupan en dos bloques lógicos:

- 👥 **Gente** (uso diario): **Contactos · Estancias · CRM** — quiénes son, qué ocupan, la relación.
- 📄 **Papeleo**: **Contratos · Expedientes** — acuerdos firmados y el filtro de aprobación de inquilinos nuevos.

Nuevo orden: **Contactos · Estancias · CRM · Contratos · Expedientes**.

Cambio cosmético en `navigation.ts` (solo orden del sub-nav). `tsc`/`eslint` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_