### PR TITLE
Cuenta combinada (engagements): pool de contratos con estado de cuenta consolidado

### DIFF
--- a/docs/specs/people-crm-stays-model.md
+++ b/docs/specs/people-crm-stays-model.md
@@ -1,6 +1,6 @@
 # Spec — Modelo de Personas, CRM y Estancias (operación híbrida STR/MTR/LTR)
 
-**Status:** propuesta · pendiente de revisión por Fran
+**Status:** aprobado por Fran · en construcción por fases (2b y 3b en main; engagements Fase 1 en curso)
 **Autor:** Claude Code (planeación) · **Ejecutor previsto:** Claude Code
 **Origen:** discusión Fran ↔ Claude sobre cómo estructurar la sección "Inquilinos"
 (Contactos / Clientes / Contratos / Expedientes) para una operación híbrida.
@@ -217,13 +217,21 @@ Orden sugerido en "Inquilinos" (operación): **Personas · Estancias (Contratos/
 
 ---
 
-## 12. Decisiones abiertas (para Fran)
+## 12. Decisiones (resueltas por Fran)
 
-1. **Party = enriquecer `occupants`** (menos disruptivo) **o tabla `parties` nueva**
-   (más limpio, más migración). ¿Preferencia?
-2. **"Estancias" como vista unificada** sobre contratos+reservas, ¿o mantenerlas como
-   dos pestañas separadas y solo unificar el modelo por debajo?
-3. **Facturación corporativa:** ¿consolidada por empresa, por unidad, o configurable?
-4. **¿El CRM sale del sidebar como sección propia**, o se queda como pestaña dentro de
-   Inquilinos (respetando "el sidebar no crece")?
-5. ¿Hay algún escenario más (depósitos compartidos, subarriendo, etc.) que falte cubrir?
+1. **Party = enriquecer `occupants`** ✅ (decisión "1A", 2026-06; `occupants.kind`
+   persona|empresa en main vía `20260627_party_kind_payer.sql`).
+2. **"Estancias" unificadas dentro de Inquilinos** ✅ (decisión "2A", 2026-06).
+3. **Facturación corporativa: consolidada** ✅ (2026-07-02; `engagements.billing_mode`
+   default `'consolidated'`, `'per_unit'` disponible como opción).
+4. **CRM se queda como pestaña dentro de Inquilinos** (el sidebar no crece) — vigente.
+5. Escenarios extra (depósitos compartidos, subarriendo): sin casos reales aún; se
+   abordan cuando aparezcan.
+
+### Decisiones del caso Natturaly Complements (2026-07-02)
+
+- El mes único de **D201** SÍ se registra (con su 50% de descuento documentado).
+- El saldo del pool se **reconstruye desde febrero 2026** — se capturan cargos y
+  abonos reales; NO hay ajuste de saldo inicial. El saldo se deriva del historial.
+- Estado de cuenta del pool: **consolidado** a nombre de Natturaly Complements con
+  desglose por unidad.

--- a/src/app/api/engagements/[id]/estado-cuenta/route.ts
+++ b/src/app/api/engagements/[id]/estado-cuenta/route.ts
@@ -1,0 +1,31 @@
+// BaW OS — GET /api/engagements/[id]/estado-cuenta?periodo=YYYY-MM
+// Estado de cuenta CONSOLIDADO del pool: movimientos de todos los contratos
+// miembros mezclados por fecha (unidad como prefijo) + saldo individual por
+// contrato. Devuelve JSON; el PDF consolidado es follow-up.
+import { NextRequest } from 'next/server'
+import { createServiceClient, apiError, apiOk } from '@/lib/api-auth'
+import { requireMemberCaller } from '@/lib/admin-auth'
+import { getEstadoCuentaCombinadoData } from '@/lib/engagement'
+
+export const dynamic = 'force-dynamic'
+
+function currentPeriodo(): string {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+}
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  const auth = await requireMemberCaller()
+  if (!auth.ok) return apiError(auth.message, auth.status)
+
+  const periodo = request.nextUrl.searchParams.get('periodo') || currentPeriodo()
+  if (!/^\d{4}-\d{2}$/.test(periodo)) {
+    return apiError('periodo inválido (use YYYY-MM)', 400)
+  }
+
+  const supabase = createServiceClient()
+  const doc = await getEstadoCuentaCombinadoData(supabase, auth.orgId, params.id, periodo)
+  if (!doc) return apiError('Engagement no encontrado o sin contratos', 404)
+
+  return apiOk(doc)
+}

--- a/src/app/api/engagements/[id]/route.ts
+++ b/src/app/api/engagements/[id]/route.ts
@@ -1,0 +1,74 @@
+// BaW OS — PATCH /api/engagements/[id]
+// Edita un engagement (whitelist de columnas) y agrega/quita contratos miembro.
+import { NextRequest } from 'next/server'
+import { createServiceClient, apiError, apiOk } from '@/lib/api-auth'
+import { requireAdminCaller } from '@/lib/admin-auth'
+
+export const dynamic = 'force-dynamic'
+
+const PATCH_ALLOWED = new Set(['name', 'status', 'notes', 'payer_occupant_id', 'billing_mode'])
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const auth = await requireAdminCaller()
+  if (!auth.ok) return apiError(auth.message, auth.status)
+
+  const body = await request.json().catch(() => null)
+  if (!body) return apiError('Body inválido', 400)
+
+  const supabase = createServiceClient()
+
+  const { data: engagement } = await supabase
+    .from('engagements')
+    .select('id')
+    .eq('id', params.id)
+    .eq('org_id', auth.orgId)
+    .maybeSingle()
+  if (!engagement) return apiError('Engagement no encontrado', 404)
+
+  const updates: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(body)) {
+    if (PATCH_ALLOWED.has(k)) updates[k] = v
+  }
+
+  const addIds: string[] = Array.isArray(body.add_contract_ids)
+    ? body.add_contract_ids.filter((x: unknown) => typeof x === 'string')
+    : []
+  const removeIds: string[] = Array.isArray(body.remove_contract_ids)
+    ? body.remove_contract_ids.filter((x: unknown) => typeof x === 'string')
+    : []
+
+  if (Object.keys(updates).length === 0 && addIds.length === 0 && removeIds.length === 0) {
+    return apiError('No hay cambios válidos', 400)
+  }
+
+  if (Object.keys(updates).length > 0) {
+    updates.updated_at = new Date().toISOString()
+    const { error } = await supabase
+      .from('engagements')
+      .update(updates)
+      .eq('id', params.id)
+      .eq('org_id', auth.orgId)
+    if (error) return apiError(error.message, 500)
+  }
+
+  if (addIds.length > 0) {
+    const { error } = await supabase
+      .from('contracts')
+      .update({ engagement_id: params.id })
+      .in('id', addIds)
+      .eq('org_id', auth.orgId)
+    if (error) return apiError(error.message, 500)
+  }
+
+  if (removeIds.length > 0) {
+    const { error } = await supabase
+      .from('contracts')
+      .update({ engagement_id: null })
+      .in('id', removeIds)
+      .eq('org_id', auth.orgId)
+      .eq('engagement_id', params.id)
+    if (error) return apiError(error.message, 500)
+  }
+
+  return apiOk({ id: params.id })
+}

--- a/src/app/api/engagements/route.ts
+++ b/src/app/api/engagements/route.ts
@@ -1,0 +1,92 @@
+// BaW OS — Cuentas combinadas (engagements)
+// GET: lista los engagements de la org con pagador y contratos miembro.
+// POST: crea un engagement y opcionalmente le asigna contratos.
+import { NextRequest } from 'next/server'
+import { createServiceClient, apiError, apiOk } from '@/lib/api-auth'
+import { requireMemberCaller, requireAdminCaller } from '@/lib/admin-auth'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_request: NextRequest) {
+  const auth = await requireMemberCaller()
+  if (!auth.ok) return apiError(auth.message, auth.status)
+
+  const supabase = createServiceClient()
+  const { data: engagements, error } = await supabase
+    .from('engagements')
+    .select('id, name, payer_occupant_id, billing_mode, status, notes, created_at, payer:occupants(id, name, kind)')
+    .eq('org_id', auth.orgId)
+    .order('created_at', { ascending: false })
+  if (error) return apiError(error.message, 500)
+
+  const ids = (engagements || []).map((e) => e.id)
+  let membersByEngagement = new Map<string, unknown[]>()
+  if (ids.length > 0) {
+    const { data: contracts, error: contractsError } = await supabase
+      .from('contracts')
+      .select('id, engagement_id, status, monthly_amount, unit:units(number), occupant:occupants(name)')
+      .in('engagement_id', ids)
+      .eq('org_id', auth.orgId)
+    if (contractsError) return apiError(contractsError.message, 500)
+    membersByEngagement = new Map()
+    for (const c of contracts || []) {
+      const list = membersByEngagement.get(c.engagement_id) || []
+      list.push(c)
+      membersByEngagement.set(c.engagement_id, list)
+    }
+  }
+
+  return apiOk(
+    (engagements || []).map((e) => ({ ...e, contracts: membersByEngagement.get(e.id) || [] })),
+  )
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdminCaller()
+  if (!auth.ok) return apiError(auth.message, auth.status)
+
+  const body = await request.json().catch(() => null)
+  const name = typeof body?.name === 'string' ? body.name.trim() : ''
+  if (!name) return apiError('name es requerido', 400)
+
+  const contractIds: string[] = Array.isArray(body?.contract_ids)
+    ? body.contract_ids.filter((x: unknown) => typeof x === 'string')
+    : []
+
+  const supabase = createServiceClient()
+
+  // El pagador (si viene) debe ser un occupant de la misma org.
+  if (body?.payer_occupant_id) {
+    const { data: payer } = await supabase
+      .from('occupants')
+      .select('id')
+      .eq('id', body.payer_occupant_id)
+      .eq('org_id', auth.orgId)
+      .maybeSingle()
+    if (!payer) return apiError('payer_occupant_id no pertenece a la org', 400)
+  }
+
+  const { data: engagement, error } = await supabase
+    .from('engagements')
+    .insert({
+      org_id: auth.orgId,
+      name,
+      payer_occupant_id: body?.payer_occupant_id ?? null,
+      billing_mode: body?.billing_mode === 'per_unit' ? 'per_unit' : 'consolidated',
+      notes: typeof body?.notes === 'string' ? body.notes : null,
+    })
+    .select('id, name, payer_occupant_id, billing_mode, status, notes, created_at')
+    .single()
+  if (error || !engagement) return apiError(error?.message || 'No se pudo crear', 500)
+
+  if (contractIds.length > 0) {
+    const { error: assignError } = await supabase
+      .from('contracts')
+      .update({ engagement_id: engagement.id })
+      .in('id', contractIds)
+      .eq('org_id', auth.orgId)
+    if (assignError) return apiError(`Engagement creado pero sin asignar contratos: ${assignError.message}`, 500)
+  }
+
+  return apiOk(engagement)
+}

--- a/src/app/cobros/EngagementsPanel.tsx
+++ b/src/app/cobros/EngagementsPanel.tsx
@@ -1,0 +1,428 @@
+'use client'
+
+// BaW OS — Panel de cuentas combinadas (engagements) en /cobros.
+// Muestra los pools (p.ej. Natturaly Complements = D102+D202+D201) con su
+// saldo consolidado derivado de los movimientos reales, y permite crear un
+// pool nuevo y ver el estado de cuenta combinado. El saldo NO es un ajuste:
+// sale del mismo motor que los estados de cuenta individuales.
+
+import { useCallback, useEffect, useState } from 'react'
+import { Layers, Plus, X, FileText, Trash2 } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { useToast } from '@/components/Toast'
+import { formatCurrency } from '@/lib/utils'
+import PersonPicker, { type PickedPerson } from '@/components/PersonPicker'
+import type { EstadoCuentaCombinadoDoc } from '@/lib/engagement'
+
+interface EngagementRow {
+  id: string
+  name: string
+  status: string
+  payer: { id: string; name: string; kind?: string } | null
+  contracts: Array<{
+    id: string
+    status: string
+    monthly_amount: number
+    unit: { number: string } | null
+    occupant: { name: string } | null
+  }>
+}
+
+interface ContractOption {
+  id: string
+  label: string
+}
+
+function one<T>(v: T | T[] | null | undefined): T | null {
+  return Array.isArray(v) ? (v[0] ?? null) : (v ?? null)
+}
+
+export default function EngagementsPanel({
+  orgId,
+  selectedMonth,
+}: {
+  orgId: string | null | undefined
+  selectedMonth: string
+}) {
+  const toast = useToast()
+  const [engagements, setEngagements] = useState<EngagementRow[]>([])
+  const [saldos, setSaldos] = useState<Map<string, number>>(new Map())
+  const [loaded, setLoaded] = useState(false)
+
+  // Modal de creación
+  const [showCreate, setShowCreate] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [name, setName] = useState('')
+  const [payer, setPayer] = useState<PickedPerson | null>(null)
+  const [contractOptions, setContractOptions] = useState<ContractOption[]>([])
+  const [selectedContracts, setSelectedContracts] = useState<Set<string>>(new Set())
+
+  // Modal de detalle (estado de cuenta consolidado)
+  const [detail, setDetail] = useState<EstadoCuentaCombinadoDoc | null>(null)
+  const [detailFor, setDetailFor] = useState<EngagementRow | null>(null)
+  const [loadingDetail, setLoadingDetail] = useState(false)
+
+  const fetchEngagements = useCallback(async () => {
+    const res = await fetch('/api/engagements')
+    if (!res.ok) return
+    const json = await res.json()
+    const rows = ((json.data || []) as Array<Record<string, unknown>>).map((e) => ({
+      id: e.id as string,
+      name: e.name as string,
+      status: e.status as string,
+      payer: one(e.payer as EngagementRow['payer'] | EngagementRow['payer'][] | null),
+      contracts: ((e.contracts || []) as Array<Record<string, unknown>>).map((c) => ({
+        id: c.id as string,
+        status: c.status as string,
+        monthly_amount: Number(c.monthly_amount || 0),
+        unit: one(c.unit as { number: string } | { number: string }[] | null),
+        occupant: one(c.occupant as { name: string } | { name: string }[] | null),
+      })),
+    }))
+    setEngagements(rows.filter((e) => e.status === 'active'))
+    setLoaded(true)
+  }, [])
+
+  useEffect(() => {
+    if (!orgId) return
+    fetchEngagements()
+  }, [orgId, fetchEngagements])
+
+  // Saldo consolidado por engagement para el mes de corte seleccionado.
+  useEffect(() => {
+    let cancelled = false
+    async function loadSaldos() {
+      const next = new Map<string, number>()
+      for (const e of engagements) {
+        const res = await fetch(`/api/engagements/${e.id}/estado-cuenta?periodo=${selectedMonth}`)
+        if (!res.ok) continue
+        const json = await res.json()
+        if (json?.data?.data) next.set(e.id, Number(json.data.data.saldoTotal || 0))
+      }
+      if (!cancelled) setSaldos(next)
+    }
+    if (engagements.length > 0) loadSaldos()
+    return () => {
+      cancelled = true
+    }
+  }, [engagements, selectedMonth])
+
+  async function openCreate() {
+    setName('')
+    setPayer(null)
+    setSelectedContracts(new Set())
+    setShowCreate(true)
+    const { data } = await supabase
+      .from('contracts')
+      .select('id, monthly_amount, engagement_id, unit:units(number), occupant:occupants(name)')
+      .eq('org_id', orgId)
+      .in('status', ['active', 'en_renovacion'])
+    setContractOptions(
+      ((data || []) as Array<Record<string, unknown>>)
+        .filter((c) => !c.engagement_id)
+        .map((c) => {
+          const unit = one(c.unit as { number: string } | { number: string }[] | null)
+          const occupant = one(c.occupant as { name: string } | { name: string }[] | null)
+          return {
+            id: c.id as string,
+            label: `${unit?.number || '—'} · ${occupant?.name || 'Sin inquilino'} · ${formatCurrency(Number(c.monthly_amount || 0))}`,
+          }
+        })
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    )
+  }
+
+  async function createEngagement() {
+    if (!name.trim()) {
+      toast.error('Ponle nombre a la cuenta combinada')
+      return
+    }
+    setSaving(true)
+    const res = await fetch('/api/engagements', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: name.trim(),
+        payer_occupant_id: payer?.id ?? null,
+        contract_ids: Array.from(selectedContracts),
+      }),
+    })
+    setSaving(false)
+    if (!res.ok) {
+      const json = await res.json().catch(() => null)
+      toast.error(json?.error || 'No se pudo crear la cuenta combinada')
+      return
+    }
+    toast.success('Cuenta combinada creada')
+    setShowCreate(false)
+    fetchEngagements()
+  }
+
+  async function openDetail(e: EngagementRow) {
+    setDetailFor(e)
+    setLoadingDetail(true)
+    setDetail(null)
+    const res = await fetch(`/api/engagements/${e.id}/estado-cuenta?periodo=${selectedMonth}`)
+    setLoadingDetail(false)
+    if (!res.ok) {
+      toast.error('No se pudo cargar el estado de cuenta combinado')
+      setDetailFor(null)
+      return
+    }
+    const json = await res.json()
+    setDetail(json.data as EstadoCuentaCombinadoDoc)
+  }
+
+  async function removeMember(engagementId: string, contractId: string) {
+    const res = await fetch(`/api/engagements/${engagementId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ remove_contract_ids: [contractId] }),
+    })
+    if (!res.ok) {
+      toast.error('No se pudo quitar el contrato del pool')
+      return
+    }
+    toast.success('Contrato fuera del pool')
+    setDetailFor(null)
+    setDetail(null)
+    fetchEngagements()
+  }
+
+  // Sin engagements: solo el botón discreto para crear el primero.
+  if (!loaded || (engagements.length === 0 && !showCreate)) {
+    return (
+      <div className="flex justify-end">
+        {loaded && (
+          <button
+            onClick={openCreate}
+            className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-indigo-500 dark:text-gray-400 transition-colors"
+          >
+            <Layers className="w-4 h-4" /> Nueva cuenta combinada
+          </button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide flex items-center gap-2">
+          <Layers className="w-4 h-4" /> Cuentas combinadas
+        </h2>
+        <button
+          onClick={openCreate}
+          className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-indigo-500 dark:text-gray-400 transition-colors"
+        >
+          <Plus className="w-4 h-4" /> Nueva
+        </button>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {engagements.map((e) => {
+          const saldo = saldos.get(e.id)
+          return (
+            <div key={e.id} className="card p-4 space-y-2">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="font-semibold">{e.name}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    {e.payer ? `Paga: ${e.payer.name}` : 'Sin pagador asignado'} · {e.contracts.length} contrato{e.contracts.length === 1 ? '' : 's'}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="text-xs text-gray-500 dark:text-gray-400">Saldo del pool</p>
+                  <p className={`font-bold ${saldo && saldo > 0 ? 'text-red-500' : 'text-emerald-500'}`}>
+                    {saldo === undefined ? '…' : formatCurrency(saldo)}
+                  </p>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {e.contracts.map((c) => (
+                  <span
+                    key={c.id}
+                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                  >
+                    {c.unit?.number || '—'}
+                  </span>
+                ))}
+              </div>
+              <button
+                onClick={() => openDetail(e)}
+                className="inline-flex items-center gap-1.5 text-sm text-indigo-500 hover:text-indigo-400 transition-colors"
+              >
+                <FileText className="w-4 h-4" /> Estado de cuenta combinado
+              </button>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Modal: crear cuenta combinada */}
+      {showCreate && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="card w-full max-w-lg p-6 space-y-4 max-h-[85vh] overflow-y-auto">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-bold">Nueva cuenta combinada</h3>
+              <button onClick={() => setShowCreate(false)} className="text-gray-400 hover:text-gray-200">
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Nombre del pool</label>
+              <input
+                className="input-field w-full"
+                placeholder="p. ej. Natturaly Complements"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Quién paga (persona o empresa)</label>
+              <PersonPicker orgId={orgId} value={payer} onChange={setPayer} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Contratos del pool</label>
+              {contractOptions.length === 0 ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  No hay contratos activos disponibles (los que ya están en otro pool no aparecen).
+                </p>
+              ) : (
+                <div className="space-y-1 max-h-48 overflow-y-auto border border-gray-200 dark:border-gray-700 rounded-lg p-2">
+                  {contractOptions.map((c) => (
+                    <label key={c.id} className="flex items-center gap-2 text-sm cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={selectedContracts.has(c.id)}
+                        onChange={() =>
+                          setSelectedContracts((prev) => {
+                            const next = new Set(prev)
+                            if (next.has(c.id)) next.delete(c.id)
+                            else next.add(c.id)
+                            return next
+                          })
+                        }
+                      />
+                      {c.label}
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setShowCreate(false)} className="btn-secondary">
+                Cancelar
+              </button>
+              <button onClick={createEngagement} disabled={saving} className="btn-primary">
+                {saving ? 'Creando…' : 'Crear pool'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Modal: estado de cuenta consolidado */}
+      {detailFor && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="card w-full max-w-3xl p-6 space-y-4 max-h-[85vh] overflow-y-auto">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-lg font-bold">{detailFor.name}</h3>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Estado de cuenta consolidado · corte {selectedMonth}
+                  {detail ? ` · ${detail.folio}` : ''}
+                </p>
+              </div>
+              <button
+                onClick={() => {
+                  setDetailFor(null)
+                  setDetail(null)
+                }}
+                className="text-gray-400 hover:text-gray-200"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {loadingDetail && <p className="text-sm text-gray-500">Cargando…</p>}
+
+            {detail && (
+              <>
+                {/* Resumen del pool */}
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                  {[
+                    { label: 'Saldo anterior', value: detail.data.saldoAnterior },
+                    { label: 'Cargos del periodo', value: detail.data.cargosPeriodo },
+                    { label: 'Pagos recibidos', value: detail.data.pagosRecibidos },
+                    { label: 'Saldo total', value: detail.data.saldoTotal },
+                  ].map((s) => (
+                    <div key={s.label} className="rounded-lg bg-gray-50 dark:bg-gray-800/60 p-3">
+                      <p className="text-xs text-gray-500 dark:text-gray-400">{s.label}</p>
+                      <p className={`font-bold ${s.label === 'Saldo total' && s.value > 0 ? 'text-red-500' : ''}`}>
+                        {formatCurrency(s.value)}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Saldo por unidad */}
+                <div>
+                  <p className="text-sm font-semibold mb-1">Por unidad</p>
+                  <div className="flex flex-wrap gap-2">
+                    {detail.members.map((m) => (
+                      <span
+                        key={m.contractId}
+                        className="inline-flex items-center gap-2 px-2.5 py-1 rounded-lg text-sm bg-gray-100 dark:bg-gray-800"
+                      >
+                        <strong>{m.unitNumber}</strong> {m.tenantName} ·{' '}
+                        <span className={m.saldoTotal > 0 ? 'text-red-500' : 'text-emerald-500'}>
+                          {formatCurrency(m.saldoTotal)}
+                        </span>
+                        <button
+                          title="Quitar del pool"
+                          onClick={() => removeMember(detailFor.id, m.contractId)}
+                          className="text-gray-400 hover:text-red-500"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Movimientos */}
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                        <th className="py-1.5 pr-3">Fecha</th>
+                        <th className="py-1.5 pr-3">Concepto</th>
+                        <th className="py-1.5 pr-3 text-right">Cargo</th>
+                        <th className="py-1.5 pr-3 text-right">Abono</th>
+                        <th className="py-1.5 text-right">Saldo</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {detail.data.movimientos.map((m, i) => (
+                        <tr key={i} className="border-b border-gray-100 dark:border-gray-800">
+                          <td className="py-1.5 pr-3 whitespace-nowrap">{m.date}</td>
+                          <td className="py-1.5 pr-3">{m.concept}</td>
+                          <td className="py-1.5 pr-3 text-right">{m.charge ? formatCurrency(m.charge) : '—'}</td>
+                          <td className="py-1.5 pr-3 text-right text-emerald-500">
+                            {m.credit ? formatCurrency(m.credit) : '—'}
+                          </td>
+                          <td className="py-1.5 text-right font-medium">{formatCurrency(m.balance)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -13,6 +13,7 @@ import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 import InvoiceModal from '@/components/InvoiceModal'
 import PersonPicker, { type PickedPerson } from '@/components/PersonPicker'
+import EngagementsPanel from './EngagementsPanel'
 
 interface ContractRow {
   id: string
@@ -670,6 +671,9 @@ export default function CobrosPage() {
           />
         </div>
       </div>
+
+      {/* Cuentas combinadas (pools tipo Natturaly Complements) */}
+      <EngagementsPanel orgId={orgId} selectedMonth={selectedMonth} />
 
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-2">

--- a/src/lib/engagement.ts
+++ b/src/lib/engagement.ts
@@ -1,0 +1,187 @@
+// BaW OS — Cuenta combinada (engagement): estado de cuenta consolidado.
+//
+// Un engagement agrupa N contratos bajo un mismo pagador (spec
+// people-crm-stays-model §6, p.ej. Natturaly Complements = D102+D202+D201).
+// Este módulo deriva el saldo del POOL de los movimientos reales de cada
+// contrato miembro — no hay "ajuste inicial": el historial manda (decisión
+// Fran 2026-07-02). Reusa computeEstadoCuenta para que el consolidado cuadre
+// exactamente con los estados de cuenta individuales.
+//
+// `computeEstadoCuentaCombinado` es PURA (sin I/O) → testeable.
+// `getEstadoCuentaCombinadoData` hace el fetch a Supabase y arma el documento.
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  computeEstadoCuenta,
+  periodEndOf,
+  type EstadoCuenta,
+  type EstadoCuentaPayment,
+} from '@/lib/estado-cuenta'
+
+// ── Tipos ──────────────────────────────────────────────────────────────────
+
+export interface EngagementMemberInput {
+  contractId: string
+  unitNumber: string
+  tenantName: string
+  contractStatus: string
+  payments: EstadoCuentaPayment[]
+}
+
+export interface EngagementMemberSummary {
+  contractId: string
+  unitNumber: string
+  tenantName: string
+  contractStatus: string
+  saldoTotal: number
+}
+
+export interface EstadoCuentaCombinado {
+  /** Consolidado del pool: movimientos de todos los contratos mezclados por
+   *  fecha, con la unidad como prefijo del concepto. */
+  data: EstadoCuenta
+  /** Saldo individual de cada contrato miembro (mismo motor, mismo corte). */
+  members: EngagementMemberSummary[]
+}
+
+export interface EstadoCuentaCombinadoDoc extends EstadoCuentaCombinado {
+  engagementId: string
+  engagementName: string
+  payerName: string | null
+  buildingName: string
+  periodo: string
+  folio: string
+  emittedAt: string // ISO
+}
+
+// ── Núcleo puro ─────────────────────────────────────────────────────────────
+
+/** Folio determinista del consolidado: EC-CC-<nombre-compacto>-<periodo>. */
+export function folioCombinadoFor(engagementName: string, periodo: string): string {
+  const compact = (engagementName || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toUpperCase()
+    .slice(0, 10) || 'POOL'
+  return `EC-CC-${compact}-${periodo}`
+}
+
+/**
+ * Consolida los estados de cuenta de los contratos miembros de un engagement.
+ * El pool se calcula pasando TODOS los renglones (etiquetados con su unidad)
+ * por el mismo motor que un contrato individual, así:
+ *   saldo del pool === Σ saldos individuales (mismo corte, mismos criterios).
+ */
+export function computeEstadoCuentaCombinado(
+  members: EngagementMemberInput[],
+  periodo: string,
+  corteISO?: string,
+): EstadoCuentaCombinado {
+  const corte = corteISO ?? periodEndOf(periodo)
+
+  const merged: EstadoCuentaPayment[] = members.flatMap((m) =>
+    m.payments.map((p) => ({ ...p, conceptPrefix: m.unitNumber })),
+  )
+
+  return {
+    data: computeEstadoCuenta(merged, periodo, corte),
+    members: members.map((m) => ({
+      contractId: m.contractId,
+      unitNumber: m.unitNumber,
+      tenantName: m.tenantName,
+      contractStatus: m.contractStatus,
+      saldoTotal: computeEstadoCuenta(m.payments, periodo, corte).saldoTotal,
+    })),
+  }
+}
+
+// ── Capa de datos ───────────────────────────────────────────────────────────
+
+const PAYMENT_COLUMNS =
+  'id, contract_id, due_date, paid_date, amount, rent_amount, water_fee, amount_paid, late_fee_amount, late_fee_level, status, ancillary_charge_id, notes'
+
+/**
+ * Carga el engagement con sus contratos miembros y arma el documento
+ * consolidado. Filtra SIEMPRE por el org_id dado (invariante multi-tenant):
+ * el caller pasa el org del contexto autenticado.
+ */
+export async function getEstadoCuentaCombinadoData(
+  supabase: SupabaseClient,
+  orgId: string,
+  engagementId: string,
+  periodo: string,
+): Promise<EstadoCuentaCombinadoDoc | null> {
+  const { data: engagement } = await supabase
+    .from('engagements')
+    .select('id, org_id, name, payer_occupant_id, payer:occupants(name)')
+    .eq('id', engagementId)
+    .eq('org_id', orgId)
+    .maybeSingle()
+  if (!engagement) return null
+
+  const { data: contracts } = await supabase
+    .from('contracts')
+    .select('id, status, unit:units(number, building_id), occupant:occupants(name)')
+    .eq('engagement_id', engagementId)
+    .eq('org_id', orgId)
+  const memberContracts = contracts || []
+  if (memberContracts.length === 0) return null
+
+  const corte = periodEndOf(periodo)
+  const { data: payments } = await supabase
+    .from('payments')
+    .select(PAYMENT_COLUMNS)
+    .in('contract_id', memberContracts.map((c) => c.id))
+    .eq('org_id', orgId)
+    .lte('due_date', corte)
+    .order('due_date', { ascending: true })
+
+  const paymentsByContract = new Map<string, EstadoCuentaPayment[]>()
+  for (const p of (payments || []) as Array<EstadoCuentaPayment & { contract_id: string }>) {
+    const list = paymentsByContract.get(p.contract_id) || []
+    list.push(p)
+    paymentsByContract.set(p.contract_id, list)
+  }
+
+  const one = <T,>(v: unknown): T | null => (Array.isArray(v) ? ((v[0] as T) ?? null) : ((v as T) ?? null))
+
+  const members: EngagementMemberInput[] = memberContracts.map((c) => {
+    const unit = one<{ number: string; building_id: string | null }>(c.unit)
+    const occupant = one<{ name: string }>(c.occupant)
+    return {
+      contractId: c.id,
+      unitNumber: unit?.number || '—',
+      tenantName: occupant?.name || 'Sin inquilino',
+      contractStatus: c.status,
+      payments: paymentsByContract.get(c.id) || [],
+    }
+  })
+  // Orden estable por unidad para que el documento sea reproducible.
+  members.sort((a, b) => a.unitNumber.localeCompare(b.unitNumber))
+
+  let buildingName = 'Edificio'
+  const firstUnit = one<{ building_id: string | null }>(memberContracts[0]?.unit)
+  if (firstUnit?.building_id) {
+    const { data: building } = await supabase
+      .from('buildings')
+      .select('name')
+      .eq('id', firstUnit.building_id)
+      .maybeSingle()
+    if (building?.name) buildingName = building.name
+  }
+
+  const payer = one<{ name: string }>(engagement.payer)
+  const combinado = computeEstadoCuentaCombinado(members, periodo, corte)
+
+  return {
+    ...combinado,
+    engagementId: engagement.id,
+    engagementName: engagement.name,
+    payerName: payer?.name ?? null,
+    buildingName,
+    periodo,
+    folio: folioCombinadoFor(engagement.name, periodo),
+    emittedAt: new Date().toISOString(),
+  }
+}

--- a/src/lib/estado-cuenta.ts
+++ b/src/lib/estado-cuenta.ts
@@ -28,6 +28,9 @@ export interface EstadoCuentaPayment {
   status: string
   ancillary_charge_id?: string | null
   notes?: string | null
+  /** Prefijo del concepto (p.ej. la unidad 'D102') en estados de cuenta que
+   *  mezclan renglones de varios contratos (cuenta combinada). */
+  conceptPrefix?: string
 }
 
 export type MovimientoKind =
@@ -106,18 +109,25 @@ function periodStartOf(periodo: string): string {
 }
 
 /** Último día del mes del periodo 'YYYY-MM' como 'YYYY-MM-DD'. */
-function periodEndOf(periodo: string): string {
+export function periodEndOf(periodo: string): string {
   const [y, m] = periodo.split('-').map(Number)
   const last = new Date(y, m, 0).getDate()
   return `${periodo}-${String(last).padStart(2, '0')}`
 }
 
 function conceptFor(p: EstadoCuentaPayment): string {
-  if (p.ancillary_charge_id) return p.notes || 'Cargo accesorio'
-  const hasWater = Number(p.water_fee || 0) > 0
-  if (Number(p.rent_amount || 0) > 0 && hasWater) return 'Renta + servicios'
-  if (hasWater && !Number(p.rent_amount || 0)) return 'Servicios'
-  return 'Renta mensual'
+  const base = (() => {
+    if (p.ancillary_charge_id) return p.notes || 'Cargo accesorio'
+    const hasWater = Number(p.water_fee || 0) > 0
+    if (Number(p.rent_amount || 0) > 0 && hasWater) return 'Renta + servicios'
+    if (hasWater && !Number(p.rent_amount || 0)) return 'Servicios'
+    return 'Renta mensual'
+  })()
+  return withPrefix(p, base)
+}
+
+function withPrefix(p: EstadoCuentaPayment, concept: string): string {
+  return p.conceptPrefix ? `${p.conceptPrefix} · ${concept}` : concept
 }
 
 // ── Núcleo: agregación pura ─────────────────────────────────────────────────
@@ -205,7 +215,7 @@ export function computeEstadoCuenta(
       const partial = paid + 0.001 < base + fee
       movimientos.push({
         date: p.paid_date || p.due_date,
-        concept: partial ? 'Pago recibido (parcial)' : 'Pago recibido',
+        concept: withPrefix(p, partial ? 'Pago recibido (parcial)' : 'Pago recibido'),
         charge: 0,
         credit: paid,
         balance,
@@ -220,7 +230,7 @@ export function computeEstadoCuenta(
       balance = round2(balance + fee)
       movimientos.push({
         date: p.due_date,
-        concept: `Recargo por mora — ${days} días`,
+        concept: withPrefix(p, `Recargo por mora — ${days} días`),
         charge: fee,
         credit: 0,
         balance,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -202,6 +202,7 @@ export interface Contract {
   unit_id?: string | null // NULL = contrato independiente (standalone)
   occupant_id: string
   payer_occupant_id?: string | null // quién paga si ≠ inquilino (Fase 2b); NULL = el inquilino
+  engagement_id?: string | null // cuenta combinada a la que pertenece (pool); NULL = individual
   start_date: string
   billing_start_date?: string | null // Cobros factura desde aquí; NULL = desde start_date
   end_date?: string
@@ -230,6 +231,22 @@ export interface Contract {
   // Relations (joined)
   unit?: Unit
   occupant?: Occupant
+}
+
+/** Cuenta combinada: agrupa N contratos bajo un mismo pagador (spec §6). */
+export interface Engagement {
+  id: string
+  org_id: string
+  name: string
+  payer_occupant_id?: string | null
+  billing_mode: 'consolidated' | 'per_unit'
+  status: 'active' | 'closed'
+  notes?: string | null
+  created_at: string
+  updated_at: string
+  // Relations (joined)
+  payer?: Occupant
+  contracts?: Contract[]
 }
 
 export interface Payment {

--- a/supabase/migrations/20260702_engagements.sql
+++ b/supabase/migrations/20260702_engagements.sql
@@ -1,0 +1,47 @@
+-- BaW OS — Fase engagements: cuenta combinada (spec people-crm-stays-model §6).
+--
+-- Un engagement agrupa N contratos bajo un mismo pagador (persona o empresa,
+-- p.ej. Natturaly Complements con D102+D202+D201) para verlos como UNA cuenta:
+-- saldo pooled y estado de cuenta consolidado. Decisiones de Fran 2026-07-02:
+-- se registra el mes único de D201, el historial se reconstruye desde febrero
+-- (el saldo se DERIVA de los movimientos, sin ajuste inicial), y la facturación
+-- del pool es consolidada. Idempotente, no destructiva.
+
+CREATE TABLE IF NOT EXISTS public.engagements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  -- Quién paga el pool (occupants con kind='empresa' o 'persona').
+  payer_occupant_id uuid REFERENCES public.occupants(id),
+  -- Consolidado = un estado de cuenta del pool; per_unit = por unidad con
+  -- saldo compartido. Default según decisión de Fran.
+  billing_mode text NOT NULL DEFAULT 'consolidated'
+    CHECK (billing_mode IN ('consolidated', 'per_unit')),
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'closed')),
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_engagements_org ON public.engagements (org_id, status);
+
+-- Membresía: el contrato apunta a su engagement. FK directa a engagements (no
+-- introduce una segunda FK contracts→occupants, así que no rompe los embeds
+-- PostgREST occupant:occupants(...) — ver nota en 20260627_party_kind_payer).
+ALTER TABLE public.contracts
+  ADD COLUMN IF NOT EXISTS engagement_id uuid REFERENCES public.engagements(id);
+
+CREATE INDEX IF NOT EXISTS idx_contracts_engagement
+  ON public.contracts (engagement_id) WHERE engagement_id IS NOT NULL;
+
+ALTER TABLE public.engagements ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS engagements_member ON public.engagements;
+CREATE POLICY engagements_member ON public.engagements FOR ALL
+  USING (EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = engagements.org_id AND om.user_id = auth.uid()
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.org_members om
+    WHERE om.org_id = engagements.org_id AND om.user_id = auth.uid()
+  ));


### PR DESCRIPTION
## Summary

Fase 1 de **engagements** (spec `people-crm-stays-model` §6, aprobado): agrupar N contratos bajo un mismo pagador — el caso real es **Natturaly Complements = D102 + D202 + D201** — con saldo pooled y estado de cuenta **consolidado**. Implementa las 3 decisiones de Fran (2026-07-02): se registra el mes único de D201, el historial se reconstruye desde febrero (**el saldo se deriva de los movimientos, sin ajuste inicial**), y la facturación del pool es consolidada.

### Qué incluye (5 commits)

1. **Migración `20260702_engagements.sql`**: tabla `engagements` (org, nombre, pagador, `billing_mode` consolidated/per_unit, status) + `contracts.engagement_id` con FK directa (NO agrega segunda FK contracts→occupants, así que los embeds PostgREST `occupant:occupants(...)` siguen funcionando) + RLS espejo de `service_rates`.
2. **Motor consolidado** (`src/lib/engagement.ts`): `computeEstadoCuentaCombinado` pasa los renglones de TODOS los contratos miembros (etiquetados con su unidad) por el MISMO `computeEstadoCuenta` de siempre → **el saldo del pool cuadra por construcción con la suma de los saldos individuales**. `estado-cuenta.ts` solo gana un `conceptPrefix` opcional.
3. **API**: `GET/POST /api/engagements` (lectura member, escritura admin), `PATCH /api/engagements/[id]` (whitelist + agregar/quitar contratos), `GET /api/engagements/[id]/estado-cuenta?periodo=YYYY-MM` (JSON consolidado). Todo filtrado por org del caller.
4. **UI en /cobros**: panel "Cuentas combinadas" — tarjeta por pool con saldo consolidado al mes de corte, chips por unidad con saldo individual, modal de estado de cuenta (resumen + movimientos mezclados por fecha con la unidad como prefijo), y modal de creación (nombre + PersonPicker de pagador + multi-select de contratos activos sin pool).
5. **Spec actualizado**: status aprobado + decisiones registradas.

## ⚠️ Orden de deploy (regla del repo)

**Aplicar la migración en Supabase prod ANTES de mergear** — el SQL completo está en `supabase/migrations/20260702_engagements.sql` (idempotente, no destructiva: CREATE TABLE IF NOT EXISTS + ADD COLUMN IF NOT EXISTS + RLS).

## Flujo para Fran después del merge

1. En /cobros → "Nueva cuenta combinada" → nombre "Natturaly Complements", pagador = la empresa (occupant kind=empresa), y seleccionar los contratos D102/D202/D201 (el de D201 hay que darlo de alta primero con su mes único).
2. Capturar el historial desde febrero con los flujos existentes (pago rápido / abonos por mes).
3. El saldo del pool y el estado de cuenta consolidado salen solos del historial.

## Pre-flight checklist

- [x] Rama basada en `origin/main` actualizado (post-merge #135)
- [x] No duplica PRs previos
- [x] Scope discipline: **un solo objetivo** (engagements Fase 1)
- [x] `npx tsc --noEmit` pasa
- [x] `npm run build` pasa

## Invariantes (sección 2 de AGENTS.md)

- [x] No toqué tipografía Inter / tokens / `SIDEBAR_SECTIONS` (el panel vive dentro de /cobros)
- [x] No bypass-eé `isPlatformAdmin()` ni `resolveOrgId()` — API con `requireMemberCaller`/`requireAdminCaller` + filtro org
- [x] No agregué referencias al enum legacy `member_role`
- [x] No introduje agentes fuera del catálogo
- [x] No eliminé features funcionales

## Acuerdos canónicos afectados

- [x] Schema DB / migración SQL: `20260702_engagements.sql` — Fran la aplica en prod antes del merge
- [x] Implementa el spec aprobado `docs/specs/people-crm-stays-model.md` §6 (caso corporativo)

## Verification

- [x] `npx tsc --noEmit` verde · `npm run build` verde · `eslint` verde en los 8 archivos
- [x] El consolidado reusa el motor testeado de estado de cuenta (wrapper puro, sin lógica nueva de dinero)
- [ ] Preview Vercel: verificar visualmente el panel en /cobros (afecta UI)

## Follow-ups detectados (NO incluidos en este PR)

- [ ] PDF del estado de cuenta consolidado (el endpoint devuelve JSON; el PDF individual ya existe y se puede extender)
- [ ] D303 multi-inquilino: contratos mes-a-mes por sub-ocupante (necesita montos/día de pago de Ángel, Marlen y Xitlali)
- [ ] Sweep de desambiguación + FK formal de `contracts.payer_occupant_id` (nota en `20260627_party_kind_payer.sql`)

## Merge

- [ ] Confirmo que **NO** se mergeará automáticamente. Espero aprobación humana de @franduranv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvUSwQD1FfGFUDWeHW35U)_