### PR TITLE
Security hardening: auth guards, webhook signatures, tenant isolation

### DIFF
--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -1,21 +1,24 @@
 // BaW OS — Expediente individual de aplicación (vista interna)
 import { NextRequest } from 'next/server'
-import { createServiceClient, validateApiKey, unauthorized, apiError, apiOk, getOrgId } from '@/lib/api-auth'
+import { createServiceClient, apiError, apiOk } from '@/lib/api-auth'
+import { requireMemberCaller } from '@/lib/admin-auth'
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const auth = await requireMemberCaller()
+    if (!auth.ok) return apiError(auth.message, auth.status)
+
     const { id } = await params
     const supabase = createServiceClient()
-    const orgId = getOrgId()
 
     const { data, error } = await supabase
       .from('tenant_applications')
       .select('*, unit:units(id, number, floor, type)')
       .eq('id', id)
-      .eq('org_id', orgId)
+      .eq('org_id', auth.orgId)
       .single()
 
     if (error || !data) return apiError('Aplicación no encontrada', 404)
@@ -30,19 +33,21 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const auth = await requireMemberCaller()
+    if (!auth.ok) return apiError(auth.message, auth.status)
+
     const { id } = await params
     const supabase = createServiceClient()
-    const orgId = getOrgId()
     const body = await request.json()
 
-    // Solo permitir actualizar status y notas
+    // Solo permitir actualizar status y notas (whitelist)
     const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
 
     if (body.status) {
       updates.status = body.status
       if (body.status === 'approved' || body.status === 'rejected') {
         updates.reviewed_at = new Date().toISOString()
-        updates.reviewed_by = body.reviewed_by || 'admin'
+        updates.reviewed_by = body.reviewed_by || auth.userId
       }
     }
     if (body.notes !== undefined) updates.notes = body.notes
@@ -51,7 +56,7 @@ export async function PATCH(
       .from('tenant_applications')
       .update(updates)
       .eq('id', id)
-      .eq('org_id', orgId)
+      .eq('org_id', auth.orgId)
       .select('*, unit:units(id, number, floor, type)')
       .single()
 

--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -1,11 +1,16 @@
 // BaW OS — CRUD de aplicaciones de inquilinos (vista interna Maribel)
 import { NextRequest } from 'next/server'
-import { createServiceClient, validateApiKey, unauthorized, apiError, apiOk, getOrgId } from '@/lib/api-auth'
+import { createServiceClient, apiError, apiOk } from '@/lib/api-auth'
+import { requireMemberCaller } from '@/lib/admin-auth'
 
 export async function GET(request: NextRequest) {
   try {
+    // Guard: solo miembros de la org. Antes NO había auth y expedientes (PII de
+    // aplicantes: nombre, aval, ingresos) quedaban expuestos a internet.
+    const auth = await requireMemberCaller()
+    if (!auth.ok) return apiError(auth.message, auth.status)
+
     const supabase = createServiceClient()
-    const orgId = getOrgId()
     const { searchParams } = new URL(request.url)
     const status = searchParams.get('status')
     const unitId = searchParams.get('unit_id')
@@ -13,7 +18,7 @@ export async function GET(request: NextRequest) {
     let query = supabase
       .from('tenant_applications')
       .select('*, unit:units(id, number, floor, type)')
-      .eq('org_id', orgId)
+      .eq('org_id', auth.orgId)
 
     if (status) query = query.eq('status', status)
     if (unitId) query = query.eq('unit_id', unitId)
@@ -28,14 +33,16 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    const auth = await requireMemberCaller()
+    if (!auth.ok) return apiError(auth.message, auth.status)
+
     const supabase = createServiceClient()
-    const orgId = getOrgId()
     const body = await request.json()
 
     const { data, error } = await supabase
       .from('tenant_applications')
       .insert({
-        org_id: orgId,
+        org_id: auth.orgId,
         unit_id: body.unit_id || null,
         contract_type: body.contract_type || null,
       })

--- a/src/app/api/channex/webhook/route.ts
+++ b/src/app/api/channex/webhook/route.ts
@@ -5,7 +5,7 @@
 // de "primera org por created_at". Configurar Channex para incluir el org
 // del tenant en la URL del webhook (e.g. `/api/channex/webhook?org=baw-operations`).
 import { NextRequest, NextResponse } from 'next/server'
-import { createServiceClient } from '@/lib/api-auth'
+import { createServiceClient, timingSafeEqualStr } from '@/lib/api-auth'
 import { resolveOrgIdForWebhook } from '@/lib/org-context'
 
 export const dynamic = 'force-dynamic'
@@ -34,7 +34,7 @@ export async function POST(request: NextRequest) {
     const token =
       request.nextUrl.searchParams.get('token') ??
       request.headers.get('x-channex-token')
-    if (token !== secret) {
+    if (!token || !timingSafeEqualStr(token, secret)) {
       return NextResponse.json(
         { success: false, error: 'Unauthorized' },
         { status: 401 },

--- a/src/app/api/cron/cobranza/route.ts
+++ b/src/app/api/cron/cobranza/route.ts
@@ -9,12 +9,14 @@ import { createServiceClient } from '@/lib/supabase'
 import { cobranzaRunner } from '@/lib/agents/cobranza'
 import { executeAgentRun } from '@/lib/agents/runner'
 import { cobranzaWhatsAppEnabled } from '@/lib/whatsapp'
+import { timingSafeEqualStr } from '@/lib/api-auth'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: Request) {
-  const authHeader = request.headers.get('authorization')
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  const cronSecret = process.env.CRON_SECRET || ''
+  const token = (request.headers.get('authorization') || '').replace(/^Bearer\s+/, '')
+  if (!cronSecret || !timingSafeEqualStr(token, cronSecret)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/src/app/api/cron/payments/route.ts
+++ b/src/app/api/cron/payments/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { timingSafeEqualStr } from '@/lib/api-auth'
 
 // NOTE: CRON_SECRET and SUPABASE_SERVICE_ROLE_KEY must be set as env vars in Vercel dashboard.
 // CRON_SECRET: a random string to authenticate cron requests
@@ -29,9 +30,10 @@ interface AncillaryCharge {
 // This route is called by Vercel Cron on day 1 of each month
 // Vercel cron config goes in vercel.json
 export async function GET(request: Request) {
-  // Verify cron secret to prevent unauthorized calls
-  const authHeader = request.headers.get('authorization')
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  // Verify cron secret to prevent unauthorized calls (timing-safe)
+  const cronSecret = process.env.CRON_SECRET || ''
+  const token = (request.headers.get('authorization') || '').replace(/^Bearer\s+/, '')
+  if (!cronSecret || !timingSafeEqualStr(token, cronSecret)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/src/app/api/cron/renovaciones/route.ts
+++ b/src/app/api/cron/renovaciones/route.ts
@@ -9,12 +9,14 @@ import { createServiceClient } from '@/lib/supabase'
 import { renovacionesRunner } from '@/lib/agents/renovaciones'
 import { executeAgentRun } from '@/lib/agents/runner'
 import { cobranzaWhatsAppEnabled } from '@/lib/whatsapp'
+import { timingSafeEqualStr } from '@/lib/api-auth'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: Request) {
-  const authHeader = request.headers.get('authorization')
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  const cronSecret = process.env.CRON_SECRET || ''
+  const token = (request.headers.get('authorization') || '').replace(/^Bearer\s+/, '')
+  if (!cronSecret || !timingSafeEqualStr(token, cronSecret)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/src/app/api/mifiel/webhook/route.ts
+++ b/src/app/api/mifiel/webhook/route.ts
@@ -1,10 +1,23 @@
 import { NextRequest } from "next/server"
-import { createServiceClient, apiError, apiOk } from "@/lib/api-auth"
+import { createServiceClient, apiError, apiOk, timingSafeEqualStr } from "@/lib/api-auth"
 
 export const dynamic = "force-dynamic"
 
 export async function POST(request: NextRequest) {
   try {
+    // Guard: antes CUALQUIERA podía POSTear {document_id, status:'signed'} y
+    // marcar un contrato como firmado (integridad legal). Ahora se exige un
+    // secreto compartido que Fran configura en la URL del webhook de Mifiel
+    // (?secret=<valor> o header x-webhook-secret).
+    const expected = process.env.MIFIEL_WEBHOOK_SECRET
+    const provided =
+      request.headers.get('x-webhook-secret') ||
+      new URL(request.url).searchParams.get('secret') ||
+      ''
+    if (!expected || !provided || !timingSafeEqualStr(provided, expected)) {
+      return apiError('Unauthorized', 401)
+    }
+
     const body = await request.json()
     const documentId = body.document_id || body.id
 

--- a/src/app/api/mora/route.ts
+++ b/src/app/api/mora/route.ts
@@ -45,11 +45,11 @@ export async function GET(request: NextRequest) {
     const now = new Date()
     const todayStr = now.toISOString().split('T')[0]
 
-    // Sprint 5 / fix #22: filtro multi-tenant opcional. Si el caller pasa
-    // ?org_id=<uuid> solo se devuelven datos de ese tenant. Si no se pasa,
-    // se devuelven datos cross-tenant (legacy behavior, solo seguro mientras
-    // hay 1 tenant en el sistema).
-    const orgIdParam = request.nextUrl.searchParams.get('org_id')
+    // Filtro multi-tenant. Con credencial de agente real, el org SIEMPRE es el de
+    // la credencial (no se confía en el ?org_id del query — eso daba mora
+    // cross-tenant). El caller legacy (key global) sí debe declarar ?org_id
+    // (validado arriba).
+    const orgIdParam = auth.ok ? auth.orgId : request.nextUrl.searchParams.get('org_id')
 
     // 1. Fetch overdue unconfirmed payments
     let paymentsQuery = supabase

--- a/src/app/api/payments/[id]/receipt/route.ts
+++ b/src/app/api/payments/[id]/receipt/route.ts
@@ -1,9 +1,11 @@
 // BaW OS — POST /api/payments/[id]/receipt
 // Envía el comprobante de pago por WhatsApp. Lo llama el flujo manual de /cobros
-// tras registrar un pago. Requiere sesión (humano) o API key legacy.
+// tras registrar un pago. Antes bastaba "hay un usuario" (cualquier rol/tenant)
+// y no filtraba el pago por org → IDOR. Ahora exige admin de la org y limita el
+// pago a esa org.
 import { NextRequest, NextResponse } from 'next/server'
 import { validateApiKey } from '@/lib/api-auth'
-import { createSupabaseServer } from '@/lib/supabase-server'
+import { requireAdminCaller } from '@/lib/admin-auth'
 import { sendPaymentReceipt } from '@/lib/payment-receipt'
 
 export const dynamic = 'force-dynamic'
@@ -12,14 +14,14 @@ export async function POST(
   request: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  if (!validateApiKey(request)) {
-    const supabase = createSupabaseServer()
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const auth = await requireAdminCaller()
+  let orgId: string | undefined
+  if (auth.ok) {
+    orgId = auth.orgId
+  } else if (!validateApiKey(request)) {
+    return NextResponse.json({ error: auth.message }, { status: auth.status })
   }
 
-  const result = await sendPaymentReceipt(params.id)
+  const result = await sendPaymentReceipt(params.id, orgId)
   return NextResponse.json({ success: result.ok, reason: result.reason })
 }

--- a/src/app/api/payments/[id]/route.ts
+++ b/src/app/api/payments/[id]/route.ts
@@ -2,6 +2,14 @@ import { NextRequest } from 'next/server'
 import { createServiceClient, validateApiKey, unauthorized, apiError, apiOk, getOrgId } from '@/lib/api-auth'
 import { logEvent } from '@/lib/webhooks'
 
+// Columnas que el caller puede modificar. Antes era update(body) crudo → un
+// caller podía sobreescribir org_id/contract_id/id y mover el pago de tenant.
+const PATCH_ALLOWED = new Set([
+  'status', 'amount', 'amount_paid', 'rent_amount', 'water_fee', 'late_fee_amount',
+  'late_fee_level', 'paid_date', 'due_date', 'method', 'payment_method', 'reference',
+  'confirmed_by', 'confirmed_at', 'notes',
+])
+
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   if (!validateApiKey(request)) return unauthorized()
 
@@ -9,9 +17,15 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
   const orgId = getOrgId()
   const body = await request.json()
 
+  const updates: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(body || {})) {
+    if (PATCH_ALLOWED.has(k)) updates[k] = v
+  }
+  if (Object.keys(updates).length === 0) return apiError('No hay campos válidos para actualizar', 400)
+
   const { data, error } = await supabase
     .from('payments')
-    .update(body)
+    .update(updates)
     .eq('id', params.id)
     .eq('org_id', orgId)
     .select('*, contract:contracts(*, unit:units(*), occupant:occupants(*))')
@@ -21,7 +35,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
 
   await logEvent('payment.updated', {
     payment_id: params.id,
-    changes: Object.keys(body),
+    changes: Object.keys(updates),
   })
 
   return apiOk(data)

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -30,10 +30,26 @@ export async function POST(request: NextRequest) {
 
     if (paymentId) {
       const supabase = createServiceClient()
+
+      // Leer el cargo primero para: (1) derivar org_id del PROPIO pago (no de la
+      // metadata, que puede faltar → ledger con org_id null), y (2) setear
+      // amount_paid = total del cargo (renta+agua+mora). Antes solo se ponía
+      // status='paid' sin amount_paid, y billing.ts (fuente única) lo contaba mal.
+      const { data: payment } = await supabase
+        .from('payments')
+        .select('org_id, contract_id, amount, water_fee, late_fee_amount, contract:contracts(unit_id, occupant:occupants(name))')
+        .eq('id', paymentId)
+        .single()
+
+      const totalDue = payment
+        ? Number(payment.amount || 0) + Number(payment.late_fee_amount || 0)
+        : null
+
       await supabase
         .from('payments')
         .update({
           status: 'paid',
+          amount_paid: totalDue,
           paid_date: new Date().toISOString().split('T')[0],
           method: 'stripe',
           reference: paymentIntent.id,
@@ -43,17 +59,10 @@ export async function POST(request: NextRequest) {
         })
         .eq('id', paymentId)
 
-      // Also create ledger entry
-      const { data: payment } = await supabase
-        .from('payments')
-        .select('contract_id, amount, water_fee, contract:contracts(unit_id, occupant:occupants(name))')
-        .eq('id', paymentId)
-        .single()
-
       if (payment) {
         const contract = payment.contract as unknown as { unit_id: string; occupant: { name: string } | null } | null
         await supabase.from('payment_ledger').insert({
-          org_id: paymentIntent.metadata?.org_id || null,
+          org_id: payment.org_id || paymentIntent.metadata?.org_id || null,
           payment_id: paymentId,
           contract_id: payment.contract_id,
           unit_id: contract?.unit_id || null,

--- a/src/app/api/whatsapp/send/route.ts
+++ b/src/app/api/whatsapp/send/route.ts
@@ -1,7 +1,7 @@
 // BaW OS — WhatsApp Send Message API
 import { NextRequest } from 'next/server'
-import { validateApiKey, unauthorized, apiError, apiOk, createServiceClient, getOrgId } from '@/lib/api-auth'
-import { createSupabaseServer } from '@/lib/supabase-server'
+import { validateApiKey, apiError, apiOk, createServiceClient, getOrgId } from '@/lib/api-auth'
+import { requireAdminCaller } from '@/lib/admin-auth'
 
 interface SendBody {
   to: string
@@ -11,15 +11,16 @@ interface SendBody {
 }
 
 export async function POST(request: NextRequest) {
-  // Audit 2026-06-12: la UI mandaba un API key hardcodeado en el JS del
-  // cliente (comprometido — rotar BAWOS_API_KEY). Ahora una sesión válida
-  // también autoriza, y la UI ya no embebe secretos.
-  if (!validateApiKey(request)) {
-    const supabase = createSupabaseServer()
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
-    if (!user) return unauthorized()
+  // Endpoint sensible: usa el WHATSAPP_ACCESS_TOKEN del sistema para enviar a
+  // cualquier número. Antes autorizaba a CUALQUIER sesión (cualquier rol/tenant).
+  // Ahora exige admin de la org (pm_owner/pm_admin); el API key legacy sigue
+  // como fallback para llamadas internas (timing-safe en validateApiKey).
+  let auditOrgId = getOrgId()
+  const auth = await requireAdminCaller()
+  if (auth.ok) {
+    auditOrgId = auth.orgId
+  } else if (!validateApiKey(request)) {
+    return apiError(auth.message, auth.status)
   }
 
   const accessToken = process.env.WHATSAPP_ACCESS_TOKEN
@@ -88,7 +89,7 @@ export async function POST(request: NextRequest) {
   // Audit log
   const supabase = createServiceClient()
   await supabase.from('audit_log').insert({
-    org_id: getOrgId(),
+    org_id: auditOrgId,
     actor_type: 'agent',
     actor_id: 'whatsapp-bot',
     action: 'whatsapp.message.sent',

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -1,7 +1,18 @@
 // BaW OS — WhatsApp Webhook (Meta Cloud API)
 import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'node:crypto'
 import { createServiceClient } from '@/lib/api-auth'
 import { resolveOrgIdForWebhook } from '@/lib/org-context'
+
+// Verifica X-Hub-Signature-256 = sha256=HMAC_SHA256(appSecret, rawBody) de Meta.
+function verifyMetaSignature(raw: string, header: string | null, secret: string): boolean {
+  if (!header || !header.startsWith('sha256=')) return false
+  const expected = crypto.createHmac('sha256', secret).update(raw).digest('hex')
+  const provided = header.slice('sha256='.length)
+  const a = Buffer.from(expected, 'hex')
+  const b = Buffer.from(provided, 'hex')
+  return a.length === b.length && crypto.timingSafeEqual(a, b)
+}
 
 const FAQS: Record<string, string> = {
   FAQ: 'Hola 👋 Soy el asistente de BaW. Para pagos usa la referencia de tu contrato. Para reportar una incidencia responde INCIDENCIA. Para hablar con un asesor responde ASESOR.',
@@ -33,7 +44,16 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const payload = await request.json()
+    // Verificar firma de Meta ANTES de procesar. Sin firma válida no se procesa
+    // (antes cualquiera podía POSTear con ?org=<slug> e inyectar incidents/audit
+    // y disparar envíos). Se devuelve 200 para que Meta no deshabilite el webhook.
+    const rawBody = await request.text()
+    const appSecret = process.env.WHATSAPP_APP_SECRET
+    if (!appSecret || !verifyMetaSignature(rawBody, request.headers.get('x-hub-signature-256'), appSecret)) {
+      console.error('[whatsapp] firma inválida o WHATSAPP_APP_SECRET sin configurar — no se procesa')
+      return NextResponse.json({ status: 'ok' })
+    }
+    const payload = JSON.parse(rawBody)
     const entry = payload?.entry?.[0]
     const change = entry?.changes?.[0]?.value
     if (!change?.messages?.[0]) {

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -2,6 +2,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
+/** Comparación en tiempo constante (evita canal lateral por tiempo). */
+export function timingSafeEqualStr(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}
+
 export function createServiceClient() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -53,8 +63,8 @@ export function apiOk<T>(data: T) {
 export function validateApiKey(request: NextRequest): boolean {
   const apiKey = request.headers.get('x-api-key')
   const expected = process.env.BAWOS_API_KEY
-  if (!expected) return false
-  return apiKey === expected
+  if (!expected || !apiKey) return false
+  return timingSafeEqualStr(apiKey, expected)
 }
 
 /**

--- a/src/lib/owner-context.ts
+++ b/src/lib/owner-context.ts
@@ -58,11 +58,23 @@ export async function resolveOwnerContext(): Promise<OwnerContext> {
 
   const service = createServiceClient()
 
-  // 1. property_owners enlazados al user_id O matching por email (fallback)
-  const { data: owners } = await service
-    .from('property_owners')
-    .select('id, full_name, org_id, organizations(name, slug)')
-    .or(`user_id.eq.${user.id},email.ilike.${user.email}`)
+  // 1. property_owners del user. Match primario por user_id (enlace explícito y
+  //    seguro). Fallback por email SOLO si el email está confirmado — antes se
+  //    matcheaba por email no verificado e interpolado crudo en .or(), lo que
+  //    permitía que otra org registrara tu email y te diera acceso a sus
+  //    finanzas. La query por email va parametrizada (.ilike), no interpolada.
+  const sel = 'id, full_name, org_id, organizations(name, slug)'
+  const { data: byUser } = await service.from('property_owners').select(sel).eq('user_id', user.id)
+  const owners = [...(byUser || [])]
+
+  const emailConfirmed = !!((user as { email_confirmed_at?: string }).email_confirmed_at || user.confirmed_at)
+  if (emailConfirmed && user.email) {
+    const { data: byEmail } = await service.from('property_owners').select(sel).ilike('email', user.email)
+    const seen = new Set(owners.map((o) => o.id))
+    for (const o of byEmail || []) {
+      if (!seen.has(o.id)) owners.push(o)
+    }
+  }
 
   if (!owners || owners.length === 0) {
     throw new OwnerContextError(

--- a/src/lib/payment-receipt.ts
+++ b/src/lib/payment-receipt.ts
@@ -18,19 +18,24 @@ export interface ReceiptResult {
   reason?: string
 }
 
-/** Envía el comprobante del pago indicado. No lanza; seguro como fire-and-forget. */
-export async function sendPaymentReceipt(paymentId: string): Promise<ReceiptResult> {
+/**
+ * Envía el comprobante del pago indicado. No lanza; seguro como fire-and-forget.
+ * `orgId` (opcional pero recomendado): si se pasa, el pago debe pertenecer a esa
+ * org — evita IDOR (un caller que itera payment ids de otro tenant).
+ */
+export async function sendPaymentReceipt(paymentId: string, orgId?: string): Promise<ReceiptResult> {
   try {
     if (!whatsAppConfigured() || !cobranzaWhatsAppEnabled()) {
       return { ok: false, reason: 'whatsapp_disabled' }
     }
     const supabase = createServiceClient()
 
-    const { data: payment } = await supabase
+    let paymentQuery = supabase
       .from('payments')
       .select('id, org_id, contract_id, amount, amount_paid, paid_date, method, reference, late_fee_amount')
       .eq('id', paymentId)
-      .maybeSingle()
+    if (orgId) paymentQuery = paymentQuery.eq('org_id', orgId)
+    const { data: payment } = await paymentQuery.maybeSingle()
     if (!payment || !payment.contract_id) return { ok: false, reason: 'payment_not_found' }
 
     const { data: contract } = await supabase


### PR DESCRIPTION
## Summary

Cierra las vulnerabilidades **urgentes** encontradas en la auditoría de seguridad: endpoints sin auth que exponían PII, webhooks sin verificación de firma, fugas cross-tenant (IDOR / org supplied por el caller) y comparaciones de secretos vulnerables a timing. Es puramente hardening de seguridad — **no** mezcla la deuda técnica (esa va en un PR separado).

### Qué cambia (por concern)

1. **Applications sin auth → PII expuesta.** `GET/POST /api/applications` y `/api/applications/[id]` importaban `validateApiKey` pero **nunca lo llamaban**: cualquiera en internet podía leer expedientes de aplicantes (nombre, aval, ingresos). Ahora exigen `requireMemberCaller()` y filtran todo por `auth.orgId`.
2. **whatsapp/send y payment receipt.** Autorizaban a cualquier sesión (cualquier rol/tenant). Ahora exigen admin de la org (`requireAdminCaller`); `sendPaymentReceipt` filtra el pago por `orgId` → cierra IDOR.
3. **mora cross-tenant.** Con credencial de agente real el `org_id` se toma de la credencial, no del `?org_id` del query.
4. **payments PATCH.** `update(body)` crudo permitía sobreescribir `org_id/contract_id/id` y mover un pago de tenant. Ahora hay whitelist de columnas.
5. **Webhooks sin firma.** WhatsApp valida `X-Hub-Signature-256` (HMAC de Meta) antes de procesar; Mifiel exige secreto compartido (antes cualquiera podía marcar un contrato como firmado). Channex y los 3 crons pasan a comparación timing-safe.
6. **API key timing-safe.** `validateApiKey` rechaza claves vacías y compara en tiempo constante (`timingSafeEqualStr`).
7. **owner-context cross-tenant.** Match por `user_id` primero; fallback por email **solo si está confirmado** y con query parametrizada (antes se interpolaba el email en `.or()`, permitiendo que otra org registrara tu email y te diera acceso a sus finanzas).
8. **stripe webhook.** Lee el pago antes de actualizar, setea `amount_paid` al total del cargo (para que `billing.ts` lo cuente bien) y deriva `org_id` del pago, no solo de la metadata.

## ⚠️ Acción requerida de Fran ANTES/AL desplegar

- **Configurar en Vercel:** `WHATSAPP_APP_SECRET` (App Secret de la app de Meta) y `MIFIEL_WEBHOOK_SECRET` (valor a incluir en la URL del webhook de Mifiel como `?secret=<valor>` o header `x-webhook-secret`).
- **Rotar `BAWOS_API_KEY`** — estaba embebido en el JS del cliente (comprometido).
- Confirmar que la URL del webhook de WhatsApp en Meta sigue apuntando aquí; sin `WHATSAPP_APP_SECRET` el handler responde 200 pero **no procesa** mensajes (fail-safe).

## Pre-flight checklist

- [x] `git fetch origin` — revisé estado real de main
- [x] Verifiqué que no duplica un PR ya mergeado
- [x] Esta rama está basada en `origin/main` actualizado
- [x] Scope discipline: **un solo objetivo** (seguridad); la deuda técnica va aparte
- [x] `npx tsc --noEmit` pasa
- [x] `npm run build` pasa

## Invariantes (sección 2 de AGENTS.md)

- [x] No toqué la tipografía Inter en `src/app/layout.tsx`
- [x] No creé sets paralelos de tokens
- [x] No agregué/quité/renombré secciones de `SIDEBAR_SECTIONS`
- [x] No bypass-eé `isPlatformAdmin()` ni `resolveOrgId()` — al contrario, refuerzo el aislamiento por org
- [x] No agregué referencias al enum legacy `member_role`
- [x] No introduje agentes fuera del catálogo
- [x] No eliminé features mergeadas funcionales

## Acuerdos canónicos afectados

- [x] Roles / permisos / RLS — refuerza guards existentes (`requireMemberCaller`/`requireAdminCaller`), sin cambiar el modelo
- [x] API pública — endpoints que estaban de facto abiertos ahora exigen auth (cambio de comportamiento intencional)
- Ninguna migración SQL en este PR.

## Verification

- [x] `npx tsc --noEmit` verde
- [x] `npm run build` verde
- [x] `bash tests/agents/run-all.sh` — 39/39 tests verdes (4 suites)
- [x] `eslint` verde en los 16 archivos tocados

## Follow-ups detectados (NO incluidos en este PR)

Van en el **PR de deuda técnica** separado:
- [ ] Doble fuente de verdad en cobros (recompute client-only → mover a server)
- [ ] Columnas fantasma en `/api/v1/reservations`
- [ ] Remoción del backend Python muerto (`_python_app`, `api_backend`)
- [ ] Enum legacy `member_role` (#23)
- [ ] Reconciliación `water_fee` vs `service_rates`
- [ ] Migración masiva de `getOrgId()` legacy (~28 rutas con sesión) — grande, scope propio

## Merge

- [ ] Confirmo que **NO** se mergeará automáticamente. Espero aprobación humana de @franduranv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_