### PR TITLE
fix(dashboard): Mission Control proyecta el adeudo igual que Cobros

### DIFF
--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -8,6 +8,7 @@ import { useToast } from '@/components/Toast'
 import { formatCurrency } from '@/lib/utils'
 import { calcMoraSurcharge } from '@/lib/mora-engine'
 import { mapPaymentMethod, referenceFor, resolveServiceRate, type ServiceRate } from '@/lib/cobros'
+import { scheduleMonths, computeMonthStatus, rankPayment, type BillingStatus } from '@/lib/billing'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 import InvoiceModal from '@/components/InvoiceModal'
@@ -53,8 +54,6 @@ interface ReceiptRow {
   payerName: string | null
 }
 
-type BillingStatus = 'pagado' | 'parcial' | 'pendiente' | 'vencido' | 'mora' | 'verbal'
-
 interface BillingRow {
   contract: ContractRow
   payment: PaymentRow | null
@@ -67,7 +66,6 @@ interface BillingRow {
 }
 
 const WATER_FEE_DEFAULT = 250
-const MAX_MONTHS_BACK = 24
 const MONTH_NAMES = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic']
 
 function pad2(n: number) {
@@ -96,40 +94,8 @@ function monthLabel(month: string): string {
   return `${MONTH_NAMES[m - 1]} ${y}`
 }
 
-// Meses 'YYYY-MM' desde el inicio del contrato hasta el mes de corte (inclusive),
-// acotado a los últimos MAX_MONTHS_BACK meses para no generar listas gigantes.
-function scheduleMonths(startISO: string | null, cutoff: string): string[] {
-  const [cy, cm] = cutoff.split('-').map(Number)
-  let y: number
-  let m: number
-  if (startISO) {
-    // Derivar el mes directo del string 'YYYY-MM-DD' para no desfasar por zona
-    // horaria (new Date('2026-02-01') retrocede a ene 31 en husos UTC negativos).
-    const [sy, sm] = startISO.slice(0, 7).split('-').map(Number)
-    y = sy
-    m = sm
-  } else {
-    y = cy
-    m = cm
-  }
-  const out: string[] = []
-  while (y < cy || (y === cy && m <= cm)) {
-    out.push(`${y}-${pad2(m)}`)
-    m++
-    if (m > 12) {
-      m = 1
-      y++
-    }
-  }
-  return out.slice(-MAX_MONTHS_BACK)
-}
-
-// Prioridad de pago cuando hay más de un registro en el mismo mes.
-function rankPayment(p: PaymentRow): number {
-  if (p.status === 'paid') return 3
-  if (p.status === 'partial') return 2
-  return 1
-}
+// scheduleMonths, rankPayment y computeMonthStatus viven en @/lib/billing
+// (fuente única que comparten Cobros, Mission Control y Morosidad).
 
 // Mora sugerida al registrar: respeta una mora ya guardada; si no, la calcula por
 // los días entre el vencimiento y la fecha de pago.
@@ -218,11 +184,10 @@ export default function CobrosPage() {
     for (const p of payments) {
       const key = `${p.contract_id}|${p.due_date.slice(0, 7)}`
       const prev = paymentByKey.get(key)
-      if (!prev || rankPayment(p) > rankPayment(prev)) paymentByKey.set(key, p)
+      if (!prev || rankPayment(p.status) > rankPayment(prev.status)) paymentByKey.set(key, p)
     }
 
     const today = new Date()
-    const todayMid = new Date(today.getFullYear(), today.getMonth(), today.getDate())
 
     const billingRows: BillingRow[] = []
     for (const c of contracts) {
@@ -234,36 +199,15 @@ export default function CobrosPage() {
         // Cuota de agua: tarifa del edificio vigente para el mes (fallback $250).
         const waterFee =
           resolveServiceRate(waterRates, 'agua', c.unit?.building_id ?? null, month) ?? WATER_FEE_DEFAULT
-        const base = payment?.amount ?? c.monthly_amount + waterFee
-        const fee = Number(payment?.late_fee_amount || 0)
-        const paid = Number(payment?.amount_paid || 0)
-        const hasCollection = payment != null && (payment.status === 'paid' || payment.status === 'partial')
-
-        let status: BillingStatus = 'pendiente'
-        let moraAmount = 0
-        let remaining = 0
-
-        if (hasCollection) {
-          remaining = Math.max(0, base + fee - paid)
-          status = remaining > 0.001 ? 'parcial' : 'pagado'
-        } else if (!c.payment_day) {
-          status = 'verbal'
-        } else {
-          const due = new Date(`${dueDate}T00:00:00`)
-          if (todayMid < due) {
-            status = 'pendiente'
-          } else {
-            // Recargo escalonado (motor de mora): 0% gracia (1-5d), 5% (6-15d), 10% (16+).
-            const daysPastDue = dayDiff(due, todayMid)
-            const { amount: surcharge } = calcMoraSurcharge(c.monthly_amount, daysPastDue)
-            if (surcharge > 0) {
-              status = 'mora'
-              moraAmount = surcharge
-            } else {
-              status = 'vencido'
-            }
-          }
-        }
+        // Estatus/mora/saldo: lógica compartida con el dashboard (@/lib/billing).
+        const { status, moraAmount, remaining } = computeMonthStatus({
+          monthlyAmount: c.monthly_amount,
+          paymentDay: c.payment_day,
+          dueDate,
+          waterFee,
+          payment,
+          today,
+        })
 
         billingRows.push({ contract: c, payment, month, dueDate, status, moraAmount, remaining, waterFee })
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,8 @@ import {
 } from '@/components/ui/status'
 import ContractAlertsBanner from '@/components/ContractAlertsBanner'
 import { useActiveContext, ALL_BUILDINGS } from '@/lib/useActiveContext'
+import { scheduleMonths, computeMonthStatus, rankPayment, pad2 } from '@/lib/billing'
+import { resolveServiceRate, type ServiceRate } from '@/lib/cobros'
 
 // S9 hotfix: Mission Control ahora espera el contexto activo y filtra todas
 // las queries por activeOrgId. Antes confiaba 100% en RLS y, cuando una sola
@@ -102,11 +104,8 @@ export default function MissionControl() {
         // Selects: con filtro de edificio usamos !inner para poder filtrar por
         // la columna anidada; sin filtro, embeds normales (no excluir filas).
         const contractsSel = bId
-          ? 'id, unit_id, monthly_amount, end_date, status, unit:units!inner(number, building_id), occupant:occupants(name)'
-          : 'id, unit_id, monthly_amount, end_date, status, unit:units(number), occupant:occupants(name)'
-        const paymentsSel = bId
-          ? 'id, amount, due_date, status, contract:contracts!inner(unit:units!inner(number, building_id), occupant:occupants(name))'
-          : 'id, amount, due_date, status, contract:contracts(unit:units(number), occupant:occupants(name))'
+          ? 'id, unit_id, monthly_amount, payment_day, start_date, billing_start_date, end_date, status, unit:units!inner(number, building_id), occupant:occupants(name)'
+          : 'id, unit_id, monthly_amount, payment_day, start_date, billing_start_date, end_date, status, unit:units(number, building_id), occupant:occupants(name)'
         const incidentsSel = bId
           ? 'id, status, created_at, description, unit:units!inner(number, building_id)'
           : 'id, status, created_at, description, unit:units(number)'
@@ -124,14 +123,6 @@ export default function MissionControl() {
           .in('status', ['active', 'en_renovacion'])
         if (bId) contractsQ = contractsQ.eq('unit.building_id', bId)
 
-        let paymentsQ = supabase
-          .from('payments')
-          .select(paymentsSel)
-          .eq('org_id', activeOrgId)
-          .in('status', ['pending', 'late'])
-        if (bId) paymentsQ = paymentsQ.eq('contract.unit.building_id', bId)
-        const paymentsFinal = paymentsQ.order('due_date', { ascending: true })
-
         let incidentsQ = supabase
           .from('incidents')
           .select(incidentsSel)
@@ -142,17 +133,73 @@ export default function MissionControl() {
           .order('created_at', { ascending: false })
           .limit(5)
 
-        const [unitsRes, contractsRes, paymentsRes, maintRes] = await Promise.all([
+        const [unitsRes, contractsRes, maintRes] = await Promise.all([
           unitsFinal,
           contractsQ,
-          paymentsFinal,
           incidentsFinal,
         ])
 
         const units = unitsRes.data || []
-        const contracts = contractsRes.data || []
-        const payments = paymentsRes.data || []
+        const contracts = (contractsRes.data || []) as Record<string, unknown>[]
         const tickets = maintRes.data || []
+
+        // Pagos (todos) de esos contratos + tarifas de agua, para PROYECTAR el
+        // adeudo igual que Cobros (fuente única @/lib/billing). Antes el dashboard
+        // contaba solo filas con status 'late' y subcontaba la morosidad real.
+        const contractIds = contracts.map((c) => c.id as string)
+        const [allPaymentsRes, ratesRes] = await Promise.all([
+          contractIds.length
+            ? supabase
+                .from('payments')
+                .select('contract_id, due_date, status, amount, amount_paid, late_fee_amount')
+                .in('contract_id', contractIds)
+            : Promise.resolve({ data: [] as Record<string, unknown>[] }),
+          supabase
+            .from('service_rates')
+            .select('building_id, service, amount, effective_from')
+            .eq('org_id', activeOrgId)
+            .eq('service', 'agua'),
+        ])
+        const allPayments = (allPaymentsRes.data || []) as Record<string, unknown>[]
+        const waterRates = (ratesRes.data || []) as ServiceRate[]
+
+        const paymentByKey = new Map<string, Record<string, unknown>>()
+        for (const p of allPayments) {
+          const key = `${p.contract_id}|${String(p.due_date).slice(0, 7)}`
+          const prev = paymentByKey.get(key)
+          if (!prev || rankPayment(p.status as string) > rankPayment(prev.status as string)) paymentByKey.set(key, p)
+        }
+
+        const cutoff = `${now.getFullYear()}-${pad2(now.getMonth() + 1)}`
+        type OverdueRow = { contract: Record<string, unknown>; dueDate: string; owed: number }
+        const overdueRows: OverdueRow[] = []
+        for (const c of contracts) {
+          const unitRel = c.unit as { building_id?: string | null } | { building_id?: string | null }[] | null
+          const buildingId = (Array.isArray(unitRel) ? unitRel[0]?.building_id : unitRel?.building_id) ?? null
+          const months = scheduleMonths(
+            (c.billing_start_date as string | null) ?? (c.start_date as string | null),
+            cutoff,
+          )
+          for (const month of months) {
+            const dueDate = `${month}-${pad2(Number(c.payment_day) || 1)}`
+            const payment = (paymentByKey.get(`${c.id}|${month}`) || null) as
+              | { status: string; amount: number | null; amount_paid: number | null; late_fee_amount: number | null }
+              | null
+            const waterFee = resolveServiceRate(waterRates, 'agua', buildingId, month) ?? 250
+            const r = computeMonthStatus({
+              monthlyAmount: Number(c.monthly_amount || 0),
+              paymentDay: (c.payment_day as number) ?? null,
+              dueDate,
+              waterFee,
+              payment,
+              today: now,
+            })
+            if (r.status === 'mora' || r.status === 'vencido' || r.status === 'parcial') {
+              overdueRows.push({ contract: c, dueDate, owed: r.owed })
+            }
+          }
+        }
+        overdueRows.sort((a, b) => a.dueDate.localeCompare(b.dueDate))
 
         // S9: empty state honesto — si la org existe pero no tiene units ni
         // contracts, mostrar dashboard vacío (no onboarding) porque el user
@@ -170,21 +217,14 @@ export default function MissionControl() {
           (u: { status: string }) => u.status === 'available'
         ).length
         const monthlyRevenue = contracts.reduce(
-          (sum: number, c: { monthly_amount: number | null }) =>
-            sum + Number(c.monthly_amount || 0),
+          (sum: number, c) => sum + Number((c.monthly_amount as number) || 0),
           0
         )
-        const overdue = payments.filter(
-          (p: { status: string }) => p.status === 'late'
-        )
-        const overdueAmount = overdue.reduce(
-          (sum: number, p: { amount: number | null }) =>
-            sum + Number(p.amount || 0),
-          0
-        )
+        // Morosidad = adeudo proyectado (vencido/mora/parcial), igual que Cobros.
+        const overdueAmount = overdueRows.reduce((sum, r) => sum + r.owed, 0)
+        const overdueCount = overdueRows.length
         const expiringCount = contracts.filter(
-          (c: { end_date: string | null }) =>
-            c.end_date && daysUntil(c.end_date) <= 60
+          (c) => c.end_date && daysUntil(c.end_date as string) <= 60
         ).length
 
         setMetrics({
@@ -193,29 +233,29 @@ export default function MissionControl() {
           availableUnits,
           monthlyRevenue,
           overdueAmount,
-          overdueCount: overdue.length,
+          overdueCount,
           expiringCount,
         })
 
+        const unitNumber = (c: Record<string, unknown>): string => {
+          const u = c.unit as { number?: string } | { number?: string }[] | null
+          return (Array.isArray(u) ? u[0]?.number : u?.number) || '—'
+        }
+        const occupantName = (c: Record<string, unknown>): string => {
+          const o = c.occupant as { name?: string } | { name?: string }[] | null
+          return (Array.isArray(o) ? o[0]?.name : o?.name) || 'Sin ocupante'
+        }
+
         setCollections(
-          payments.slice(0, 5).map((p: any) => ({
-            id: p.id,
-            unit:
-              p.contract?.[0]?.unit?.[0]?.number ||
-              p.contract?.unit?.number ||
-              '—',
-            tenant:
-              p.contract?.[0]?.occupant?.[0]?.name ||
-              p.contract?.occupant?.name ||
-              'Sin ocupante',
-            amount: Number(p.amount || 0),
-            status: p.status === 'late' ? 'late' : 'pending',
+          overdueRows.slice(0, 5).map((r, i) => ({
+            id: `${r.contract.id}-${r.dueDate}-${i}`,
+            unit: unitNumber(r.contract),
+            tenant: occupantName(r.contract),
+            amount: r.owed,
+            status: 'late' as const,
             daysOverdue: Math.max(
               0,
-              Math.floor(
-                (now.getTime() - new Date(p.due_date).getTime()) /
-                  (1000 * 60 * 60 * 24)
-              )
+              Math.floor((now.getTime() - new Date(r.dueDate).getTime()) / (1000 * 60 * 60 * 24))
             ),
           }))
         )

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,100 @@
+// BaW OS — Lógica de facturación compartida (fuente única de verdad).
+//
+// Cobros, Mission Control y Morosidad deben contar lo mismo. Antes Cobros
+// proyectaba los adeudos desde el calendario del contrato, mientras el dashboard
+// contaba solo filas de pago materializadas (y subcontaba). Esta librería pura
+// centraliza el cálculo: dado un contrato y un mes, ¿cuál es su estatus y cuánto
+// se debe? Sin React ni DB.
+
+import { calcMoraSurcharge } from '@/lib/mora-engine'
+
+export type BillingStatus = 'pagado' | 'parcial' | 'pendiente' | 'vencido' | 'mora' | 'verbal'
+
+export const MAX_MONTHS_BACK = 24
+
+export function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function dayDiff(from: Date, to: Date): number {
+  return Math.floor((to.getTime() - from.getTime()) / 86_400_000)
+}
+
+/**
+ * Meses 'YYYY-MM' desde el inicio (o billing_start) hasta el mes de corte
+ * (inclusive), acotado a los últimos MAX_MONTHS_BACK meses.
+ */
+export function scheduleMonths(startISO: string | null, cutoff: string): string[] {
+  const [cy, cm] = cutoff.split('-').map(Number)
+  let y: number
+  let m: number
+  if (startISO) {
+    // Derivar el mes del string 'YYYY-MM-DD' para no desfasar por zona horaria.
+    const [sy, sm] = startISO.slice(0, 7).split('-').map(Number)
+    y = sy
+    m = sm
+  } else {
+    y = cy
+    m = cm
+  }
+  const out: string[] = []
+  while (y < cy || (y === cy && m <= cm)) {
+    out.push(`${y}-${pad2(m)}`)
+    m++
+    if (m > 12) {
+      m = 1
+      y++
+    }
+  }
+  return out.slice(-MAX_MONTHS_BACK)
+}
+
+/** Rank para elegir el pago representativo de un mes (paid > partial > otros). */
+export function rankPayment(status: string): number {
+  if (status === 'paid') return 3
+  if (status === 'partial') return 2
+  return 1
+}
+
+export type MonthStatusInput = {
+  monthlyAmount: number
+  paymentDay: number | null
+  dueDate: string // 'YYYY-MM-DD'
+  waterFee: number
+  payment: { status: string; amount: number | null; amount_paid: number | null; late_fee_amount: number | null } | null
+  today: Date
+}
+
+export type MonthStatusResult = {
+  status: BillingStatus
+  moraAmount: number
+  remaining: number // saldo vivo en pagos parciales
+  owed: number // lo que se adeuda hoy (morosidad): vencido/mora = base+mora, parcial = saldo, resto = 0
+}
+
+/** Estatus y adeudo de UN mes de UN contrato. Misma lógica que usa la tabla de Cobros. */
+export function computeMonthStatus(i: MonthStatusInput): MonthStatusResult {
+  const base = i.payment?.amount ?? i.monthlyAmount + i.waterFee
+  const fee = Number(i.payment?.late_fee_amount || 0)
+  const paid = Number(i.payment?.amount_paid || 0)
+  const hasCollection = i.payment != null && (i.payment.status === 'paid' || i.payment.status === 'partial')
+  const todayMid = new Date(i.today.getFullYear(), i.today.getMonth(), i.today.getDate())
+
+  if (hasCollection) {
+    const remaining = Math.max(0, base + fee - paid)
+    return { status: remaining > 0.001 ? 'parcial' : 'pagado', moraAmount: 0, remaining, owed: remaining }
+  }
+  if (!i.paymentDay) {
+    return { status: 'verbal', moraAmount: 0, remaining: 0, owed: 0 }
+  }
+  const due = new Date(`${i.dueDate}T00:00:00`)
+  if (todayMid < due) {
+    return { status: 'pendiente', moraAmount: 0, remaining: 0, owed: 0 }
+  }
+  const daysPastDue = dayDiff(due, todayMid)
+  const { amount: surcharge } = calcMoraSurcharge(i.monthlyAmount, daysPastDue)
+  if (surcharge > 0) {
+    return { status: 'mora', moraAmount: surcharge, remaining: 0, owed: base + surcharge }
+  }
+  return { status: 'vencido', moraAmount: 0, remaining: 0, owed: base }
+}


### PR DESCRIPTION
## La inconsistencia: Mission Control decía morosidad $0, Cobros mostraba vencidos

**Causa:** Mission Control contaba solo **filas de pago con status `late`**. Pero los meses no pagados **no tienen fila** (se crea al registrar un pago), mientras Cobros **proyecta** los adeudos desde el calendario del contrato. Dos fuentes distintas → el dashboard subcontaba.

## El fix: fuente única
- **Nueva `lib/billing.ts`** — la lógica de facturación centralizada y **pura** (sin React ni DB): `scheduleMonths`, `rankPayment`, `computeMonthStatus`. Es la misma que ya usaba Cobros, ahora compartida.
- **Cobros** → usa `lib/billing` en vez de su copia local. **Mismo comportamiento** (refactor sin cambio funcional).
- **Mission Control** → carga **todos** los pagos de los contratos activos + las tarifas de agua y **proyecta el adeudo mes a mes** con `computeMonthStatus`. La **morosidad** ahora es la suma de lo adeudado (vencido/mora/parcial) y **cuadra con Cobros**. La lista de "Cobros pendientes" sale de la misma proyección.

## Resultado
Mission Control, Cobros y la lista de pendientes cuentan **lo mismo**. La morosidad refleja el adeudo real proyectado, no solo las filas materializadas.

## Follow-up
`/api/mora` (server-side) puede importar la misma `lib/billing` para cuadrar también — lo dejo señalado, no en este PR.

### Validación
- `npx tsc --noEmit` → 0 · `npx eslint` → limpio · `npm run build` → ✅
- Sin migración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_