### PR TITLE
fix(cobros): flecha de orden inline + nombre del inquilino sin cortar

### DIFF
--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -829,22 +829,22 @@ export default function CobrosPage() {
                   />
                 </th>
                 <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">
-                  <button onClick={() => toggleSort('depto')} className="hover:text-gray-900 dark:hover:text-white">Depto{sortArrow('depto')}</button>
+                  <button onClick={() => toggleSort('depto')} className="whitespace-nowrap hover:text-gray-900 dark:hover:text-white">Depto{sortArrow('depto')}</button>
                 </th>
                 <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">
-                  <button onClick={() => toggleSort('mes')} className="hover:text-gray-900 dark:hover:text-white">Mes{sortArrow('mes')}</button>
+                  <button onClick={() => toggleSort('mes')} className="whitespace-nowrap hover:text-gray-900 dark:hover:text-white">Mes{sortArrow('mes')}</button>
                 </th>
                 <th className="text-left px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">
-                  <button onClick={() => toggleSort('inquilino')} className="hover:text-gray-900 dark:hover:text-white">Inquilino{sortArrow('inquilino')}</button>
+                  <button onClick={() => toggleSort('inquilino')} className="whitespace-nowrap hover:text-gray-900 dark:hover:text-white">Inquilino{sortArrow('inquilino')}</button>
                 </th>
                 <th className="text-right px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Renta</th>
                 <th className="text-right px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Agua</th>
                 <th className="text-right px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">
-                  <button onClick={() => toggleSort('total')} className="hover:text-gray-900 dark:hover:text-white">Total{sortArrow('total')}</button>
+                  <button onClick={() => toggleSort('total')} className="whitespace-nowrap hover:text-gray-900 dark:hover:text-white">Total{sortArrow('total')}</button>
                 </th>
                 <th className="text-center px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Vence</th>
                 <th className="text-center px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">
-                  <button onClick={() => toggleSort('status')} className="hover:text-gray-900 dark:hover:text-white">Status{sortArrow('status')}</button>
+                  <button onClick={() => toggleSort('status')} className="whitespace-nowrap hover:text-gray-900 dark:hover:text-white">Status{sortArrow('status')}</button>
                 </th>
                 <th className="text-center px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Confirmó</th>
                 <th className="text-center px-4 py-3 text-gray-500 dark:text-gray-400 font-medium">Acción</th>
@@ -886,7 +886,7 @@ export default function CobrosPage() {
                     <td className="px-4 py-3 text-gray-700 dark:text-gray-300 capitalize whitespace-nowrap">
                       {monthLabel(row.month)}
                     </td>
-                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300 whitespace-nowrap">
                       {row.contract.occupant?.name || 'Sin inquilino'}
                     </td>
                     <td className="px-4 py-3 text-right text-gray-700 dark:text-gray-300">{formatCurrency(rentAmt)}</td>


### PR DESCRIPTION
## Dos detalles cosméticos de Cobros

### 1. La flecha de orden caía debajo del texto
Los encabezados ordenables (Depto, Inquilino, etc.) dejaban que el texto "Depto ↑" se partiera en dos líneas cuando la columna era angosta — la flecha quedaba **abajo**. En "Mes" no pasaba por ser corto. **Fix:** `whitespace-nowrap` en los encabezados → la flecha (↑/↓) queda **al lado del texto** siempre.

### 2. El nombre del inquilino se partía en 3–4 líneas
La columna Inquilino se comprimía y partía el nombre ("Erick Mauricio Nuñez Rivera" en 4 líneas) incluso con espacio. **Fix:** `whitespace-nowrap` en la celda → el nombre va en una línea y la tabla hace **scroll horizontal** en pantallas chicas (patrón estándar), en vez de envolver feo.

Cambios de clases CSS, sin lógica. `tsc`/`eslint`/`build` ✅, sin migración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_