### PR TITLE
fix(portal): el portal del inquilino muestra meses pendientes/vencidos

### DIFF
--- a/src/app/api/portal/[token]/route.ts
+++ b/src/app/api/portal/[token]/route.ts
@@ -1,14 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { scheduleMonths, computeMonthStatus, rankPayment, pad2 } from '@/lib/billing'
+import { resolveServiceRate, type ServiceRate } from '@/lib/cobros'
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ||
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
+const WATER_FEE_DEFAULT = 250
+
 function createPortalClient() {
   return createClient(SUPABASE_URL, SUPABASE_KEY, {
     auth: { autoRefreshToken: false, persistSession: false }
   })
+}
+
+// Mapea el estatus interno (lib/billing) al vocabulario del portal del inquilino.
+function portalStatus(s: string): string {
+  if (s === 'pagado') return 'paid'
+  if (s === 'pendiente' || s === 'verbal') return 'pending'
+  return 'late' // vencido, mora, parcial
 }
 
 export async function GET(
@@ -21,7 +32,7 @@ export async function GET(
   // Fetch contract by portal_token
   const { data: contract, error } = await supabase
     .from('contracts')
-    .select('id, unit_id, occupant_id, monthly_amount, start_date, end_date, status, payment_day')
+    .select('id, org_id, unit_id, occupant_id, monthly_amount, start_date, billing_start_date, end_date, status, payment_day')
     .eq('portal_token', token)
     .eq('portal_enabled', true)
     .single()
@@ -36,7 +47,7 @@ export async function GET(
   // Fetch unit separately
   const { data: unit } = await supabase
     .from('units')
-    .select('number, floor, type')
+    .select('number, floor, type, building_id')
     .eq('id', contract.unit_id)
     .single()
 
@@ -45,13 +56,60 @@ export async function GET(
     ? await supabase.from('occupants').select('name').eq('id', contract.occupant_id).single()
     : { data: null }
 
-  // Fetch last 6 payments
+  // Todos los pagos del contrato (para saber qué meses están cubiertos).
   const { data: payments } = await supabase
     .from('payments')
-    .select('due_date, amount, status, paid_date, water_fee')
+    .select('due_date, amount, amount_paid, late_fee_amount, status, paid_date, water_fee')
     .eq('contract_id', contract.id)
-    .order('due_date', { ascending: false })
-    .limit(6)
+
+  // Tarifas de agua del edificio (Fase 1 servicios).
+  const { data: rates } = await supabase
+    .from('service_rates')
+    .select('building_id, service, amount, effective_from')
+    .eq('org_id', contract.org_id)
+    .eq('service', 'agua')
+  const waterRates = (rates || []) as ServiceRate[]
+  const buildingId = unit?.building_id ?? null
+
+  // Indexa el pago representativo por mes.
+  const paymentByKey = new Map<string, { due_date: string; amount: number | null; amount_paid: number | null; late_fee_amount: number | null; status: string; paid_date: string | null; water_fee: number | null }>()
+  for (const p of payments || []) {
+    const key = String(p.due_date).slice(0, 7)
+    const prev = paymentByKey.get(key)
+    if (!prev || rankPayment(p.status) > rankPayment(prev.status)) paymentByKey.set(key, p)
+  }
+
+  // Proyecta el calendario del contrato hasta el mes en curso: muestra pagados,
+  // pendientes y vencidos (no solo las filas registradas). Mismo cálculo que Cobros.
+  const now = new Date()
+  const cutoff = `${now.getFullYear()}-${pad2(now.getMonth() + 1)}`
+  const currentWaterFee = resolveServiceRate(waterRates, 'agua', buildingId, cutoff) ?? WATER_FEE_DEFAULT
+  const day = contract.payment_day || 1
+
+  const projected = scheduleMonths(contract.billing_start_date ?? contract.start_date, cutoff).map((month) => {
+    const dueDate = `${month}-${pad2(day)}`
+    const payment = paymentByKey.get(month) || null
+    const waterFee = resolveServiceRate(waterRates, 'agua', buildingId, month) ?? WATER_FEE_DEFAULT
+    const r = computeMonthStatus({
+      monthlyAmount: Number(contract.monthly_amount || 0),
+      paymentDay: contract.payment_day,
+      dueDate,
+      waterFee,
+      payment,
+      today: now,
+    })
+    return {
+      month: dueDate,
+      amount: payment?.amount ?? Number(contract.monthly_amount || 0) + waterFee,
+      water_fee: payment?.water_fee ?? waterFee,
+      status: portalStatus(r.status),
+      paid_date: payment?.paid_date ?? null,
+    }
+  })
+
+  // Más reciente primero, acotado a los últimos 12 meses para el portal.
+  projected.reverse()
+  const portalPayments = projected.slice(0, 12)
 
   // Fetch active incidents for this unit
   const { data: incidents } = await supabase
@@ -65,7 +123,7 @@ export async function GET(
     contract: {
       unit_id: contract.unit_id,
       monthly_amount: contract.monthly_amount,
-      water_fee: 250, // default agua
+      water_fee: currentWaterFee,
       start_date: contract.start_date,
       end_date: contract.end_date,
       status: contract.status,
@@ -75,13 +133,7 @@ export async function GET(
     unit: unit
       ? { unit_number: unit.number, floor: unit.floor, type: unit.type }
       : null,
-    payments: (payments || []).map((p) => ({
-      month: p.due_date,
-      amount: p.amount,
-      water_fee: p.water_fee,
-      status: p.status,
-      paid_date: p.paid_date,
-    })),
+    payments: portalPayments,
     incidents: incidents || [],
   })
 }

--- a/src/app/api/tenant/[token]/route.ts
+++ b/src/app/api/tenant/[token]/route.ts
@@ -1,5 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServiceClient } from '@/lib/api-auth'
+import { scheduleMonths, computeMonthStatus, rankPayment, pad2 } from '@/lib/billing'
+import { resolveServiceRate, type ServiceRate } from '@/lib/cobros'
+
+const WATER_FEE_DEFAULT = 250
+
+function portalStatus(s: string): string {
+  if (s === 'pagado') return 'paid'
+  if (s === 'pendiente' || s === 'verbal') return 'pending'
+  return 'late' // vencido, mora, parcial
+}
 
 export async function GET(
   _request: NextRequest,
@@ -12,9 +22,9 @@ export async function GET(
   const { data: contract, error } = await supabase
     .from('contracts')
     .select(`
-      id, unit_id, monthly_amount, water_fee, start_date, end_date, status, payment_day,
+      id, org_id, unit_id, monthly_amount, water_fee, start_date, billing_start_date, end_date, status, payment_day,
       occupant:occupants(name),
-      unit:units(number, floor, type)
+      unit:units(number, floor, type, building_id)
     `)
     .eq('portal_token', token)
     .eq('portal_enabled', true)
@@ -30,15 +40,56 @@ export async function GET(
   const occupantRaw = contract.occupant as unknown
   const occupant = Array.isArray(occupantRaw) ? occupantRaw[0] as { name: string } | undefined : occupantRaw as { name: string } | null
   const unitRaw = contract.unit as unknown
-  const unit = Array.isArray(unitRaw) ? unitRaw[0] as { number: string; floor: number; type: string } | undefined : unitRaw as { number: string; floor: number; type: string } | null
+  const unit = Array.isArray(unitRaw) ? unitRaw[0] as { number: string; floor: number; type: string; building_id: string | null } | undefined : unitRaw as { number: string; floor: number; type: string; building_id: string | null } | null
 
-  // Fetch last 6 payments
+  // Todos los pagos del contrato + tarifas de agua, para proyectar el calendario.
   const { data: payments } = await supabase
     .from('payments')
-    .select('id, due_date, amount, status, paid_date, water_fee, method')
+    .select('id, due_date, amount, amount_paid, late_fee_amount, status, paid_date, water_fee, method')
     .eq('contract_id', contract.id)
-    .order('due_date', { ascending: false })
-    .limit(6)
+
+  const { data: rates } = await supabase
+    .from('service_rates')
+    .select('building_id, service, amount, effective_from')
+    .eq('org_id', contract.org_id)
+    .eq('service', 'agua')
+  const waterRates = (rates || []) as ServiceRate[]
+  const buildingId = unit?.building_id ?? null
+
+  const paymentByKey = new Map<string, { id: string; due_date: string; amount: number | null; amount_paid: number | null; late_fee_amount: number | null; status: string; paid_date: string | null; water_fee: number | null; method: string | null }>()
+  for (const p of payments || []) {
+    const key = String(p.due_date).slice(0, 7)
+    const prev = paymentByKey.get(key)
+    if (!prev || rankPayment(p.status) > rankPayment(prev.status)) paymentByKey.set(key, p)
+  }
+
+  const now = new Date()
+  const cutoff = `${now.getFullYear()}-${pad2(now.getMonth() + 1)}`
+  const day = contract.payment_day || 1
+
+  const projected = scheduleMonths(contract.billing_start_date ?? contract.start_date, cutoff).map((month) => {
+    const dueDate = `${month}-${pad2(day)}`
+    const payment = paymentByKey.get(month) || null
+    const waterFee = resolveServiceRate(waterRates, 'agua', buildingId, month) ?? WATER_FEE_DEFAULT
+    const r = computeMonthStatus({
+      monthlyAmount: Number(contract.monthly_amount || 0),
+      paymentDay: contract.payment_day,
+      dueDate,
+      waterFee,
+      payment,
+      today: now,
+    })
+    return {
+      id: payment?.id ?? dueDate,
+      month: dueDate,
+      amount: payment?.amount ?? Number(contract.monthly_amount || 0) + waterFee,
+      water_fee: payment?.water_fee ?? waterFee,
+      status: portalStatus(r.status),
+      paid_date: payment?.paid_date ?? null,
+      method: payment?.method ?? null,
+    }
+  })
+  projected.reverse()
 
   // Fetch active incidents for this unit
   const { data: incidents } = await supabase
@@ -53,7 +104,7 @@ export async function GET(
       id: contract.id,
       unit_id: contract.unit_id,
       monthly_amount: contract.monthly_amount,
-      water_fee: contract.water_fee,
+      water_fee: resolveServiceRate(waterRates, 'agua', buildingId, cutoff) ?? contract.water_fee ?? WATER_FEE_DEFAULT,
       start_date: contract.start_date,
       end_date: contract.end_date,
       status: contract.status,
@@ -63,15 +114,7 @@ export async function GET(
     unit: unit
       ? { unit_number: unit.number, floor: unit.floor, type: unit.type }
       : null,
-    payments: (payments || []).map((p) => ({
-      id: p.id,
-      month: p.due_date,
-      amount: p.amount,
-      water_fee: p.water_fee,
-      status: p.status,
-      paid_date: p.paid_date,
-      method: p.method,
-    })),
+    payments: projected.slice(0, 12),
     incidents: incidents || [],
   })
 }


### PR DESCRIPTION
## El portal solo mostraba meses pagados

**Mismo patrón** que Mission Control: el portal del inquilino listaba únicamente las **filas de pago registradas**, así que el inquilino veía solo los meses **pagados**. Los **pendientes/vencidos** (que no tienen fila — se proyectan) no aparecían. Por eso en el portal de Erick no salían los meses que aún no registramos.

## Fix
- **`/api/portal/[token]`** y **`/api/tenant/[token]`** ahora **proyectan el calendario** del contrato con `@/lib/billing` (`scheduleMonths` + `computeMonthStatus`), mapeando el estatus interno al vocabulario del portal (**paid / pending / late**). El inquilino ve **pagados, pendientes y vencidos** (últimos 12 meses), no solo lo registrado.
- La **cuota de agua** del portal sale de la **tarifa vigente del edificio** (`service_rates`), no del $250 fijo.

## Resultado
Erick verá sus meses **Mar–Jun 2026 como pendientes/vencidos** en su portal (aunque no se hayan registrado pagos), igual que en Cobros. Patricia y Leticia verán sus pagados + lo que deban.

### Validación
- `npx tsc --noEmit` → 0 · `npx eslint` → limpio · `npm run build` → ✅
- Sin migración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_