### PR TITLE
Consolidación de diseño: /estancias a tokens de instrumento (+ instruments.css listo para baw-design)

### DIFF
--- a/src/app/estancias/page.tsx
+++ b/src/app/estancias/page.tsx
@@ -8,13 +8,14 @@
 // ver "todo lo que está ocupado" sin importar el instrumento. Crear/editar sigue
 // viviendo en Contratos y Reservaciones.
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, type CSSProperties } from 'react'
 import Link from 'next/link'
 import { CalendarRange, Search, FileText, BedDouble, Filter } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { useOrgContext } from '@/hooks/useOrgContext'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
+import { INSTR_VAR } from '@/components/calendar/calendar-ui'
 import { formatCurrency, formatDate } from '@/lib/utils'
 
 type Instrument = 'contrato' | 'reservacion'
@@ -35,11 +36,9 @@ type Stay = {
   href: string
 }
 
-const TYPE_BADGE: Record<StayType, string> = {
-  STR: 'bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20',
-  MTR: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20',
-  LTR: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20',
-}
+// Tipos de estancia con los tokens de instrumento del kit UI System v1
+// (--baw-instr-*, los mismos del calendario): STR teal · MTR ámbar · LTR azul.
+// Antes: clases Tailwind sueltas con STR morado, que ya no coincidía.
 
 const CONTRACT_STATUS: Record<string, { label: string; cls: string }> = {
   active: { label: 'Activo', cls: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400' },
@@ -253,7 +252,7 @@ export default function EstanciasPage() {
                       </span>
                     </td>
                     <td className="py-2.5 pr-3">
-                      <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_BADGE[s.type]}`}>
+                      <span className="tl-chip" style={{ '--c': INSTR_VAR[s.type] } as CSSProperties}>
                         {s.type}
                       </span>
                     </td>


### PR DESCRIPTION
## Summary

Primera mitad de la consolidación del design system acordada con Fran (2026-07-03):

- **`/estancias`** migra sus chips de tipo de estancia de clases Tailwind sueltas (STR **morado**, que ya no coincidía con el calendario) a los **tokens de instrumento** `--baw-instr-*` del kit UI System v1 vía la clase `tl-chip` — STR teal · MTR ámbar · LTR azul, idéntico al calendario. Diff mínimo (1 archivo).

## Segunda mitad (bloqueada, requiere acceso al repo `baw-design`)

Mover los tokens a su casa definitiva. Intenté agregar `zxy-vc/baw-design` a la sesión pero la aprobación del conector no llegó (dos intentos). Cuando tengas el repo a la mano, esto es lo que va en `tokens/instruments.css` de `baw-design` (valores exactos del kit, hoy duplicados en `globals.css` de baw-os con el alias `--baw-instr-*`):

```css
/* ── Instrumentos de ocupación (calendario / estancias) ─────────────── */
:root {
  --instr-str-500:    oklch(60% 0.12 195);
  --instr-mtr-500:    oklch(66% 0.16 70);
  --instr-ltr-500:    oklch(58% 0.16 245);
  --instr-hold-500:   var(--gray-500);
  --instr-season-500: var(--green-500);
  --instr-tent-500:   var(--gray-400);
  --instr-block-500:  var(--red-500);
}
```

...más `@import "./instruments.css";` en `tokens/index.css`. Después, en baw-os, los `--baw-instr-*` de `globals.css` pasan a ser aliases (`--baw-instr-str: var(--instr-str-500)`) y se bumpea el submodule pointer — ese será un PR chico de seguimiento.

## Pre-flight checklist

- [x] Rama sobre `origin/main` (`7cc8e6f`) · [x] scope único · [x] `tsc` y `build` verdes

## Invariantes

- [x] Todas respetadas. No hay tokens nuevos (usa los `--baw-instr-*` que entraron en #140); reduce clases Tailwind sueltas a favor del sistema — abona al espíritu del issue #24.

## Acuerdos canónicos afectados

- [x] Diseño: unifica la paleta de tipos de estancia entre `/estancias` y `/calendario`.

## Verification

- [x] Build verde. Cambio visual esperado: el chip STR de Estancias pasa de morado a teal (los de MTR/LTR conservan tono, ahora vía token).

## Follow-ups (NO incluidos)

- [ ] `instruments.css` en el repo `baw-design` + alias en baw-os + bump del submodule (bloqueado por acceso al repo — snippet listo arriba).

## Merge

- [x] NO se mergeará automáticamente. Espero aprobación de @franduranv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6L5rZfdkJSULa2a3TrJWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6L5rZfdkJSULa2a3TrJWG)_