### PR TITLE
Cotizador STR por noche: temporadas y precios fijos de unidad aplicados día por día

### DIFF
--- a/src/app/quotes/page.tsx
+++ b/src/app/quotes/page.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState, useRef } from 'react'
 import { Calculator, Printer, FileText, CalendarPlus } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { useOrgContext } from '@/hooks/useOrgContext'
+import { addDaysISO, nightlyPrice, type RateOverride } from '@/lib/calendar-occupancy'
 import { formatCurrency } from '@/lib/utils'
 
 interface QuoteUnit {
@@ -68,6 +69,7 @@ export default function QuotesPage() {
   const { orgId, loading: orgLoading } = useOrgContext()
   const [units, setUnits] = useState<QuoteUnit[]>([])
   const [seasons, setSeasons] = useState<Season[]>([])
+  const [overrides, setOverrides] = useState<RateOverride[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedUnit, setSelectedUnit] = useState('')
   const [modality, setModality] = useState<Modality>('LTR')
@@ -115,6 +117,27 @@ export default function QuotesPage() {
     fetchData(orgId)
   }, [orgId, orgLoading])
 
+  // Precios fijos por unidad+rango (unit_rate_overrides, fase 3 del
+  // calendario): ganan sobre base × temporada, igual que en /calendario.
+  // Si la tabla no existe aún en prod, la query falla y cotizamos sin ellos.
+  useEffect(() => {
+    if (!selectedUnit) {
+      setOverrides([])
+      return
+    }
+    let cancelled = false
+    supabase
+      .from('unit_rate_overrides')
+      .select('id, unit_id, start_date, end_date, nightly_rate_mxn, notes')
+      .eq('unit_id', selectedUnit)
+      .then(({ data }) => {
+        if (!cancelled) setOverrides((data ?? []) as RateOverride[])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedUnit])
+
   function getActiveSeason(date: string): Season | null {
     if (!date) return null
     return seasons.find((s) => date >= s.start_date && date <= s.end_date) || null
@@ -161,15 +184,35 @@ export default function QuotesPage() {
 
       const activeSeason = getActiveSeason(checkInDate)
       const seasonMultiplier = activeSeason ? Number(activeSeason.price_multiplier) : 1
-      const pricePerNight = Math.round(unit.base_rate_mxn * seasonMultiplier)
+
+      // Con fechas concretas: suma NOCHE POR NOCHE — cada día aplica su propia
+      // temporada y sus precios fijos de unidad (misma resolución que el
+      // calendario y el panel de rango). Sin fechas: base × temporada del
+      // check-in × noches (estimación rápida).
+      let basePrice: number
+      let perDay = false
+      if (checkInDate && checkOutDate && checkOutDate > checkInDate) {
+        basePrice = 0
+        for (let iso = checkInDate; iso < checkOutDate; iso = addDaysISO(iso, 1)) {
+          basePrice += nightlyPrice(unit.base_rate_mxn, seasons, iso, overrides) ?? 0
+        }
+        perDay = true
+      } else {
+        basePrice = Math.round(unit.base_rate_mxn * seasonMultiplier) * nights
+      }
+      const pricePerNight = Math.round(basePrice / Math.max(1, nights))
+
       const extraPersons = Math.max(0, persons - includedGuests)
-      const basePrice = pricePerNight * nights
       const extraPersonsFee = extraPersons * EXTRA_PERSON_FEE * nights
       const subtotal = basePrice + extraPersonsFee
       const discountAmount = subtotal * (discount / 100)
       const cleaningFee = unit.cleaning_fee_mxn ?? 0
       const iva = (subtotal - discountAmount + cleaningFee) * 0.16
       const total = subtotal - discountAmount + cleaningFee + iva
+
+      const hasOverrideInRange =
+        perDay &&
+        overrides.some((o) => !(o.end_date < checkInDate || o.start_date >= checkOutDate))
 
       return {
         basePrice,
@@ -184,12 +227,13 @@ export default function QuotesPage() {
           ...(activeSeason
             ? [`✨ Temporada: ${activeSeason.name} (×${activeSeason.price_multiplier})`]
             : []),
-          `Tarifa: ${formatCurrency(pricePerNight)}/noche (unidad completa, hasta ${includedGuests} huéspedes)${
-            activeSeason
-              ? ` — base ${formatCurrency(unit.base_rate_mxn)} × ${activeSeason.price_multiplier}`
-              : ''
-          }`,
-          `Base: ${formatCurrency(pricePerNight)} × ${nights} noches`,
+          ...(hasOverrideInRange
+            ? ['📌 Incluye precio fijo de esta unidad en parte del rango']
+            : []),
+          `Tarifa${perDay ? ' promedio' : ''}: ${formatCurrency(pricePerNight)}/noche (unidad completa, hasta ${includedGuests} huéspedes)`,
+          perDay
+            ? `Base: suma noche por noche del ${checkInDate} al ${checkOutDate} (temporadas y precios fijos aplicados por día)`
+            : `Base: ${formatCurrency(pricePerNight)} × ${nights} noches`,
           ...(extraPersons > 0
             ? [`+${extraPersons} persona(s) extra: ${formatCurrency(EXTRA_PERSON_FEE)}/pers/noche`]
             : []),


### PR DESCRIPTION
## Summary

Cierra el follow-up anotado en #142 que quedó desbloqueado al mergear #141 + #142 juntos: el cotizador ahora resuelve el precio STR **noche por noche** con la misma función que el calendario (`nightlyPrice` de `calendar-occupancy`):

- Con fechas de check-in/check-out, la base es la **suma por día**: cada noche aplica su propia temporada Y los **precios fijos por unidad** (`unit_rate_overrides`) si existen. Antes se aplicaba el multiplicador del día de check-in a TODAS las noches (una estancia que cruzaba el inicio de temporada alta cotizaba mal).
- Sin fechas, se mantiene la estimación rápida (base × temporada × noches).
- El desglose indica cuándo el rango incluye precio fijo ("📌 Incluye precio fijo de esta unidad...") y muestra la tarifa como promedio.
- Si la tabla `unit_rate_overrides` no existiera, degrada a cotizar sin overrides (ya está aplicada en prod según Fran, 2026-07-03).

Con esto, cotizador ≡ calendario ≡ panel de rango: un solo motor de precio.

## Pre-flight checklist

- [x] Rama sobre `origin/main` actualizado (`d51da06`, post #143) · [x] scope único (1 archivo) · [x] `tsc` y `build` verdes

## Invariantes

- [x] Todas respetadas.

## Acuerdos canónicos afectados

- [x] Ninguno — reutiliza la lógica ya mergeada de `calendar-occupancy`.

## Verification

- [x] Build verde; `nightlyPrice` ya está cubierta por la suite de 52 casos (override gana / inclusive / fuera de rango / sin base)
- [ ] Preview: cotizar un rango que cruce el inicio de una temporada y verificar que el total = suma visible en el calendario de la unidad

## Merge

- [x] NO se mergeará automáticamente. Espero aprobación de @franduranv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6L5rZfdkJSULa2a3TrJWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6L5rZfdkJSULa2a3TrJWG)_