### PR TITLE
Calendario de unidades: timeline fluido (spec UI System v1) + mensual por unidad con price management de temporadas

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,7 +1,7 @@
 # PROJECT_STATE.md — Estado vivo de BaW OS
 
 > **Este archivo cambia seguido.** Cualquier agente que vaya a tocar el repo debe leerlo después de `AGENTS.md` y antes de empezar.
-> **Última actualización:** 2026-07-03 (Fase 1 Public Listing: rutas públicas genéricas `/edificios/[buildingSlug]`, galería pública, leads MTR/LTR, UI de publicación).
+> **Última actualización:** 2026-07-03 (Calendario de unidades PR 1; antes el mismo día: Fase 1 Public Listing).
 
 ---
 
@@ -23,6 +23,18 @@ Plan de 4 fases acordado en chat (rama `claude/property-listing-website-qf916r`)
 4. **Fase 4** — Consolidación PM rentas fijas (recordatorios de vencimiento, vacancia → listing).
 
 Decisión estratégica registrada (2026-07-03): canal directo por edificio/tenant (modelo WanderOS), NO marketplace consolidado bajo marca BaW por ahora. La relación con el huésped pertenece al tenant.
+
+---
+
+## 0.ter · Calendario de unidades (aprobado por Fran 2026-07-03, rama `claude/calendar-units-display-8waabf`)
+
+Sección de visualización de ocupación modelo Airbnb, 2 vistas, en Portafolio → Calendario:
+
+- **Vista A `/calendario`** — timeline multi-unidad: filas = unidades agrupadas por edificio (colapsables), columnas = días (zoom 2 semanas/mes/trimestre, navegación ◀ Hoy ▶), barras = estancias de los 3 instrumentos con colores de `/estancias` (STR morado / MTR ámbar / LTR azul), holds del booking público en gris rayado, franja de temporadas (`str_seasons`) arriba, línea de "hoy", KPIs de la ventana (ocupación %, noches vacantes, entradas/salidas hoy, contratos vencen ≤60d), filtros (edificio/tipo unidad/tipo estancia/holds/búsqueda), drawer de detalle con link al instrumento.
+- **Vista B `/calendario/[unitId]`** — mensual por unidad con scroll vertical (meses apilados): cada día muestra ocupación + **precio por noche = `units.base_rate_mxn` × multiplicador de temporada** (misma fórmula que `/quotes`), tinte esmeralda en días con temporada.
+- Lógica pura compartida en `src/lib/calendar-occupancy.ts` (rangos semiabiertos `[start, endExclusive)` como los EXCLUDE de DB; contratos `end_date` inclusivo → +1; `terminated`/`cancelled` no pintan; tentativas/holds no cuentan en ocupación). Constantes visuales en `src/components/calendar/calendar-ui.ts` (tailwind no escanea src/lib). Sin migraciones de DB.
+- **PR 2 pendiente (acordado):** price management interactivo desde la Vista B (seleccionar rango → crear/editar temporada en `str_seasons`, editar tarifa base, cotización rápida) + crear reservación/contrato desde celdas vacías. **Fase 3 futura:** `unit_rate_overrides` por unidad (requiere migración), drag & drop, bloqueos de mantenimiento con fechas.
+- Nota: RLS de `str_seasons` solo tiene política service_role en `20260404_rls_hardening.sql`; `/pricing` y `/quotes` ya la leen client-side igual que el calendario — si en prod el browser no la ve, el calendario degrada sin temporadas (mismo comportamiento que el cotizador). Verificar en el audit de drift de Fase 2.
 
 ---
 

--- a/src/app/calendario/[unitId]/page.tsx
+++ b/src/app/calendario/[unitId]/page.tsx
@@ -1,0 +1,369 @@
+'use client'
+
+// BaW OS — Calendario de unidades · Vista B (mensual por unidad).
+//
+// Modelo Airbnb host: meses apilados con scroll vertical. Cada día muestra la
+// ocupación (banda con el color del tipo de estancia) y el precio por noche
+// (tarifa base de la unidad × multiplicador de temporada de str_seasons —
+// misma fórmula que el cotizador). Read-only en esta fase; la edición de
+// temporadas/tarifas desde el calendario llega en el siguiente PR.
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { ArrowLeft, CalendarDays } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { useActiveContext } from '@/lib/useActiveContext'
+import { SkeletonTable } from '@/components/Skeleton'
+import EmptyState from '@/components/EmptyState'
+import StayDrawer from '@/components/calendar/StayDrawer'
+import {
+  TYPE_BADGE,
+  HOLD_STRIPES,
+  SEASON_CHIP,
+  barClassFor,
+} from '@/components/calendar/calendar-ui'
+import type { CalendarStay, Season } from '@/lib/calendar-occupancy'
+import {
+  todayISO,
+  addDaysISO,
+  contractToStay,
+  reservationToStay,
+  holdToStay,
+  seasonForDate,
+  nightlyPrice,
+  monthMatrix,
+  monthLabel,
+  monthRange,
+} from '@/lib/calendar-occupancy'
+import { formatCurrency } from '@/lib/utils'
+import type { UnitType } from '@/types'
+
+interface UnitDetail {
+  id: string
+  number: string
+  floor: number | null
+  type: UnitType
+  status: string
+  base_rate_mxn: number | null
+  monthly_rate_mxn: number | null
+  is_publicly_bookable: boolean | null
+  building: { id: string; name: string } | { id: string; name: string }[] | null
+}
+
+const WEEKDAYS = ['lun', 'mar', 'mié', 'jue', 'vie', 'sáb', 'dom']
+
+function one<T>(rel: T | T[] | null | undefined): T | null {
+  if (Array.isArray(rel)) return rel[0] ?? null
+  return rel ?? null
+}
+
+export default function UnidadCalendarioPage() {
+  const params = useParams()
+  const unitId = params.unitId as string
+  const { activeOrgId, loading: ctxLoading } = useActiveContext()
+
+  const today = todayISO()
+  const [unit, setUnit] = useState<UnitDetail | null>(null)
+  const [stays, setStays] = useState<CalendarStay[]>([])
+  const [seasons, setSeasons] = useState<Season[]>([])
+  const [loading, setLoading] = useState(true)
+  const [monthsBack, setMonthsBack] = useState(0)
+  const [monthsAhead, setMonthsAhead] = useState(6)
+  const [selected, setSelected] = useState<CalendarStay | null>(null)
+
+  useEffect(() => {
+    if (ctxLoading) return
+    if (!activeOrgId || !unitId) {
+      setLoading(false)
+      return
+    }
+    let alive = true
+
+    async function load(orgId: string) {
+      setLoading(true)
+      try {
+        const [unitRes, contractsRes, reservationsRes, holdsRes, seasonsRes] = await Promise.all([
+          supabase
+            .from('units')
+            .select('id, number, floor, type, status, base_rate_mxn, monthly_rate_mxn, is_publicly_bookable, building:buildings(id, name)')
+            .eq('id', unitId)
+            .eq('org_id', orgId)
+            .maybeSingle(),
+          supabase
+            .from('contracts')
+            .select('id, unit_id, rent_type, status, monthly_amount, start_date, end_date, notes, occupant:occupants(name)')
+            .eq('org_id', orgId)
+            .eq('unit_id', unitId)
+            .is('archived_at', null),
+          // reservations filtra por organization_id (esquema histórico)
+          supabase
+            .from('reservations')
+            .select('id, unit_id, guest_name, check_in, check_out, status, payment_status, total_price, guests_count, channel, notes')
+            .eq('organization_id', orgId)
+            .eq('unit_id', unitId),
+          supabase
+            .from('reservation_holds')
+            .select('id, unit_id, from_date, to_date, guests_count, guest_email, expires_at')
+            .eq('unit_id', unitId)
+            .gt('expires_at', new Date().toISOString()),
+          supabase.from('str_seasons').select('*').order('start_date'),
+        ])
+
+        const merged: CalendarStay[] = [
+          ...((contractsRes.data ?? []) as any[]).map(contractToStay),
+          ...((reservationsRes.data ?? []) as any[]).map(reservationToStay),
+          ...((holdsRes.data ?? []) as any[]).map(holdToStay),
+        ].filter((s): s is CalendarStay => s !== null)
+
+        if (alive) {
+          setUnit((unitRes.data as UnitDetail | null) ?? null)
+          setStays(merged)
+          setSeasons((seasonsRes.data ?? []) as Season[])
+        }
+      } finally {
+        if (alive) setLoading(false)
+      }
+    }
+
+    load(activeOrgId)
+    return () => {
+      alive = false
+    }
+  }, [ctxLoading, activeOrgId, unitId])
+
+  const months = useMemo(
+    () => monthRange(today, monthsBack, monthsAhead),
+    [today, monthsBack, monthsAhead],
+  )
+
+  function staysCovering(iso: string): CalendarStay[] {
+    return stays.filter(
+      (s) => s.start <= iso && (s.endExclusive === null || iso < s.endExclusive),
+    )
+  }
+
+  const building = one(unit?.building ?? null)
+  const showPrices = unit?.base_rate_mxn != null
+
+  if (ctxLoading || loading) {
+    return (
+      <div className="space-y-6">
+        <SkeletonTable />
+      </div>
+    )
+  }
+
+  if (!activeOrgId) {
+    return (
+      <EmptyState
+        icon={CalendarDays}
+        title="Sin organización activa"
+        description="Selecciona una organización en el switcher del sidebar."
+      />
+    )
+  }
+
+  if (!unit) {
+    return (
+      <div className="space-y-4">
+        <Link
+          href="/calendario"
+          className="inline-flex items-center gap-1.5 text-sm text-indigo-500 hover:text-indigo-400"
+        >
+          <ArrowLeft className="w-4 h-4" /> Volver al calendario
+        </Link>
+        <EmptyState
+          icon={CalendarDays}
+          title="Unidad no encontrada"
+          description="La unidad no existe o pertenece a otra organización."
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <Link
+          href="/calendario"
+          className="inline-flex items-center gap-1.5 text-sm text-indigo-500 hover:text-indigo-400 mb-2"
+        >
+          <ArrowLeft className="w-4 h-4" /> Todas las unidades
+        </Link>
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-xl sm:text-2xl font-bold flex items-center gap-2">
+            <CalendarDays className="w-6 h-6 text-indigo-400" />
+            Unidad {unit.number}
+          </h1>
+          <span
+            className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
+              unit.type === 'STR' || unit.type === 'MTR' || unit.type === 'LTR'
+                ? TYPE_BADGE[unit.type]
+                : 'bg-gray-500/10 text-gray-500 border border-gray-500/20'
+            }`}
+          >
+            {unit.type}
+          </span>
+        </div>
+        <p className="text-gray-500 dark:text-gray-400 mt-1 text-sm">
+          {building ? `${building.name} · ` : ''}
+          {showPrices
+            ? `Tarifa base ${formatCurrency(unit.base_rate_mxn!)}/noche`
+            : 'Sin tarifa base por noche configurada'}
+          {unit.monthly_rate_mxn != null
+            ? ` · Renta mensual ${formatCurrency(unit.monthly_rate_mxn)}/mes`
+            : ''}
+          {showPrices ? ' · precio/día = base × temporada' : ''}
+        </p>
+      </div>
+
+      {/* Cargar meses anteriores */}
+      <button
+        onClick={() => setMonthsBack((n) => n + 3)}
+        className="px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 muted-text"
+      >
+        ← Cargar meses anteriores
+      </button>
+
+      {/* Meses apilados */}
+      <div className="space-y-8 max-w-3xl">
+        {months.map(({ year, month }) => {
+          const cells = monthMatrix(year, month)
+          return (
+            <section key={`${year}-${month}`}>
+              <h2
+                className="text-base font-semibold capitalize mb-2"
+                style={{ color: 'var(--baw-text)' }}
+              >
+                {monthLabel(year, month)}
+              </h2>
+              <div className="card p-2">
+                <div className="grid grid-cols-7 mb-1">
+                  {WEEKDAYS.map((d) => (
+                    <div key={d} className="text-center text-[11px] uppercase tracking-wide muted-text py-1">
+                      {d}
+                    </div>
+                  ))}
+                </div>
+                <div className="grid grid-cols-7">
+                  {cells.map((cell) => {
+                    if (!cell.inMonth) {
+                      return <div key={cell.iso} className="min-h-[72px]" />
+                    }
+                    const covering = staysCovering(cell.iso)
+                    // La banda pinta la estancia "más firme": no-hold primero
+                    const band =
+                      covering.find((s) => s.kind !== 'hold' && !s.tentative) ??
+                      covering.find((s) => s.kind !== 'hold') ??
+                      covering[0] ??
+                      null
+                    const isStart = band ? band.start === cell.iso : false
+                    const isEnd = band
+                      ? band.endExclusive !== null && addDaysISO(cell.iso, 1) === band.endExclusive
+                      : false
+                    const season = seasonForDate(seasons, cell.iso)
+                    const price = showPrices
+                      ? nightlyPrice(unit.base_rate_mxn, seasons, cell.iso)
+                      : null
+                    const isPast = cell.iso < today
+                    const isToday = cell.iso === today
+
+                    return (
+                      <button
+                        key={cell.iso}
+                        onClick={() => band && setSelected(band)}
+                        disabled={!band}
+                        className={`relative min-h-[72px] p-1 text-left border border-black/[0.04] dark:border-white/[0.04] transition-colors ${
+                          band ? 'cursor-pointer hover:bg-black/[0.03] dark:hover:bg-white/[0.03]' : 'cursor-default'
+                        } ${season ? 'bg-emerald-500/[0.06]' : ''} ${isPast ? 'opacity-55' : ''}`}
+                        title={
+                          band
+                            ? `${band.person} · ${band.start} → ${band.moveOutDay ?? 'sin fin'}`
+                            : season
+                            ? `${season.name} ×${season.price_multiplier}`
+                            : cell.iso
+                        }
+                      >
+                        <span
+                          className={`text-xs tabular-nums ${
+                            isToday
+                              ? 'inline-flex items-center justify-center w-5 h-5 rounded-full bg-indigo-600 text-white font-semibold'
+                              : 'muted-text'
+                          }`}
+                        >
+                          {cell.day}
+                        </span>
+
+                        {/* Banda de ocupación */}
+                        {band && (
+                          <span
+                            className={`absolute left-0 right-0 top-1/2 -translate-y-1/2 h-5 border text-[10px] font-medium truncate px-1 leading-[18px] ${barClassFor(
+                              band.kind,
+                              band.type,
+                              band.tentative,
+                            )} ${isStart ? 'rounded-l-md ml-0.5' : ''} ${
+                              isEnd ? 'rounded-r-md mr-0.5' : ''
+                            }`}
+                            style={band.kind === 'hold' ? HOLD_STRIPES : undefined}
+                          >
+                            {isStart ? band.person : ''}
+                          </span>
+                        )}
+
+                        {/* Precio por noche (solo días libres para no encimar) */}
+                        {price !== null && !band && (
+                          <span
+                            className={`absolute bottom-1 right-1 text-[10px] tabular-nums ${
+                              season
+                                ? 'text-emerald-600 dark:text-emerald-400 font-medium'
+                                : 'muted-text'
+                            }`}
+                            title={
+                              season
+                                ? `${formatCurrency(price)} · ${season.name} ×${season.price_multiplier}`
+                                : formatCurrency(price)
+                            }
+                          >
+                            ${price.toLocaleString('es-MX')}
+                          </span>
+                        )}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            </section>
+          )
+        })}
+      </div>
+
+      {/* Cargar más meses */}
+      <button
+        onClick={() => setMonthsAhead((n) => n + 3)}
+        className="px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 muted-text"
+      >
+        Cargar más meses →
+      </button>
+
+      {/* Leyenda */}
+      <div className="flex flex-wrap items-center gap-3 text-xs muted-text">
+        <span className="flex items-center gap-1.5">
+          <span className={`w-3 h-3 rounded ${SEASON_CHIP}`} /> Día en temporada (precio ×
+          multiplicador)
+        </span>
+        <span className="flex items-center gap-1.5 opacity-60">
+          <span className="w-3 h-3 rounded border border-dashed border-gray-400 bg-gray-400/30" />{' '}
+          Tentativa / hold
+        </span>
+      </div>
+
+      <StayDrawer
+        stay={selected}
+        unitLabel={`Unidad ${unit.number}${building ? ` · ${building.name}` : ''}`}
+        onClose={() => setSelected(null)}
+      />
+    </div>
+  )
+}

--- a/src/app/calendario/page.tsx
+++ b/src/app/calendario/page.tsx
@@ -1,0 +1,735 @@
+'use client'
+
+// BaW OS — Calendario de unidades · Vista A (timeline multi-unidad).
+//
+// Modelo Airbnb multi-calendar: filas = unidades agrupadas por edificio,
+// columnas = días con desplazamiento horizontal por ventana (◀ Hoy ▶ + zoom).
+// Barras = estancias de los 3 instrumentos (contratos LTR/MTR, reservaciones
+// STR, holds del booking público) + franja de temporadas (str_seasons) arriba.
+// Read-only en esta fase: click en barra → drawer con link al instrumento;
+// click en la unidad → /calendario/[unitId] (Vista B mensual con precios).
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  CalendarDays,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  Search,
+  Filter,
+} from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { useActiveContext } from '@/lib/useActiveContext'
+import { SkeletonTable } from '@/components/Skeleton'
+import EmptyState from '@/components/EmptyState'
+import { KPICard } from '@/components/ui/status'
+import StayDrawer from '@/components/calendar/StayDrawer'
+import {
+  TYPE_BADGE,
+  BAR_CLASS,
+  HOLD_STRIPES,
+  SEASON_CHIP,
+  barClassFor,
+} from '@/components/calendar/calendar-ui'
+import type { CalendarStay, Season, StayType } from '@/lib/calendar-occupancy'
+import {
+  todayISO,
+  addDaysISO,
+  diffDaysISO,
+  isWeekendISO,
+  contractToStay,
+  reservationToStay,
+  holdToStay,
+  layoutLanes,
+  computeKpis,
+} from '@/lib/calendar-occupancy'
+import type { UnitType } from '@/types'
+
+interface UnitRow {
+  id: string
+  building_id: string | null
+  number: string
+  floor: number | null
+  type: UnitType
+  status: string
+  base_rate_mxn: number | null
+  monthly_rate_mxn: number | null
+}
+
+const UNIT_TYPE_LABELS: Record<UnitType, string> = {
+  STR: 'Corta estancia',
+  MTR: 'Media estancia',
+  LTR: 'Larga estancia',
+  RETAIL: 'Local comercial',
+  OFFICE: 'Oficina',
+  COMMON: 'Área común',
+}
+
+type Zoom = 14 | 31 | 92
+const ZOOM_OPTIONS: Array<{ value: Zoom; label: string }> = [
+  { value: 14, label: '2 semanas' },
+  { value: 31, label: 'Mes' },
+  { value: 92, label: 'Trimestre' },
+]
+const COL_PX: Record<Zoom, number> = { 14: 44, 31: 26, 92: 11 }
+const LABEL_W = 210
+const LANE_H = 24
+const ALL = '__ALL__'
+const SIN_EDIFICIO = '__NONE__'
+
+export default function CalendarioPage() {
+  const {
+    activeOrgId,
+    activeBuildingId,
+    buildings,
+    loading: ctxLoading,
+  } = useActiveContext()
+
+  const today = todayISO()
+  const [units, setUnits] = useState<UnitRow[]>([])
+  const [stays, setStays] = useState<CalendarStay[]>([])
+  const [seasons, setSeasons] = useState<Season[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [zoom, setZoom] = useState<Zoom>(31)
+  const [windowStart, setWindowStart] = useState(() => addDaysISO(todayISO(), -7))
+
+  const [buildingFilter, setBuildingFilter] = useState<string>(ALL)
+  const [unitTypeFilter, setUnitTypeFilter] = useState<'all' | UnitType>('all')
+  const [stayTypeFilter, setStayTypeFilter] = useState<'all' | StayType>('all')
+  const [showHolds, setShowHolds] = useState(true)
+  const [query, setQuery] = useState('')
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+  const [selected, setSelected] = useState<CalendarStay | null>(null)
+
+  // Respetar el building activo del switcher como filtro inicial (patrón /units)
+  useEffect(() => {
+    if (activeBuildingId && activeBuildingId !== 'all' && buildingFilter === ALL) {
+      setBuildingFilter(activeBuildingId)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeBuildingId])
+
+  useEffect(() => {
+    if (ctxLoading) return
+    if (!activeOrgId) {
+      setUnits([])
+      setStays([])
+      setLoading(false)
+      return
+    }
+    let alive = true
+
+    async function load(orgId: string) {
+      setLoading(true)
+      try {
+        const [unitsRes, contractsRes, reservationsRes, seasonsRes] = await Promise.all([
+          supabase
+            .from('units')
+            .select('id, building_id, number, floor, type, status, base_rate_mxn, monthly_rate_mxn')
+            .eq('org_id', orgId)
+            .is('archived_at', null)
+            .order('floor')
+            .order('number'),
+          supabase
+            .from('contracts')
+            .select('id, unit_id, rent_type, status, monthly_amount, start_date, end_date, notes, occupant:occupants(name)')
+            .eq('org_id', orgId)
+            .is('archived_at', null)
+            .not('unit_id', 'is', null),
+          // Ojo: reservations filtra por organization_id, no org_id (esquema histórico)
+          supabase
+            .from('reservations')
+            .select('id, unit_id, guest_name, check_in, check_out, status, payment_status, total_price, guests_count, channel, notes')
+            .eq('organization_id', orgId),
+          supabase.from('str_seasons').select('*').order('start_date'),
+        ])
+
+        const unitRows = (unitsRes.data ?? []) as UnitRow[]
+
+        // reservation_holds no tiene org_id: se acota por las unidades de la org
+        let holdRows: any[] = []
+        if (unitRows.length > 0) {
+          const { data } = await supabase
+            .from('reservation_holds')
+            .select('id, unit_id, from_date, to_date, guests_count, guest_email, expires_at')
+            .in('unit_id', unitRows.map((u) => u.id))
+            .gt('expires_at', new Date().toISOString())
+          holdRows = data ?? []
+        }
+
+        const merged: CalendarStay[] = [
+          ...((contractsRes.data ?? []) as any[]).map(contractToStay),
+          ...((reservationsRes.data ?? []) as any[]).map(reservationToStay),
+          ...holdRows.map(holdToStay),
+        ].filter((s): s is CalendarStay => s !== null)
+
+        if (alive) {
+          setUnits(unitRows)
+          setStays(merged)
+          setSeasons((seasonsRes.data ?? []) as Season[])
+        }
+      } finally {
+        if (alive) setLoading(false)
+      }
+    }
+
+    load(activeOrgId)
+    return () => {
+      alive = false
+    }
+  }, [ctxLoading, activeOrgId])
+
+  const orgBuildings = useMemo(
+    () => buildings.filter((b) => b.org_id === activeOrgId),
+    [buildings, activeOrgId],
+  )
+
+  const days = zoom
+  const colPx = COL_PX[zoom]
+  const gridW = days * colPx
+  const dayList = useMemo(
+    () => Array.from({ length: days }, (_, i) => addDaysISO(windowStart, i)),
+    [windowStart, days],
+  )
+  const todayIdx = diffDaysISO(windowStart, today)
+  const todayVisible = todayIdx >= 0 && todayIdx < days
+
+  // Barras visibles según filtros de tipo de estancia / holds
+  const visibleStays = useMemo(
+    () =>
+      stays.filter((s) => {
+        if (s.kind === 'hold') return showHolds
+        return stayTypeFilter === 'all' || s.type === stayTypeFilter
+      }),
+    [stays, stayTypeFilter, showHolds],
+  )
+
+  const staysByUnit = useMemo(() => {
+    const map = new Map<string, CalendarStay[]>()
+    for (const s of visibleStays) {
+      if (!map.has(s.unitId)) map.set(s.unitId, [])
+      map.get(s.unitId)!.push(s)
+    }
+    return map
+  }, [visibleStays])
+
+  const filteredUnits = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return units.filter((u) => {
+      if (buildingFilter !== ALL && (u.building_id ?? SIN_EDIFICIO) !== buildingFilter) return false
+      if (unitTypeFilter !== 'all' && u.type !== unitTypeFilter) return false
+      if (q) {
+        const numberMatch = u.number.toLowerCase().includes(q)
+        const personMatch = (staysByUnit.get(u.id) ?? []).some((s) =>
+          s.person.toLowerCase().includes(q),
+        )
+        if (!numberMatch && !personMatch) return false
+      }
+      return true
+    })
+  }, [units, buildingFilter, unitTypeFilter, query, staysByUnit])
+
+  const groups = useMemo(() => {
+    const byBuilding = new Map<string, UnitRow[]>()
+    for (const u of filteredUnits) {
+      const key = u.building_id ?? SIN_EDIFICIO
+      if (!byBuilding.has(key)) byBuilding.set(key, [])
+      byBuilding.get(key)!.push(u)
+    }
+    const nameOf = (id: string) =>
+      id === SIN_EDIFICIO
+        ? 'Sin edificio'
+        : orgBuildings.find((b) => b.id === id)?.name ?? 'Edificio'
+    return Array.from(byBuilding.entries())
+      .map(([id, list]) => ({ id, name: nameOf(id), units: list }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [filteredUnits, orgBuildings])
+
+  const kpis = useMemo(
+    () =>
+      computeKpis(
+        filteredUnits.map((u) => u.id),
+        visibleStays,
+        windowStart,
+        days,
+        today,
+      ),
+    [filteredUnits, visibleStays, windowStart, days, today],
+  )
+
+  // Encabezado: runs de meses [label, startIdx, span]
+  const monthSpans = useMemo(() => {
+    const spans: Array<{ label: string; startIdx: number; span: number }> = []
+    for (let i = 0; i < dayList.length; i++) {
+      const ym = dayList[i].slice(0, 7)
+      const last = spans[spans.length - 1]
+      if (last && dayList[last.startIdx].slice(0, 7) === ym) {
+        last.span++
+      } else {
+        const [y, m] = ym.split('-').map(Number)
+        spans.push({
+          label: new Date(Date.UTC(y, m - 1, 1)).toLocaleDateString('es-MX', {
+            month: 'short',
+            year: 'numeric',
+            timeZone: 'UTC',
+          }),
+          startIdx: i,
+          span: 1,
+        })
+      }
+    }
+    return spans
+  }, [dayList])
+
+  // Temporadas recortadas a la ventana
+  const seasonSegments = useMemo(() => {
+    const windowEnd = addDaysISO(windowStart, days)
+    return seasons
+      .map((s) => {
+        const endExclusive = addDaysISO(s.end_date, 1)
+        if (endExclusive <= windowStart || s.start_date >= windowEnd) return null
+        const a = s.start_date < windowStart ? windowStart : s.start_date
+        const b = endExclusive > windowEnd ? windowEnd : endExclusive
+        return {
+          season: s,
+          startIdx: diffDaysISO(windowStart, a),
+          span: diffDaysISO(a, b),
+        }
+      })
+      .filter((x): x is { season: Season; startIdx: number; span: number } => x !== null)
+  }, [seasons, windowStart, days])
+
+  function shift(dir: -1 | 1) {
+    setWindowStart((ws) => addDaysISO(ws, dir * Math.max(7, Math.floor(days / 2))))
+  }
+
+  function toggleGroup(id: string) {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const unitLabelFor = (stay: CalendarStay | null) => {
+    if (!stay) return undefined
+    const u = units.find((x) => x.id === stay.unitId)
+    if (!u) return undefined
+    const b = orgBuildings.find((x) => x.id === u.building_id)
+    return `Unidad ${u.number}${b ? ` · ${b.name}` : ''}`
+  }
+
+  const showDayNumbers = zoom !== 92
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl sm:text-2xl font-bold flex items-center gap-2">
+          <CalendarDays className="w-6 h-6 text-indigo-400" />
+          Calendario de unidades
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
+          Ocupación de los 3 instrumentos — contratos (LTR/MTR), reservaciones (STR) y holds —
+          con temporadas de precio.
+        </p>
+      </div>
+
+      {ctxLoading || loading ? (
+        <SkeletonTable />
+      ) : !activeOrgId ? (
+        <EmptyState
+          icon={CalendarDays}
+          title="Sin organización activa"
+          description="Selecciona una organización en el switcher del sidebar para ver su calendario."
+        />
+      ) : units.length === 0 ? (
+        <EmptyState
+          icon={CalendarDays}
+          title="No hay unidades"
+          description="Crea unidades en Portafolio → Unidades para verlas en el calendario."
+        />
+      ) : (
+        <>
+          {/* KPIs de la ventana visible (respetan filtros) */}
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+            <KPICard label="Ocupación (ventana)" value={`${kpis.occupancyPct}%`} />
+            <KPICard label="Noches vacantes" value={kpis.vacantNights} />
+            <KPICard
+              label="Hoy · entradas / salidas"
+              value={`${kpis.movesInToday} / ${kpis.movesOutToday}`}
+            />
+            <KPICard
+              label="Contratos vencen ≤60d"
+              value={kpis.expiringSoon}
+              warning={kpis.expiringSoon > 0}
+            />
+          </div>
+
+          {/* Controles */}
+          <div className="flex flex-col xl:flex-row xl:items-center gap-3">
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => shift(-1)}
+                className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
+                aria-label="Anterior"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => setWindowStart(addDaysISO(today, -7))}
+                className="px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-800"
+              >
+                Hoy
+              </button>
+              <button
+                onClick={() => shift(1)}
+                className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
+                aria-label="Siguiente"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+              <input
+                type="date"
+                value={windowStart}
+                onChange={(e) => e.target.value && setWindowStart(e.target.value)}
+                className="input-field text-sm py-1.5 w-auto"
+                aria-label="Ir a fecha"
+              />
+              <div className="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+                {ZOOM_OPTIONS.map((z) => (
+                  <button
+                    key={z.value}
+                    onClick={() => setZoom(z.value)}
+                    className={`px-3 py-2 text-sm font-medium transition-colors ${
+                      zoom === z.value
+                        ? 'bg-indigo-600 text-white'
+                        : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400'
+                    }`}
+                  >
+                    {z.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-1 flex-wrap items-center gap-2">
+              <Filter className="w-4 h-4 text-gray-400 shrink-0" />
+              {orgBuildings.length > 1 && (
+                <select
+                  value={buildingFilter}
+                  onChange={(e) => setBuildingFilter(e.target.value)}
+                  className="input-field text-sm py-1.5 w-auto"
+                >
+                  <option value={ALL}>Todos los edificios</option>
+                  {orgBuildings.map((b) => (
+                    <option key={b.id} value={b.id}>
+                      {b.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+              <select
+                value={unitTypeFilter}
+                onChange={(e) => setUnitTypeFilter(e.target.value as 'all' | UnitType)}
+                className="input-field text-sm py-1.5 w-auto"
+              >
+                <option value="all">Toda unidad</option>
+                {(Object.keys(UNIT_TYPE_LABELS) as UnitType[]).map((t) => (
+                  <option key={t} value={t}>
+                    {UNIT_TYPE_LABELS[t]}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={stayTypeFilter}
+                onChange={(e) => setStayTypeFilter(e.target.value as 'all' | StayType)}
+                className="input-field text-sm py-1.5 w-auto"
+              >
+                <option value="all">Toda estancia</option>
+                <option value="STR">STR (corta)</option>
+                <option value="MTR">MTR (media)</option>
+                <option value="LTR">LTR (larga)</option>
+              </select>
+              <label className="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={showHolds}
+                  onChange={(e) => setShowHolds(e.target.checked)}
+                  className="rounded"
+                />
+                Holds
+              </label>
+              <div className="relative flex-1 min-w-[180px]">
+                <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Buscar unidad o persona…"
+                  className="input-field w-full pl-9 text-sm py-1.5"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Timeline */}
+          <div className="card p-0 overflow-hidden">
+            <div className="overflow-x-auto">
+              <div style={{ width: LABEL_W + gridW, minWidth: '100%' }}>
+                {/* Header: meses */}
+                <div className="flex border-b border-gray-200 dark:border-gray-800">
+                  <div
+                    className="sticky left-0 z-20 shrink-0 px-3 py-1.5 text-[11px] uppercase tracking-wide muted-text"
+                    style={{ width: LABEL_W, backgroundColor: 'var(--baw-surface)' }}
+                  >
+                    Unidad
+                  </div>
+                  <div className="relative" style={{ width: gridW, height: 26 }}>
+                    {monthSpans.map((m) => (
+                      <div
+                        key={m.startIdx}
+                        className="absolute top-0 h-full flex items-center px-2 text-xs font-medium capitalize border-l border-gray-200 dark:border-gray-800"
+                        style={{
+                          left: m.startIdx * colPx,
+                          width: m.span * colPx,
+                          color: 'var(--baw-text)',
+                        }}
+                      >
+                        <span className="truncate">{m.label}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Header: días */}
+                <div className="flex border-b border-gray-200 dark:border-gray-800">
+                  <div
+                    className="sticky left-0 z-20 shrink-0"
+                    style={{ width: LABEL_W, backgroundColor: 'var(--baw-surface)' }}
+                  />
+                  <div className="flex" style={{ width: gridW, height: 24 }}>
+                    {dayList.map((iso, i) => {
+                      const isToday = iso === today
+                      const showNum =
+                        showDayNumbers || iso.endsWith('-01') || new Date(iso + 'T00:00:00Z').getUTCDay() === 1
+                      return (
+                        <div
+                          key={iso}
+                          className={`shrink-0 flex items-center justify-center text-[10px] tabular-nums ${
+                            isWeekendISO(iso) ? 'bg-black/[0.03] dark:bg-white/[0.04]' : ''
+                          } ${i > 0 ? 'border-l border-black/[0.05] dark:border-white/[0.05]' : ''}`}
+                          style={{ width: colPx }}
+                          title={iso}
+                        >
+                          {isToday ? (
+                            <span className="px-1 rounded bg-indigo-600 text-white font-semibold">
+                              {Number(iso.slice(8, 10))}
+                            </span>
+                          ) : showNum ? (
+                            <span className="muted-text">{Number(iso.slice(8, 10))}</span>
+                          ) : null}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+
+                {/* Franja de temporadas */}
+                {seasonSegments.length > 0 && (
+                  <div className="flex border-b border-gray-200 dark:border-gray-800">
+                    <div
+                      className="sticky left-0 z-20 shrink-0 px-3 flex items-center text-[11px] muted-text"
+                      style={{ width: LABEL_W, backgroundColor: 'var(--baw-surface)' }}
+                    >
+                      Temporadas
+                    </div>
+                    <div className="relative" style={{ width: gridW, height: 24 }}>
+                      {seasonSegments.map(({ season, startIdx, span }) => (
+                        <div
+                          key={season.id}
+                          className={`absolute top-1 h-[16px] rounded px-1.5 text-[10px] leading-[14px] truncate ${SEASON_CHIP}`}
+                          style={{ left: startIdx * colPx, width: span * colPx }}
+                          title={`${season.name} · ×${season.price_multiplier} · ${season.start_date} → ${season.end_date}`}
+                        >
+                          {span * colPx > 56 ? `${season.name} ×${season.price_multiplier}` : ''}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Grupos por edificio */}
+                {groups.map((g) => (
+                  <div key={g.id}>
+                    <button
+                      onClick={() => toggleGroup(g.id)}
+                      className="flex items-center w-full border-b border-gray-200 dark:border-gray-800 bg-black/[0.02] dark:bg-white/[0.02] hover:bg-black/[0.04] dark:hover:bg-white/[0.04] transition-colors"
+                    >
+                      <div
+                        className="sticky left-0 z-20 shrink-0 px-3 py-1.5 flex items-center gap-1.5 text-xs font-semibold"
+                        style={{ width: LABEL_W, color: 'var(--baw-text)' }}
+                      >
+                        <ChevronDown
+                          className={`w-3.5 h-3.5 transition-transform ${
+                            collapsed.has(g.id) ? '-rotate-90' : ''
+                          }`}
+                        />
+                        {g.name}
+                        <span className="muted-text font-normal">({g.units.length})</span>
+                      </div>
+                    </button>
+
+                    {!collapsed.has(g.id) &&
+                      g.units.map((u) => {
+                        const { bars, laneCount } = layoutLanes(
+                          staysByUnit.get(u.id) ?? [],
+                          windowStart,
+                          days,
+                        )
+                        const rowH = Math.max(34, 10 + laneCount * LANE_H)
+                        return (
+                          <div
+                            key={u.id}
+                            className="flex border-b border-gray-100 dark:border-gray-800/70"
+                          >
+                            {/* Celda de unidad (sticky) */}
+                            <div
+                              className="sticky left-0 z-20 shrink-0 px-3 flex items-center gap-2 border-r border-gray-200 dark:border-gray-800"
+                              style={{
+                                width: LABEL_W,
+                                height: rowH,
+                                backgroundColor: 'var(--baw-surface)',
+                              }}
+                            >
+                              <Link
+                                href={`/calendario/${u.id}`}
+                                className="font-medium text-sm hover:text-indigo-500 transition-colors truncate"
+                                style={{ color: 'var(--baw-text)' }}
+                                title={`Abrir calendario mensual de ${u.number}`}
+                              >
+                                {u.number}
+                              </Link>
+                              <span
+                                className={`inline-flex px-1.5 py-0 rounded-full text-[10px] font-medium ${
+                                  u.type === 'STR' || u.type === 'MTR' || u.type === 'LTR'
+                                    ? TYPE_BADGE[u.type]
+                                    : 'bg-gray-500/10 text-gray-500 border border-gray-500/20'
+                                }`}
+                              >
+                                {u.type}
+                              </span>
+                            </div>
+
+                            {/* Grid de días + barras */}
+                            <div className="relative" style={{ width: gridW, height: rowH }}>
+                              {/* fondo: separadores de día, fin de semana, hoy */}
+                              <div className="absolute inset-0 flex">
+                                {dayList.map((iso, i) => (
+                                  <div
+                                    key={iso}
+                                    className={`shrink-0 h-full ${
+                                      iso === today
+                                        ? 'bg-indigo-500/[0.07]'
+                                        : isWeekendISO(iso)
+                                        ? 'bg-black/[0.03] dark:bg-white/[0.04]'
+                                        : ''
+                                    } ${
+                                      i > 0
+                                        ? iso.endsWith('-01')
+                                          ? 'border-l border-gray-300 dark:border-gray-700'
+                                          : 'border-l border-black/[0.05] dark:border-white/[0.05]'
+                                        : ''
+                                    }`}
+                                    style={{ width: colPx }}
+                                  />
+                                ))}
+                              </div>
+                              {/* línea de hoy */}
+                              {todayVisible && (
+                                <div
+                                  className="absolute top-0 bottom-0 w-[2px] bg-indigo-500/70 z-10 pointer-events-none"
+                                  style={{ left: todayIdx * colPx }}
+                                />
+                              )}
+                              {/* barras */}
+                              {bars.map((b) => {
+                                const showText = b.span * colPx >= 44
+                                return (
+                                  <button
+                                    key={b.stay.key}
+                                    onClick={() => setSelected(b.stay)}
+                                    className={`absolute border text-left px-1.5 text-[11px] font-medium truncate transition-opacity hover:opacity-90 ${barClassFor(
+                                      b.stay.kind,
+                                      b.stay.type,
+                                      b.stay.tentative,
+                                    )} ${b.clippedStart ? 'rounded-l-none' : 'rounded-l-md'} ${
+                                      b.clippedEnd ? 'rounded-r-none' : 'rounded-r-md'
+                                    }`}
+                                    style={{
+                                      left: b.startIdx * colPx + 1,
+                                      width: Math.max(colPx - 2, b.span * colPx - 2),
+                                      top: 5 + b.lane * LANE_H,
+                                      height: LANE_H - 4,
+                                      lineHeight: `${LANE_H - 6}px`,
+                                      ...(b.stay.kind === 'hold' ? HOLD_STRIPES : {}),
+                                    }}
+                                    title={`${b.stay.person} · ${b.stay.start} → ${
+                                      b.stay.moveOutDay ?? 'sin fin'
+                                    }`}
+                                  >
+                                    {showText
+                                      ? `${b.clippedStart ? '← ' : ''}${b.stay.person}${
+                                          b.clippedEnd ? ' →' : ''
+                                        }`
+                                      : ''}
+                                  </button>
+                                )
+                              })}
+                            </div>
+                          </div>
+                        )
+                      })}
+                  </div>
+                ))}
+
+                {filteredUnits.length === 0 && (
+                  <div className="py-10 text-center text-sm muted-text">
+                    Sin unidades con los filtros actuales.
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Leyenda */}
+          <div className="flex flex-wrap items-center gap-3 text-xs muted-text">
+            <span className="flex items-center gap-1.5">
+              <span className={`w-3 h-3 rounded ${BAR_CLASS.STR}`} /> STR (reservación)
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className={`w-3 h-3 rounded ${BAR_CLASS.MTR}`} /> MTR (contrato)
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className={`w-3 h-3 rounded ${BAR_CLASS.LTR}`} /> LTR (contrato)
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className={`w-3 h-3 rounded border ${BAR_CLASS.hold}`} style={HOLD_STRIPES} /> Hold
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className={`w-3 h-3 rounded ${SEASON_CHIP}`} /> Temporada de precio
+            </span>
+            <span className="flex items-center gap-1.5 opacity-60">
+              <span className="w-3 h-3 rounded border border-dashed border-gray-400 bg-gray-400/30" />{' '}
+              Tentativa / pendiente
+            </span>
+          </div>
+        </>
+      )}
+
+      <StayDrawer stay={selected} unitLabel={unitLabelFor(selected)} onClose={() => setSelected(null)} />
+    </div>
+  )
+}

--- a/src/components/calendar/StayDrawer.tsx
+++ b/src/components/calendar/StayDrawer.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+// BaW OS — Drawer de detalle de estancia para el calendario de unidades.
+// Panel lateral read-only: quién, cuándo, cuánto, estatus, y link al
+// instrumento (contrato o reservación). Compartido por las vistas A y B.
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { X, FileText, BedDouble, Clock, ExternalLink, Users } from 'lucide-react'
+import type { CalendarStay } from '@/lib/calendar-occupancy'
+import { diffDaysISO } from '@/lib/calendar-occupancy'
+import { formatCurrency, formatDate } from '@/lib/utils'
+import { TYPE_BADGE, statusChipFor, PAYMENT_STATUS_LABEL, CHANNEL_LABEL } from './calendar-ui'
+
+export default function StayDrawer({
+  stay,
+  unitLabel,
+  onClose,
+}: {
+  stay: CalendarStay | null
+  unitLabel?: string
+  onClose: () => void
+}) {
+  useEffect(() => {
+    if (!stay) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [stay, onClose])
+
+  if (!stay) return null
+
+  const chip = statusChipFor(stay)
+  const nights =
+    stay.endExclusive !== null ? diffDaysISO(stay.start, stay.endExclusive) : null
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end" role="dialog" aria-modal="true">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <aside
+        className="relative h-full w-full max-w-md overflow-y-auto p-6 space-y-5 shadow-2xl"
+        style={{
+          backgroundColor: 'var(--baw-surface)',
+          borderLeft: '1px solid var(--baw-border)',
+        }}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm muted-text">
+            {stay.kind === 'contrato' ? (
+              <>
+                <FileText className="w-4 h-4" /> Contrato
+              </>
+            ) : stay.kind === 'reservacion' ? (
+              <>
+                <BedDouble className="w-4 h-4" /> Reservación
+              </>
+            ) : (
+              <>
+                <Clock className="w-4 h-4" /> Hold del booking público
+              </>
+            )}
+            {stay.type && (
+              <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_BADGE[stay.type]}`}>
+                {stay.type}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+            aria-label="Cerrar"
+          >
+            <X className="w-4 h-4 muted-text" />
+          </button>
+        </div>
+
+        <div>
+          <h2 className="text-lg font-semibold" style={{ color: 'var(--baw-text)' }}>
+            {stay.person}
+          </h2>
+          {unitLabel && <p className="text-sm muted-text mt-0.5">{unitLabel}</p>}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <p className="text-xs uppercase tracking-wide muted-text mb-0.5">
+              {stay.kind === 'contrato' ? 'Inicio' : 'Check-in'}
+            </p>
+            <p style={{ color: 'var(--baw-text)' }}>{formatDate(stay.start)}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide muted-text mb-0.5">
+              {stay.kind === 'contrato' ? 'Fin' : 'Check-out'}
+            </p>
+            <p style={{ color: 'var(--baw-text)' }}>
+              {stay.moveOutDay ? formatDate(stay.moveOutDay) : 'Sin fecha de fin'}
+            </p>
+          </div>
+          {nights !== null && stay.kind !== 'contrato' && (
+            <div>
+              <p className="text-xs uppercase tracking-wide muted-text mb-0.5">Noches</p>
+              <p style={{ color: 'var(--baw-text)' }}>{nights}</p>
+            </div>
+          )}
+          {typeof stay.guests === 'number' && stay.guests > 0 && (
+            <div>
+              <p className="text-xs uppercase tracking-wide muted-text mb-0.5">Huéspedes</p>
+              <p className="flex items-center gap-1" style={{ color: 'var(--baw-text)' }}>
+                <Users className="w-3.5 h-3.5" /> {stay.guests}
+              </p>
+            </div>
+          )}
+          {stay.amount > 0 && (
+            <div>
+              <p className="text-xs uppercase tracking-wide muted-text mb-0.5">Monto</p>
+              <p className="font-medium" style={{ color: 'var(--baw-text)' }}>
+                {formatCurrency(stay.amount)}
+                <span className="text-xs muted-text">{stay.amountSuffix}</span>
+              </p>
+            </div>
+          )}
+          {stay.channel && (
+            <div>
+              <p className="text-xs uppercase tracking-wide muted-text mb-0.5">Canal</p>
+              <p style={{ color: 'var(--baw-text)' }}>
+                {CHANNEL_LABEL[stay.channel] ?? stay.channel}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${chip.cls}`}>
+            {chip.label}
+          </span>
+          {stay.paymentStatus && (
+            <span className="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-800/60 dark:text-gray-300">
+              {PAYMENT_STATUS_LABEL[stay.paymentStatus] ?? stay.paymentStatus}
+            </span>
+          )}
+        </div>
+
+        {stay.notes && (
+          <div>
+            <p className="text-xs uppercase tracking-wide muted-text mb-1">Notas</p>
+            <p className="text-sm whitespace-pre-wrap" style={{ color: 'var(--baw-text)' }}>
+              {stay.notes}
+            </p>
+          </div>
+        )}
+
+        {stay.href && (
+          <Link
+            href={stay.href}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 hover:bg-indigo-700 text-white transition-colors"
+          >
+            <ExternalLink className="w-4 h-4" />
+            {stay.kind === 'contrato' ? 'Ver contrato' : 'Ver en Reservaciones'}
+          </Link>
+        )}
+      </aside>
+    </div>
+  )
+}

--- a/src/components/calendar/calendar-ui.ts
+++ b/src/components/calendar/calendar-ui.ts
@@ -1,0 +1,77 @@
+// BaW OS — Calendario de unidades: constantes visuales compartidas.
+//
+// Vive en src/components (no src/lib) porque tailwind.config.ts solo escanea
+// src/app, src/components y src/pages — clases declaradas en src/lib no
+// entrarían al build JIT.
+//
+// Paleta por tipo de estancia = la misma que /estancias (TYPE_BADGE):
+// STR morado · MTR ámbar · LTR azul. Holds en gris. Temporadas en esmeralda.
+
+import type { CSSProperties } from 'react'
+import type { StayKind, StayType } from '@/lib/calendar-occupancy'
+
+export const TYPE_BADGE: Record<StayType, string> = {
+  STR: 'bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20',
+  MTR: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20',
+  LTR: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20',
+}
+
+/** Barra sólida del timeline / banda del mes. key = type, o 'hold'. */
+export const BAR_CLASS: Record<StayType | 'hold', string> = {
+  STR: 'bg-purple-500/85 border-purple-400 text-white',
+  MTR: 'bg-amber-500/85 border-amber-400 text-amber-950',
+  LTR: 'bg-blue-500/85 border-blue-400 text-white',
+  hold: 'bg-gray-400/25 border-gray-400/60 text-gray-600 dark:text-gray-300',
+}
+
+/** Rayado diagonal para holds (encima de BAR_CLASS.hold). */
+export const HOLD_STRIPES: CSSProperties = {
+  backgroundImage:
+    'repeating-linear-gradient(45deg, transparent, transparent 4px, var(--baw-border) 4px, var(--baw-border) 6px)',
+}
+
+export function barClassFor(kind: StayKind, type: StayType | null, tentative: boolean): string {
+  const base = kind === 'hold' ? BAR_CLASS.hold : BAR_CLASS[type ?? 'LTR']
+  return tentative && kind !== 'hold' ? `${base} opacity-60 border-dashed` : base
+}
+
+/** Chips de estatus (mismas combinaciones que /estancias). */
+export const CONTRACT_STATUS: Record<string, { label: string; cls: string }> = {
+  active: { label: 'Activo', cls: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400' },
+  expired: { label: 'Vencido', cls: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' },
+  terminated: { label: 'Terminado', cls: 'bg-gray-100 text-gray-800 dark:bg-gray-800/50 dark:text-gray-400' },
+  pending: { label: 'Pendiente', cls: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400' },
+  renewed: { label: 'Renovado', cls: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400' },
+  en_renovacion: { label: 'En renovación', cls: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400' },
+}
+
+export const RES_STATUS: Record<string, { label: string; cls: string }> = {
+  tentative: { label: 'Tentativa', cls: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400' },
+  confirmed: { label: 'Confirmada', cls: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400' },
+  cancelled: { label: 'Cancelada', cls: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' },
+  checked_in: { label: 'Check-in', cls: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400' },
+  checked_out: { label: 'Check-out', cls: 'bg-gray-100 text-gray-800 dark:bg-gray-800/50 dark:text-gray-400' },
+  hold: { label: 'Hold (15 min)', cls: 'bg-gray-100 text-gray-800 dark:bg-gray-800/50 dark:text-gray-400' },
+}
+
+export function statusChipFor(stay: { kind: StayKind; status: string }): { label: string; cls: string } {
+  const map = stay.kind === 'contrato' ? CONTRACT_STATUS : RES_STATUS
+  return map[stay.status] ?? { label: stay.status, cls: RES_STATUS.checked_out.cls }
+}
+
+export const PAYMENT_STATUS_LABEL: Record<string, string> = {
+  pending: 'Pago pendiente',
+  partial: 'Pago parcial',
+  paid: 'Pagado',
+}
+
+export const CHANNEL_LABEL: Record<string, string> = {
+  airbnb: 'Airbnb',
+  booking: 'Booking.com',
+  direct: 'Directa',
+  expedia: 'Expedia',
+}
+
+/** Franja de temporadas (esmeralda = concepto de pricing, no choca con tipos). */
+export const SEASON_CHIP =
+  'bg-emerald-500/15 border border-emerald-500/30 text-emerald-700 dark:text-emerald-400'

--- a/src/lib/calendar-occupancy.ts
+++ b/src/lib/calendar-occupancy.ts
@@ -1,0 +1,395 @@
+// BaW OS — Calendario de unidades: lógica de ocupación compartida.
+//
+// Fusiona los tres instrumentos de ocupación (contratos LTR/MTR, reservaciones
+// STR y holds del booking público) en un modelo único `CalendarStay` que las
+// dos vistas del calendario (/calendario timeline y /calendario/[unitId]
+// mensual) renderizan. Solo lógica pura: nada de Tailwind aquí (tailwind no
+// escanea src/lib — las clases visuales viven en src/components/calendar/).
+//
+// Convención de fechas: strings ISO `yyyy-mm-dd` comparables lexicográficamente.
+// Los rangos son SEMIABIERTOS [start, endExclusive) — misma semántica que los
+// EXCLUDE constraints de la DB (daterange '[)') y que blocked_days del API
+// público: el día de check_out queda libre. Los contratos usan end_date
+// INCLUSIVO en DB, por eso su endExclusive = end_date + 1 día.
+
+export type StayType = 'STR' | 'MTR' | 'LTR'
+export type StayKind = 'contrato' | 'reservacion' | 'hold'
+
+export interface CalendarStay {
+  key: string
+  kind: StayKind
+  /** null solo para holds (no tienen modalidad) */
+  type: StayType | null
+  person: string
+  unitId: string
+  /** Primer día ocupado (inclusive) */
+  start: string
+  /** Primer día libre (exclusivo). null = contrato sin fecha de fin. */
+  endExclusive: string | null
+  /** Día en que la persona sale: check_out (reserva) o end_date (contrato). */
+  moveOutDay: string | null
+  status: string
+  /** true = no bloquea disponibilidad con certeza (reserva tentativa / contrato pendiente) */
+  tentative: boolean
+  amount: number
+  amountSuffix: string
+  href: string | null
+  channel?: string | null
+  guests?: number | null
+  paymentStatus?: string | null
+  notes?: string | null
+}
+
+export interface Season {
+  id: string
+  name: string
+  /** inclusive */
+  start_date: string
+  /** inclusive (misma semántica que /quotes: date >= start && date <= end) */
+  end_date: string
+  price_multiplier: number
+  notes?: string | null
+}
+
+/* ------------------------------ Fechas ISO ------------------------------ */
+
+function toUTC(iso: string): number {
+  const [y, m, d] = iso.split('-').map(Number)
+  return Date.UTC(y, m - 1, d)
+}
+
+export function todayISO(): string {
+  const now = new Date()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  return `${now.getFullYear()}-${m}-${d}`
+}
+
+export function addDaysISO(iso: string, days: number): string {
+  return new Date(toUTC(iso) + days * 86_400_000).toISOString().slice(0, 10)
+}
+
+/** Días de a → b (positivo si b es después de a) */
+export function diffDaysISO(a: string, b: string): number {
+  return Math.round((toUTC(b) - toUTC(a)) / 86_400_000)
+}
+
+export function isWeekendISO(iso: string): boolean {
+  const dow = new Date(toUTC(iso)).getUTCDay()
+  return dow === 0 || dow === 6
+}
+
+/* ----------------------- Mappers de filas Supabase ----------------------- */
+
+// Supabase devuelve joins to-one como objeto pero el tipo infiere array.
+function one<T>(rel: T | T[] | null | undefined): T | null {
+  if (Array.isArray(rel)) return rel[0] ?? null
+  return rel ?? null
+}
+
+/** Estatus de contrato que pintan ocupación. `terminated` queda fuera (terminó
+ *  antes de su end_date y no guardamos cuándo); `expired` sí — su rango ya es
+ *  pasado y es historia real de ocupación. */
+export const CONTRACT_VISIBLE_STATUSES = ['active', 'pending', 'renewed', 'en_renovacion', 'expired']
+
+/** `cancelled` no bloquea fechas, no se pinta. */
+export const RESERVATION_VISIBLE_STATUSES = ['tentative', 'confirmed', 'checked_in', 'checked_out']
+
+export interface ContractRow {
+  id: string
+  unit_id: string | null
+  rent_type: string | null
+  status: string
+  monthly_amount: number | null
+  start_date: string
+  end_date: string | null
+  notes?: string | null
+  occupant?: { name: string } | { name: string }[] | null
+}
+
+export interface ReservationRow {
+  id: string
+  unit_id: string
+  guest_name: string | null
+  check_in: string
+  check_out: string
+  status: string
+  payment_status: string | null
+  total_price: number | null
+  guests_count: number | null
+  channel: string | null
+  notes?: string | null
+}
+
+export interface HoldRow {
+  id: string
+  unit_id: string
+  from_date: string
+  to_date: string
+  guests_count: number | null
+  guest_email: string | null
+  expires_at: string
+}
+
+export function contractToStay(c: ContractRow): CalendarStay | null {
+  if (!c.unit_id || !c.start_date) return null
+  if (!CONTRACT_VISIBLE_STATUSES.includes(c.status)) return null
+  const type: StayType =
+    c.rent_type === 'STR' || c.rent_type === 'MTR' || c.rent_type === 'LTR' ? c.rent_type : 'LTR'
+  return {
+    key: `c-${c.id}`,
+    kind: 'contrato',
+    type,
+    person: one<{ name: string }>(c.occupant)?.name ?? 'Sin inquilino',
+    unitId: c.unit_id,
+    start: c.start_date,
+    endExclusive: c.end_date ? addDaysISO(c.end_date, 1) : null,
+    moveOutDay: c.end_date ?? null,
+    status: c.status,
+    tentative: c.status === 'pending',
+    amount: c.monthly_amount ?? 0,
+    amountSuffix: '/mes',
+    href: `/contracts/${c.id}`,
+    notes: c.notes ?? null,
+  }
+}
+
+export function reservationToStay(r: ReservationRow): CalendarStay | null {
+  if (!r.check_in || !r.check_out) return null
+  if (!RESERVATION_VISIBLE_STATUSES.includes(r.status)) return null
+  return {
+    key: `r-${r.id}`,
+    kind: 'reservacion',
+    type: 'STR',
+    person: r.guest_name ?? 'Sin huésped',
+    unitId: r.unit_id,
+    start: r.check_in,
+    endExclusive: r.check_out,
+    moveOutDay: r.check_out,
+    status: r.status,
+    tentative: r.status === 'tentative',
+    amount: r.total_price ?? 0,
+    amountSuffix: '',
+    href: '/reservations',
+    channel: r.channel,
+    guests: r.guests_count,
+    paymentStatus: r.payment_status,
+    notes: r.notes ?? null,
+  }
+}
+
+export function holdToStay(h: HoldRow): CalendarStay {
+  return {
+    key: `h-${h.id}`,
+    kind: 'hold',
+    type: null,
+    person: h.guest_email ? `Hold · ${h.guest_email}` : 'Hold booking público',
+    unitId: h.unit_id,
+    start: h.from_date,
+    endExclusive: h.to_date,
+    moveOutDay: h.to_date,
+    status: 'hold',
+    tentative: true,
+    amount: 0,
+    amountSuffix: '',
+    href: null,
+    guests: h.guests_count,
+    notes: `Bloqueo temporal del sitio público, expira ${new Date(h.expires_at).toLocaleString('es-MX')}`,
+  }
+}
+
+/* ------------------------------ Temporadas ------------------------------ */
+
+export function seasonForDate(seasons: Season[], iso: string): Season | null {
+  return seasons.find((s) => iso >= s.start_date && iso <= s.end_date) ?? null
+}
+
+/** Precio por noche = tarifa base de la unidad × multiplicador de temporada.
+ *  null si la unidad no tiene tarifa base configurada. */
+export function nightlyPrice(
+  baseRate: number | null | undefined,
+  seasons: Season[],
+  iso: string,
+): number | null {
+  if (baseRate == null) return null
+  const s = seasonForDate(seasons, iso)
+  return Math.round(baseRate * (s ? Number(s.price_multiplier) : 1))
+}
+
+/* --------------------- Layout del timeline (Vista A) --------------------- */
+
+export interface BarSegment {
+  stay: CalendarStay
+  /** índice de día dentro de la ventana (0-based) */
+  startIdx: number
+  /** días visibles */
+  span: number
+  clippedStart: boolean
+  clippedEnd: boolean
+  lane: number
+}
+
+/** Recorta las estancias a la ventana [windowStart, windowStart+days) y les
+ *  asigna carriles para que barras solapadas (tentativas, holds) no se pisen. */
+export function layoutLanes(
+  stays: CalendarStay[],
+  windowStart: string,
+  days: number,
+): { bars: BarSegment[]; laneCount: number } {
+  const windowEnd = addDaysISO(windowStart, days)
+  const segments = stays
+    .map((stay) => {
+      const end = stay.endExclusive ?? windowEnd // sin fin: llena hasta el borde
+      if (end <= windowStart || stay.start >= windowEnd) return null
+      const s = stay.start < windowStart ? windowStart : stay.start
+      const e = end > windowEnd ? windowEnd : end
+      return {
+        stay,
+        startIdx: diffDaysISO(windowStart, s),
+        span: Math.max(1, diffDaysISO(s, e)),
+        clippedStart: stay.start < windowStart,
+        clippedEnd: end > windowEnd || stay.endExclusive === null,
+        lane: 0,
+      }
+    })
+    .filter((x): x is BarSegment => x !== null)
+    .sort((a, b) => a.startIdx - b.startIdx || b.span - a.span)
+
+  const laneEnds: number[] = []
+  for (const seg of segments) {
+    let lane = laneEnds.findIndex((endIdx) => endIdx <= seg.startIdx)
+    if (lane === -1) {
+      lane = laneEnds.length
+      laneEnds.push(0)
+    }
+    seg.lane = lane
+    laneEnds[lane] = seg.startIdx + seg.span
+  }
+  return { bars: segments, laneCount: Math.max(1, laneEnds.length) }
+}
+
+/* -------------------------------- KPIs ---------------------------------- */
+
+export interface CalendarKpis {
+  occupancyPct: number
+  vacantNights: number
+  movesInToday: number
+  movesOutToday: number
+  /** contratos activos/en renovación que vencen en ≤60 días */
+  expiringSoon: number
+}
+
+function mergeIntervals(intervals: Array<[number, number]>): Array<[number, number]> {
+  if (intervals.length === 0) return []
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0])
+  const out: Array<[number, number]> = [sorted[0]]
+  for (let i = 1; i < sorted.length; i++) {
+    const last = out[out.length - 1]
+    const cur = sorted[i]
+    if (cur[0] <= last[1]) last[1] = Math.max(last[1], cur[1])
+    else out.push([...cur] as [number, number])
+  }
+  return out
+}
+
+/** Ocupación sobre la ventana visible. Tentativas y holds NO cuentan como
+ *  noches ocupadas (no son certeza); sí cuentan checked_out/expired (historia). */
+export function computeKpis(
+  unitIds: string[],
+  stays: CalendarStay[],
+  windowStart: string,
+  days: number,
+  today: string,
+): CalendarKpis {
+  const windowEnd = addDaysISO(windowStart, days)
+  const unitSet = new Set(unitIds)
+  const byUnit = new Map<string, Array<[number, number]>>()
+
+  for (const s of stays) {
+    if (s.kind === 'hold' || s.tentative) continue
+    if (!unitSet.has(s.unitId)) continue
+    const end = s.endExclusive ?? windowEnd
+    if (end <= windowStart || s.start >= windowEnd) continue
+    const a = diffDaysISO(windowStart, s.start < windowStart ? windowStart : s.start)
+    const b = diffDaysISO(windowStart, end > windowEnd ? windowEnd : end)
+    if (!byUnit.has(s.unitId)) byUnit.set(s.unitId, [])
+    byUnit.get(s.unitId)!.push([a, b])
+  }
+
+  let occupied = 0
+  for (const uid of unitIds) {
+    for (const [a, b] of mergeIntervals(byUnit.get(uid) ?? [])) occupied += b - a
+  }
+  const total = unitIds.length * days
+  const inScope = stays.filter((s) => s.kind !== 'hold' && unitSet.has(s.unitId))
+  const horizon = addDaysISO(today, 60)
+
+  return {
+    occupancyPct: total > 0 ? Math.round((occupied / total) * 100) : 0,
+    vacantNights: Math.max(0, total - occupied),
+    movesInToday: inScope.filter((s) => s.start === today).length,
+    movesOutToday: inScope.filter((s) => s.moveOutDay === today).length,
+    expiringSoon: inScope.filter(
+      (s) =>
+        s.kind === 'contrato' &&
+        (s.status === 'active' || s.status === 'en_renovacion') &&
+        s.moveOutDay !== null &&
+        s.moveOutDay >= today &&
+        s.moveOutDay <= horizon,
+    ).length,
+  }
+}
+
+/* --------------------- Matriz mensual (Vista B) -------------------------- */
+
+export interface MonthCell {
+  iso: string
+  day: number
+  inMonth: boolean
+}
+
+/** Celdas de un mes en semanas completas, iniciando en lunes (es-MX). */
+export function monthMatrix(year: number, month1to12: number): MonthCell[] {
+  const first = `${year}-${String(month1to12).padStart(2, '0')}-01`
+  const daysInMonth = new Date(Date.UTC(year, month1to12, 0)).getUTCDate()
+  const firstDow = new Date(toUTC(first)).getUTCDay() // 0=domingo
+  const leading = (firstDow + 6) % 7 // lunes-first
+  const cells: MonthCell[] = []
+  for (let i = leading; i > 0; i--) {
+    const iso = addDaysISO(first, -i)
+    cells.push({ iso, day: Number(iso.slice(8, 10)), inMonth: false })
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push({ iso: addDaysISO(first, d - 1), day: d, inMonth: true })
+  }
+  while (cells.length % 7 !== 0) {
+    const iso = addDaysISO(cells[cells.length - 1].iso, 1)
+    cells.push({ iso, day: Number(iso.slice(8, 10)), inMonth: false })
+  }
+  return cells
+}
+
+export function monthLabel(year: number, month1to12: number): string {
+  return new Date(Date.UTC(year, month1to12 - 1, 1)).toLocaleDateString('es-MX', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+/** Meses [año, mes 1-12] desde `offsetBack` meses antes del actual hasta
+ *  `offsetForward` meses después (relativo al mes de `todayIso`). */
+export function monthRange(
+  todayIso: string,
+  offsetBack: number,
+  offsetForward: number,
+): Array<{ year: number; month: number }> {
+  const y = Number(todayIso.slice(0, 4))
+  const m = Number(todayIso.slice(5, 7))
+  const out: Array<{ year: number; month: number }> = []
+  for (let i = -offsetBack; i < offsetForward; i++) {
+    const total = y * 12 + (m - 1) + i
+    out.push({ year: Math.floor(total / 12), month: (total % 12) + 1 })
+  }
+  return out
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -90,9 +90,12 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
     href: '/units',
     icon: 'Building2',
     placement: 'top',
-    routes: ['/buildings', '/units', '/owners'],
+    routes: ['/buildings', '/units', '/owners', '/calendario'],
     subNav: [
       { href: '/units', label: 'Unidades' },
+      // Calendario de unidades (2026-07-03, acuerdo con Fran en chat):
+      // timeline multi-unidad + mensual por unidad con temporadas de precio.
+      { href: '/calendario', label: 'Calendario' },
       { href: '/buildings', label: 'Edificios' },
       { href: '/owners', label: 'Propietarios' },
     ],


### PR DESCRIPTION
## Summary

Nueva sección **Portafolio → Calendario** (modelo Airbnb, acordado con Fran en chat 2026-07-03): visualización de ocupación de los 3 instrumentos — contratos (LTR/MTR), reservaciones (STR) y holds del booking público — más temporadas de precio, en dos vistas: `/calendario` (timeline multi-unidad) y `/calendario/[unitId]` (meses apilados con precio por noche).

**v2 (2do commit, feedback de Fran con screenshot de prod + kit UI System v1):** el timeline se reescribió a la spec «tl» del kit de diseño — grid **fluido** (las columnas reparten el 100% del ancho entre los días visibles: se acabó el espacio muerto a la derecha), tokens de instrumento `--baw-instr-*` (STR teal / MTR ámbar / LTR azul / hold gris / temporada verde), barras suaves con borde de instrumento, **half-day check-in/out** (salida y entrada conviven el mismo día), leyenda-filtro interactiva y "Nn libres" por unidad. Además ya es **interactivo**: en la Vista B se arrastra sobre días libres → panel con estimado del rango, **crear/editar/eliminar temporadas** (`str_seasons`, mismo motor que el cotizador), **editar tarifa base** de la unidad, y **crear reservación** con unidad+fechas prellenadas en `/reservations` (query params).

## Pre-flight checklist

- [x] `git fetch origin && git log origin/main --oneline -10` — revisé estado real de main
- [x] Verifiqué que mi trabajo no duplica un PR ya mergeado (no existe vista calendario; `/reservations` es grid mensual mono-unidad solo STR y solo se le agregó el prefill por query params)
- [x] `git log --oneline -5 -- <archivos modificados>` — revisé historia reciente de archivos que toqué
- [x] Esta rama está basada en `origin/main` actualizado (último commit visible: `7d33494`)
- [x] Scope discipline: este PR tiene **un solo objetivo** (sección calendario; la v2 responde al feedback de review sobre el mismo feature)
- [x] `npx tsc --noEmit` pasa
- [x] `npm run build` pasa

## Invariantes (sección 2 de AGENTS.md)

- [x] No toqué la tipografía Inter en `src/app/layout.tsx`
- [x] No creé sets paralelos de tokens — los nuevos tokens de instrumento se agregaron **al set `--baw-*` existente** en `globals.css` (`--baw-instr-str/mtr/ltr/hold/season/tent`), con los valores oklch del kit UI System v1 (sección timeline, `tokens/instruments.css`); el destino final es `design/baw-design/tokens/` cuando el submodule incorpore instruments.css
- [x] No agregué/quité/renombré secciones de `SIDEBAR_SECTIONS` en `src/lib/navigation.ts`
- [x] No bypass-eé `isPlatformAdmin()` ni `resolveOrgId()`
- [x] No agregué referencias al enum legacy `member_role`
- [x] No introduje agentes fuera del catálogo 10+1
- [x] No eliminé features mergeadas funcionales

Se agregó un **sub-item** `Calendario` al subNav de `portfolio` (mecanismo sancionado por `navigation.ts` para páginas nuevas; acuerdo de Fran en chat 2026-07-03). Las 6 secciones top + 2 footer quedan intactas.

## Acuerdos canónicos afectados

- [x] Navegación canónica: sub-item `Calendario` en Portafolio (acuerdo en chat 2026-07-03)
- [x] Diseño / tokens: tokens `--baw-instr-*` nuevos en `globals.css` + CSS de componente `tl-*`/`cal-*` (adaptación 1:1 de la spec del kit UI System v1 que compartió Fran). Pendiente follow-up: mover a `design/baw-design/tokens/instruments.css` en el repo de diseño
- [ ] Schema DB / migración SQL: **ninguna** — los writes usan tablas existentes (`str_seasons`, `units.base_rate_mxn`) con el mismo patrón client-side que `/pricing`

## Verification

- [x] Build local verde (`tsc --noEmit` + `npm run build`)
- [x] Lógica pura de `src/lib/calendar-occupancy.ts` ejercitada con 41 casos (rangos semiabiertos, carriles, KPIs, matriz mensual, cruces de año)
- [x] **Verificación visual**: preview estático con los tokens reales del submodule + el CSS nuevo, capturado con Chromium en dark y light — timeline fluido a 1600px sin espacio muerto, barras/chips/temporadas/half-day correctos en ambos temas; vista mensual con turnover a medio día, tinte de temporada y selección
- [ ] Preview Vercel del PR con datos reales — revisar antes de aprobar (este entorno no tiene credenciales de Supabase)

Detalles para review:
- `reservations` filtra por `organization_id` (esquema histórico) vs `org_id` en el resto — comentado en código.
- `reservation_holds` no tiene `org_id`: se acota por los `unit_id` de la org.
- Semántica `[start, endExclusive)` idéntica a los EXCLUDE de DB; el half-day es solo visual.
- Tentativas y holds se pintan pero no cuentan en KPIs de ocupación.
- Los writes de temporadas/tarifa son client-side (mismo patrón que `/pricing`); si RLS los bloquea en prod, el panel muestra el error en vez de fallar silencioso.
- `/reservations` ahora lee `?unit_id=&check_in=&check_out=` de `window.location` (sin `useSearchParams` para no requerir Suspense boundary).

## Issues relacionados

Ninguno abierto. Nace del acuerdo en chat con Fran (2026-07-03) registrado en `docs/PROJECT_STATE.md` §0.ter.

## Follow-ups detectados (NO incluidos en este PR)

- [ ] Mover `--baw-instr-*` y el CSS `tl-*` al repo `baw-design` (`tokens/instruments.css` + deliverable timeline) y consumirlos desde el submodule.
- [ ] Migrar los colores por tipo de estancia de `/estancias` (morado/ámbar/azul Tailwind) a los tokens `--baw-instr-*` para consistencia.
- [ ] Fase 3: `unit_rate_overrides` (precio fijo por unidad+rango, requiere migración), drag & drop de estancias, bloqueos de mantenimiento con fechas.
- [ ] `str_seasons.org_id` tiene DEFAULT de una org legacy y RLS solo service_role — candidato para el audit de drift.
- [ ] `/quotes` cotiza con `unit_prices.str_price_per_person` (legacy) vs `units.base_rate_mxn` del sitio público — unificar fuente de precio STR.

## Merge

- [x] Confirmo que **NO** se mergeará automáticamente. Espero aprobación humana de @franduranv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6L5rZfdkJSULa2a3TrJWG