### PR TITLE
feat(servicios): cuota de agua por edificio con historial (Fase 1)

### DIFF
--- a/docs/specs/services-utilities-model.md
+++ b/docs/specs/services-utilities-model.md
@@ -1,0 +1,104 @@
+# Spec — Modelo de Servicios y Egresos (agua, luz, gas, internet)
+
+**Status:** propuesta · Fase 1 en construcción
+**Autor:** Claude Code · **Ejecutor:** Claude Code
+**Origen:** Fran ↔ Claude — el agua de 809 es un recibo único prorrateado, pero lo
+ideal es que cada servicio (agua/luz/gas/internet) se pueda cobrar de distintas
+formas según el inmueble, el tipo de renta y la política del dueño/administrador,
+ligado a los egresos/consumos reales.
+
+---
+
+## 0. Objetivo
+
+Cobrar los **servicios** (agua, luz, gas, internet, +custom) de forma flexible,
+sin hardcodear montos, y que un cambio (de tarifa o de recibo) **se aplique solo**
+a las unidades que corresponda, **independiente del contrato**.
+
+---
+
+## 1. Principio núcleo
+
+Un servicio NO se guarda como número fijo en el contrato. Es una **política +
+una tarifa vigente** que Cobros **resuelve al momento de generar cada cargo**.
+Así, actualizar el agua de un edificio = un cambio de tarifa, no editar N contratos.
+
+---
+
+## 2. Los 4 modos de cobro de un servicio (por unidad)
+
+| Modo | Qué significa | Caso típico |
+|---|---|---|
+| **Incluido** | va dentro de la renta, no se cobra aparte | STR (servicios incluidos) |
+| **Cuota fija** | monto fijo mensual configurable (el $250 de hoy) | acuerdo simple |
+| **Prorrateado** | un recibo del edificio ÷ unidades del periodo | agua 809 (un recibo, se reparte) |
+| **Individual / medido** | el inquilino paga su propio recibo (su consumo) | LTR con medidor propio |
+
+---
+
+## 3. Configuración (jerarquía de defaults → override)
+
+La política se resuelve en cascada (lo más específico gana):
+
+1. **Default por org / dueño-administrador:** ej. *"en mis edificios: agua =
+   prorrateada; luz/gas/internet = individual."*
+2. **Default por tipo de renta:** LTR → individual · MTR → cuota/incluido · STR → incluido.
+3. **Override por edificio.**
+4. **Override por unidad o contrato** (la excepción).
+
+---
+
+## 4. Ligado a egresos / consumos
+
+- **Prorrateado:** se registra el **recibo del edificio** (un egreso del periodo) y
+  la cuota = `total ÷ unidades participantes`. Cambia el recibo ⇒ cambia la cuota.
+- **Individual:** se registra el **recibo/consumo de la unidad** ⇒ ese monto es el cargo.
+- **Cuota / Incluido:** no dependen del egreso.
+
+El egreso vive en el módulo de **Gastos** (`/gastos`), etiquetado por servicio,
+edificio/unidad y periodo, para que el prorrateo y los reportes lo consuman.
+
+---
+
+## 5. Generación de Cobros
+
+Por cada **unidad × mes**, por cada **servicio** activo: se resuelve su **modo** y
+su **monto** (0 si incluido, fijo si cuota, prorrateo si compartido, recibo si
+individual) y se suma al cobro del mes. Una vez registrado el pago, el monto del
+servicio queda **congelado** en ese cobro (histórico); la tarifa solo afecta meses
+aún no cobrados.
+
+---
+
+## 6. Modelo de datos
+
+| Concepto | Tabla | Notas |
+|---|---|---|
+| **Tarifa de servicio compartido** (cuota/prorrateo) | `service_rates` | org, building_id (NULL=org), service, amount, effective_from, notes. Historial efectivo. **(Fase 1)** |
+| **Política de servicio por unidad/contrato** | `unit_services` | unit_id (o contract_id), service, mode (incluido/cuota/prorrateo/individual), override_amount? **(Fase 2)** |
+| **Egreso/recibo** | `gastos` (extender) | service, building_id/unit_id, period, amount. **(Fase 3)** |
+| **Defaults por org / tipo de renta** | `org_service_policy` | service → mode default por tipo de renta. **(Fase 3)** |
+
+---
+
+## 7. Plan por fases
+
+1. **Fase 1 — Agua por edificio (resuelve 809):** tabla `service_rates` (service
+   `agua`), tarifa por edificio con **historial efectivo**; panel para registrar
+   actualizaciones (con helper "recibo ÷ unidades"); Cobros resuelve la cuota de
+   agua vigente por edificio/mes (fallback $250). Cubre cuota fija + prorrateo manual.
+2. **Fase 2 — Catálogo de servicios + modos:** luz/gas/internet, `unit_services`
+   con los 4 modos y defaults por tipo de renta; Cobros suma todos los servicios.
+3. **Fase 3 — Egresos automáticos + políticas por dueño:** registrar recibos en
+   Gastos etiquetados por servicio; prorrateo automático desde el egreso; políticas
+   default por org/administrador; reportes de servicios.
+
+---
+
+## 8. Decisiones abiertas
+
+1. **Prorrateo:** ¿partes iguales entre unidades, o ponderado (por m², por
+   recámaras, por ocupantes)? Fase 1 asume **partes iguales** (configurable después).
+2. **Unidades participantes en el prorrateo:** ¿todas las del edificio, o solo las
+   ocupadas/con contrato activo? Fase 1: **con contrato activo**.
+3. **Servicios custom:** ¿catálogo fijo (agua/luz/gas/internet) o libre? Fase 2: libre.

--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -7,7 +7,7 @@ import { useOrgContext } from '@/hooks/useOrgContext'
 import { useToast } from '@/components/Toast'
 import { formatCurrency } from '@/lib/utils'
 import { calcMoraSurcharge } from '@/lib/mora-engine'
-import { mapPaymentMethod, referenceFor } from '@/lib/cobros'
+import { mapPaymentMethod, referenceFor, resolveServiceRate, type ServiceRate } from '@/lib/cobros'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 import InvoiceModal from '@/components/InvoiceModal'
@@ -22,7 +22,7 @@ interface ContractRow {
   status: string
   start_date: string | null
   billing_start_date: string | null
-  unit: { number: string } | null
+  unit: { number: string; building_id: string | null } | null
   occupant: { name: string } | null
 }
 
@@ -63,6 +63,7 @@ interface BillingRow {
   status: BillingStatus
   moraAmount: number
   remaining: number
+  waterFee: number // cuota de agua resuelta (tarifa del edificio o fallback)
 }
 
 const WATER_FEE_DEFAULT = 250
@@ -183,7 +184,7 @@ export default function CobrosPage() {
     const contractsRes = await supabase
       .from('contracts')
       .select(
-        'id, unit_id, occupant_id, monthly_amount, payment_day, status, start_date, billing_start_date, unit:units(number), occupant:occupants(name)',
+        'id, unit_id, occupant_id, monthly_amount, payment_day, status, start_date, billing_start_date, unit:units(number, building_id), occupant:occupants(name)',
       )
       .in('status', ['active', 'en_renovacion'])
       .eq('org_id', orgId)
@@ -203,6 +204,14 @@ export default function CobrosPage() {
 
     const payments = (paymentsRes.data || []) as PaymentRow[]
 
+    // Tarifas de agua vigentes (Fase 1 servicios). Se resuelven por edificio/mes.
+    const ratesRes = await supabase
+      .from('service_rates')
+      .select('building_id, service, amount, effective_from')
+      .eq('org_id', orgId)
+      .eq('service', 'agua')
+    const waterRates = (ratesRes.data || []) as ServiceRate[]
+
     // Indexa pagos por contrato+mes (mes tomado del due_date).
     const paymentByKey = new Map<string, PaymentRow>()
     for (const p of payments) {
@@ -221,7 +230,10 @@ export default function CobrosPage() {
         const dueDate = `${month}-${pad2(day)}`
         const payment = paymentByKey.get(`${c.id}|${month}`) || null
 
-        const base = payment?.amount ?? c.monthly_amount + WATER_FEE_DEFAULT
+        // Cuota de agua: tarifa del edificio vigente para el mes (fallback $250).
+        const waterFee =
+          resolveServiceRate(waterRates, 'agua', c.unit?.building_id ?? null, month) ?? WATER_FEE_DEFAULT
+        const base = payment?.amount ?? c.monthly_amount + waterFee
         const fee = Number(payment?.late_fee_amount || 0)
         const paid = Number(payment?.amount_paid || 0)
         const hasCollection = payment != null && (payment.status === 'paid' || payment.status === 'partial')
@@ -252,7 +264,7 @@ export default function CobrosPage() {
           }
         }
 
-        billingRows.push({ contract: c, payment, month, dueDate, status, moraAmount, remaining })
+        billingRows.push({ contract: c, payment, month, dueDate, status, moraAmount, remaining, waterFee })
       }
     }
 
@@ -293,7 +305,7 @@ export default function CobrosPage() {
     const c = row.contract
     const today = new Date().toISOString().split('T')[0]
     const rent = row.payment?.rent_amount ?? c.monthly_amount
-    const water = row.payment?.water_fee ?? WATER_FEE_DEFAULT
+    const water = row.payment?.water_fee ?? row.waterFee
     const lateFee = suggestedMora(rent, row.dueDate, today, row.payment)
     const cid = row.payment?.id ?? null
     const total = rent + water + lateFee
@@ -474,7 +486,7 @@ export default function CobrosPage() {
   async function quickPayCore(row: BillingRow): Promise<boolean> {
     const c = row.contract
     const rent = row.payment?.rent_amount ?? c.monthly_amount
-    const water = row.payment?.water_fee ?? WATER_FEE_DEFAULT
+    const water = row.payment?.water_fee ?? row.waterFee
     const charge = {
       amount: rent + water,
       rent_amount: rent,
@@ -605,7 +617,7 @@ export default function CobrosPage() {
   let totalExpected = 0
   let totalCollected = 0
   for (const r of rows) {
-    const rowBase = r.payment?.amount ?? r.contract.monthly_amount + WATER_FEE_DEFAULT
+    const rowBase = r.payment?.amount ?? r.contract.monthly_amount + r.waterFee
     const rowFee = r.status === 'mora' ? r.moraAmount : Number(r.payment?.late_fee_amount || 0)
     totalExpected += rowBase + rowFee
     totalCollected += Number(r.payment?.amount_paid || 0)
@@ -799,9 +811,9 @@ export default function CobrosPage() {
             </thead>
             <tbody>
               {filtered.map((row) => {
-                const waterFee = row.payment?.water_fee ?? WATER_FEE_DEFAULT
+                const waterFee = row.payment?.water_fee ?? row.waterFee
                 const rentAmt = row.payment?.rent_amount ?? row.contract.monthly_amount
-                const total = row.payment ? row.payment.amount : row.contract.monthly_amount + WATER_FEE_DEFAULT
+                const total = row.payment ? row.payment.amount : row.contract.monthly_amount + row.waterFee
                 const rowKey = `${row.contract.id}|${row.month}`
 
                 return (

--- a/src/app/servicios/page.tsx
+++ b/src/app/servicios/page.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+// BaW OS — Servicios (Fase 1): tarifa de agua por edificio con historial.
+//
+// El agua dejó de ser un $250 fijo. Aquí registras "actualizaciones de precio":
+// una cuota por edificio vigente desde un mes. Cobros la resuelve al generar cada
+// cargo, así un cambio aplica a todas las unidades del edificio sin tocar contratos.
+// El helper de prorrateo calcula la cuota = recibo del edificio ÷ unidades.
+
+import { useEffect, useState, useCallback } from 'react'
+import { Droplets, Plus } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { useOrgContext } from '@/hooks/useOrgContext'
+import { useToast } from '@/components/Toast'
+import { formatCurrency } from '@/lib/utils'
+import { SkeletonTable } from '@/components/Skeleton'
+
+type Building = { id: string; name: string }
+type Rate = { id: string; building_id: string | null; amount: number; effective_from: string; notes: string | null }
+
+function monthLabel(iso: string): string {
+  const [y, m] = iso.slice(0, 7).split('-')
+  const names = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic']
+  return `${names[Number(m) - 1]} ${y}`
+}
+
+export default function ServiciosPage() {
+  const { orgId } = useOrgContext()
+  const toast = useToast()
+  const [buildings, setBuildings] = useState<Building[]>([])
+  const [unitsByBuilding, setUnitsByBuilding] = useState<Record<string, number>>({})
+  const [rates, setRates] = useState<Rate[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // Form "actualización de precio"
+  const [buildingId, setBuildingId] = useState('') // '' = toda la org
+  const [month, setMonth] = useState('')
+  const [useProrrateo, setUseProrrateo] = useState(true)
+  const [totalBill, setTotalBill] = useState('')
+  const [amount, setAmount] = useState('')
+  const [notes, setNotes] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const load = useCallback(async () => {
+    if (!orgId) return
+    setLoading(true)
+    const [bRes, uRes, rRes] = await Promise.all([
+      supabase.from('buildings').select('id, name').eq('org_id', orgId).order('name'),
+      supabase.from('units').select('id, building_id').eq('org_id', orgId),
+      supabase
+        .from('service_rates')
+        .select('id, building_id, amount, effective_from, notes')
+        .eq('org_id', orgId)
+        .eq('service', 'agua')
+        .order('effective_from', { ascending: false }),
+    ])
+    setBuildings((bRes.data || []) as Building[])
+    const counts: Record<string, number> = {}
+    for (const u of (uRes.data || []) as { building_id: string | null }[]) {
+      if (u.building_id) counts[u.building_id] = (counts[u.building_id] || 0) + 1
+    }
+    setUnitsByBuilding(counts)
+    setRates((rRes.data || []) as Rate[])
+    setLoading(false)
+  }, [orgId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const unitsForBuilding = buildingId
+    ? unitsByBuilding[buildingId] || 0
+    : Object.values(unitsByBuilding).reduce((a, b) => a + b, 0)
+
+  const computedAmount = useProrrateo
+    ? Number(totalBill) > 0 && unitsForBuilding > 0
+      ? Number(totalBill) / unitsForBuilding
+      : 0
+    : Number(amount)
+
+  function buildingName(id: string | null): string {
+    if (!id) return 'Toda la organización'
+    return buildings.find((b) => b.id === id)?.name || '—'
+  }
+
+  async function handleSave() {
+    if (!orgId || !month || computedAmount <= 0) {
+      toast.error('Completa el mes y el monto')
+      return
+    }
+    setSaving(true)
+    const { error } = await supabase.from('service_rates').insert({
+      org_id: orgId,
+      building_id: buildingId || null,
+      service: 'agua',
+      amount: Math.round(computedAmount * 100) / 100,
+      effective_from: `${month}-01`,
+      notes:
+        notes ||
+        (useProrrateo ? `Prorrateo: ${formatCurrency(Number(totalBill))} ÷ ${unitsForBuilding} unidades` : null),
+    })
+    setSaving(false)
+    if (error) {
+      toast.error(`No se pudo guardar: ${error.message}`)
+      return
+    }
+    setMonth('')
+    setTotalBill('')
+    setAmount('')
+    setNotes('')
+    toast.success('Tarifa de agua actualizada')
+    load()
+  }
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h1 className="text-xl sm:text-2xl font-bold flex items-center gap-2">
+          <Droplets className="w-6 h-6 text-blue-400" />
+          Servicios — Cuota de agua
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
+          La cuota de agua por edificio. Cobros usa la vigente para cada mes; un cambio aplica a todas las
+          unidades del edificio sin tocar contratos.
+        </p>
+      </div>
+
+      {/* Nueva actualización */}
+      <div className="card space-y-4">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider flex items-center gap-2">
+          <Plus className="w-4 h-4" />
+          Actualizar cuota
+        </h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Edificio</label>
+            <select
+              value={buildingId}
+              onChange={(e) => setBuildingId(e.target.value)}
+              className="input-field w-full"
+            >
+              <option value="">Toda la organización</option>
+              {buildings.map((b) => (
+                <option key={b.id} value={b.id}>
+                  {b.name} ({unitsByBuilding[b.id] || 0} u.)
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Vigente desde (mes)</label>
+            <input type="month" value={month} onChange={(e) => setMonth(e.target.value)} className="input-field w-full" />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-4 text-sm">
+          <label className="flex items-center gap-1.5 cursor-pointer">
+            <input type="radio" checked={useProrrateo} onChange={() => setUseProrrateo(true)} />
+            Prorratear recibo
+          </label>
+          <label className="flex items-center gap-1.5 cursor-pointer">
+            <input type="radio" checked={!useProrrateo} onChange={() => setUseProrrateo(false)} />
+            Cuota fija
+          </label>
+        </div>
+
+        {useProrrateo ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Total del recibo</label>
+              <input
+                type="number"
+                value={totalBill}
+                onChange={(e) => setTotalBill(e.target.value)}
+                placeholder="$0.00"
+                className="input-field w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">
+                Cuota por unidad ({unitsForBuilding} unidades)
+              </label>
+              <p className="input-field w-full bg-gray-50 dark:bg-gray-800/50 font-semibold">
+                {formatCurrency(computedAmount || 0)}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Cuota por unidad</label>
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              placeholder="$0.00"
+              className="input-field w-full sm:w-1/2"
+            />
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Nota (opcional)</label>
+          <input
+            type="text"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Ej. recibo CMAPA marzo"
+            className="input-field w-full"
+          />
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            onClick={handleSave}
+            disabled={saving || !month || computedAmount <= 0}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            {saving ? 'Guardando…' : 'Guardar actualización'}
+          </button>
+        </div>
+      </div>
+
+      {/* Historial */}
+      <div className="card">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
+          Historial de cuotas
+        </h2>
+        {loading ? (
+          <SkeletonTable />
+        ) : rates.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Sin cuotas registradas. Cobros usa $250 por defecto hasta que registres una.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                  <th className="pb-2 pr-3 font-medium">Edificio</th>
+                  <th className="pb-2 pr-3 font-medium">Vigente desde</th>
+                  <th className="pb-2 pr-3 font-medium text-right">Cuota / unidad</th>
+                  <th className="pb-2 font-medium">Nota</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                {rates.map((r) => (
+                  <tr key={r.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                    <td className="py-2.5 pr-3 text-gray-900 dark:text-white">{buildingName(r.building_id)}</td>
+                    <td className="py-2.5 pr-3 text-gray-700 dark:text-gray-300 capitalize">{monthLabel(r.effective_from)}</td>
+                    <td className="py-2.5 pr-3 text-right font-medium text-gray-900 dark:text-white">
+                      {formatCurrency(r.amount)}
+                    </td>
+                    <td className="py-2.5 text-gray-500 dark:text-gray-400">{r.notes || '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/cobros.ts
+++ b/src/lib/cobros.ts
@@ -32,3 +32,39 @@ export function referenceFor(unitNumber: string | null | undefined, month: strin
   const depto = (unitNumber || '').trim().replace(/\s+/g, '') || 'SN'
   return `${depto}-${month}`
 }
+
+/** Tarifa de un servicio (agua, luz…) por edificio, con fecha de vigencia. */
+export type ServiceRate = {
+  building_id: string | null
+  service: string
+  amount: number
+  effective_from: string // 'YYYY-MM-DD'
+}
+
+/**
+ * Resuelve la tarifa vigente de un servicio para un edificio y mes dados.
+ * Prefiere la tarifa específica del edificio sobre la de toda la org, y dentro
+ * de eso la de fecha de vigencia más reciente (≤ el mes). Devuelve null si no
+ * hay ninguna aplicable (el caller usa su fallback).
+ */
+export function resolveServiceRate(
+  rates: ServiceRate[],
+  service: string,
+  buildingId: string | null,
+  month: string, // 'YYYY-MM'
+): number | null {
+  const applicable = rates.filter(
+    (r) =>
+      r.service === service &&
+      r.effective_from.slice(0, 7) <= month &&
+      (r.building_id === buildingId || r.building_id === null),
+  )
+  if (!applicable.length) return null
+  applicable.sort((a, b) => {
+    const aSpecific = a.building_id === buildingId ? 1 : 0
+    const bSpecific = b.building_id === buildingId ? 1 : 0
+    if (aSpecific !== bSpecific) return bSpecific - aSpecific
+    return b.effective_from.localeCompare(a.effective_from)
+  })
+  return applicable[0].amount
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -130,6 +130,7 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       '/reportes',
       '/quotes',
       '/pricing',
+      '/servicios',
       '/ancillary-charges',
     ],
     subNav: [
@@ -140,6 +141,7 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       { href: '/ledger', label: 'Bitácora' },
       { href: '/reportes', label: 'Reportes' },
       { href: '/pricing', label: 'Precios' },
+      { href: '/servicios', label: 'Servicios' },
       { href: '/quotes', label: 'Cotizador' },
       { href: '/ancillary-charges', label: 'Cargos adicionales' },
     ],

--- a/supabase/migrations/20260629_service_rates.sql
+++ b/supabase/migrations/20260629_service_rates.sql
@@ -1,0 +1,33 @@
+-- BaW OS — Fase 1 servicios: tarifa de agua por edificio con historial.
+--
+-- El agua dejaba de ser un $250 hardcodeado: ahora es una TARIFA por edificio que
+-- cambia en el tiempo (actualizaciones de precio). Cobros la resuelve al generar
+-- cada cargo, así un cambio se aplica solo a todas las unidades del edificio, sin
+-- tocar contratos. Tabla general (columna `service`) para reusar en luz/gas/
+-- internet en Fase 2. Idempotente, no destructiva.
+
+CREATE TABLE IF NOT EXISTS public.service_rates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  building_id uuid REFERENCES public.buildings(id) ON DELETE CASCADE, -- NULL = toda la org
+  service text NOT NULL DEFAULT 'agua',
+  amount numeric NOT NULL CHECK (amount >= 0),
+  effective_from date NOT NULL, -- primer día del mes desde el que aplica
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_service_rates_lookup
+  ON public.service_rates (org_id, service, building_id, effective_from DESC);
+
+ALTER TABLE public.service_rates ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS service_rates_member ON public.service_rates;
+CREATE POLICY service_rates_member ON public.service_rates FOR ALL
+  USING (EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = service_rates.org_id AND om.user_id = auth.uid()
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = service_rates.org_id AND om.user_id = auth.uid()
+  ));


### PR DESCRIPTION
## Servicios — Fase 1: el agua como tarifa, no como número fijo

El agua era un **$250 hardcodeado**. Ahora es una **tarifa por edificio que cambia en el tiempo**: Cobros la resuelve al generar cada cargo, así una actualización **aplica a todas las unidades del edificio sin tocar contratos**.

### Spec
`docs/specs/services-utilities-model.md` — el modelo completo de servicios (agua/luz/gas/internet) con los **4 modos** (incluido · cuota fija · prorrateado · individual), defaults por tipo de renta y por dueño/administrador, ligado a egresos. **3 fases**; este PR es la **Fase 1 (agua)**.

### Qué incluye la Fase 1
- **Migración `20260629_service_rates.sql`**: tabla `service_rates` (`org, building_id, service, amount, effective_from, notes`) + RLS. General (columna `service`) para reusar en luz/gas/internet en Fase 2.
- **`lib/cobros` → `resolveServiceRate()`**: resuelve la tarifa vigente — prefiere la del edificio sobre la de toda la org, y la vigencia más reciente ≤ el mes.
- **Cobros**: carga las tarifas de agua y resuelve la cuota **por edificio/mes** en cada renglón (fallback **$250** si no hay tarifa). La usa en display, totales y al registrar pago. Los meses ya cobrados **conservan** su agua histórica.
- **Nueva pantalla `/servicios`** (Finanzas): registrar **"actualizaciones de precio"** de agua por edificio, con **helper de prorrateo** (recibo ÷ unidades) o **cuota fija**, e **historial**.

### Cómo resuelve 809
Un solo recibo de agua → en `/servicios` eliges el edificio, pones el **total del recibo**, el sistema calcula **÷ unidades** = cuota, y la guardas vigente desde el mes. Cobros la aplica a todas las unidades de 809. Cuando suba el consumo, registras otra actualización.

### Notas
- El helper de prorrateo divide entre **todas las unidades** del edificio; si prefieres solo las ocupadas, usa "Cuota fija" y teclea el monto exacto. (Decisión §8 del spec — afinamos en Fase 3.)
- Fases 2-3 (otros servicios, modos por unidad, egresos automáticos) quedan pendientes.

### Validación
- `npx tsc --noEmit` → 0 · `npx eslint` → limpio · `npm run build` → ✅ (`/servicios` compila)

### ⚠️ Para Fran (antes/junto al merge)
Corre la migración en Supabase. **El SQL completo va en el chat.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_