### PR TITLE
Mobile friendly: auditoría iPhone completa + fixes (tablas, filtros, viewport, touch targets, calendario)

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -39,6 +39,12 @@ Sección de visualización de ocupación modelo Airbnb, 2 vistas, en Portafolio 
 
 ---
 
+## 0.quater · Auditoría mobile-friendly (2026-07-03, rama `fix/mobile-responsive`)
+
+Auditoría de responsividad iPhone/390px sobre todo `src/`. Veredicto: el chrome ya era sólido (hamburguesa + sidebar off-canvas en `Sidebar.tsx`, modales `w-full max-w-*`, sub-nav con scroll, sitio público excelente). Fixes aplicados: 10 tablas sin `overflow-x-auto` (home, units, agents, owners anidada, owner portal, BulkUnitsModal, WizardFirstRun, 3 de /admin), filtros de mes de `/cobros` sin `flex-wrap`, `export const viewport` explícito en `layout.tsx`, grids `grid-cols-3` sin breakpoint en 4 modales/forms (UnitModal, housekeeping, ancillary-charges, policies), objetivos táctiles `p-1`→`p-2` en acciones de fila (cobros, owners, whatsapp, Sidebar, StayDrawer, StayOccupants), y el calendario abre en zoom "2 semanas" bajo 640px. Verificación visual con Chromium a 390×844 (timeline y vista mensual legibles).
+
+---
+
 ## 0.bis · Qué aterrizó entre 2026-06-11 y 2026-07-02
 
 - **Reencuadre estratégico (Fran, 2026-07-01):** BaW OS es a corto plazo la **herramienta interna de DuVa ReEs** (family office Durán Vargas: edificios 809 y 2020), no el producto SaaS a comercializar. La apuesta comercial de ZXY se mueve a **Engrane AI**. La productización de BaW OS queda en pausa, no cancelada.

--- a/src/app/admin/admins/page.tsx
+++ b/src/app/admin/admins/page.tsx
@@ -41,7 +41,7 @@ export default async function PlatformAdminsPage() {
       </div>
 
       <div
-        className="rounded-lg overflow-hidden"
+        className="rounded-lg overflow-x-auto"
         style={{
           backgroundColor: 'var(--baw-surface)',
           border: '1px solid var(--baw-border)',

--- a/src/app/admin/tenants/page.tsx
+++ b/src/app/admin/tenants/page.tsx
@@ -74,7 +74,7 @@ export default async function TenantsPage() {
       </div>
 
       <div
-        className="rounded-lg overflow-hidden"
+        className="rounded-lg overflow-x-auto"
         style={{
           backgroundColor: 'var(--baw-surface)',
           border: '1px solid var(--baw-border)',

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -68,7 +68,7 @@ export default async function UsersPage() {
       </div>
 
       <div
-        className="rounded-lg overflow-hidden"
+        className="rounded-lg overflow-x-auto"
         style={{
           backgroundColor: 'var(--baw-surface)',
           border: '1px solid var(--baw-border)',

--- a/src/app/agents/[id]/policies/PoliciesEditorClient.tsx
+++ b/src/app/agents/[id]/policies/PoliciesEditorClient.tsx
@@ -233,7 +233,7 @@ export default function PoliciesEditorClient({
         >
           Rate caps
         </h2>
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
           {(['per_minute', 'per_hour', 'per_day'] as const).map((k) => (
             <label key={k} className="flex flex-col gap-1">
               <span className="text-[11px]" style={{ color: 'var(--baw-muted)' }}>

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -374,7 +374,7 @@ export default async function AgentsPage() {
           </div>
         ) : (
           <div
-            className="rounded-lg overflow-hidden"
+            className="rounded-lg overflow-x-auto"
             style={{ border: '1px solid var(--baw-border)' }}
           >
             <table className="w-full text-[12px]">

--- a/src/app/ancillary-charges/page.tsx
+++ b/src/app/ancillary-charges/page.tsx
@@ -405,7 +405,7 @@ export default function AncillaryChargesPage() {
                   placeholder='Ej. "2 cajones extra" o "Espectacular azotea"'
                 />
               </div>
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                 <div>
                   <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Monto c/u</label>
                   <input

--- a/src/app/calendario/page.tsx
+++ b/src/app/calendario/page.tsx
@@ -152,6 +152,12 @@ export default function CalendarioPage() {
   const [savingChange, setSavingChange] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
 
+  // En pantallas chicas (iPhone) el zoom default es "2 semanas": a 31+ días
+  // las columnas fluidas bajan de ~8px y dejan de ser legibles/tocables.
+  useEffect(() => {
+    if (window.innerWidth < 640) setZoom(14)
+  }, [])
+
   // Respetar el building activo del switcher como filtro inicial (patrón /units)
   useEffect(() => {
     if (activeBuildingId && activeBuildingId !== 'all' && buildingFilter === ALL) {

--- a/src/app/cobros/page.tsx
+++ b/src/app/cobros/page.tsx
@@ -653,7 +653,7 @@ export default function CobrosPage() {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <label className="text-sm text-gray-500 dark:text-gray-400">Desde</label>
           <input
             type="month"
@@ -1053,7 +1053,7 @@ export default function CobrosPage() {
                           <button
                             onClick={() => removeReceipt(r.id)}
                             title="Eliminar abono"
-                            className="shrink-0 p-1 rounded text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
+                            className="shrink-0 p-2 rounded text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
                           >
                             <X className="w-3.5 h-3.5" />
                           </button>

--- a/src/app/housekeeping/page.tsx
+++ b/src/app/housekeeping/page.tsx
@@ -182,7 +182,7 @@ export default function HousekeepingPage() {
       </div>
 
       {/* Summary cards */}
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
         <div className="card p-3 text-center">
           <p className="text-2xl font-bold text-amber-400">{pending.length}</p>
           <p className="text-xs text-gray-600 dark:text-gray-400">Pendientes</p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { Inter, IBM_Plex_Mono, Instrument_Serif } from 'next/font/google'
 import './globals.css'
 import AppShell from '@/components/AppShell'
@@ -31,6 +31,13 @@ export const metadata: Metadata = {
   icons: {
     icon: '/favicon.svg',
   },
+}
+
+// Explícito para poder auditar la responsividad móvil (Next lo inyecta por
+// default, pero así queda declarado y controlado).
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
 }
 
 export default function RootLayout({

--- a/src/app/onboarding/WizardFirstRun.tsx
+++ b/src/app/onboarding/WizardFirstRun.tsx
@@ -845,7 +845,7 @@ function StepUnits({
             </button>
           </div>
           <div
-            className="rounded-md overflow-hidden"
+            className="rounded-md overflow-x-auto"
             style={{ border: '1px solid var(--baw-border)' }}
           >
             <table className="w-full text-[12px]">

--- a/src/app/owner/buildings/[buildingId]/page.tsx
+++ b/src/app/owner/buildings/[buildingId]/page.tsx
@@ -74,7 +74,7 @@ export default async function OwnerBuildingDetail({
         )}
 
         <div
-          className="rounded-lg overflow-hidden"
+          className="rounded-lg overflow-x-auto"
           style={{
             backgroundColor: 'var(--baw-surface)',
             border: '1px solid var(--baw-border)',

--- a/src/app/owners/page.tsx
+++ b/src/app/owners/page.tsx
@@ -412,14 +412,14 @@ export default function OwnersPage() {
                                     setEditingStake(s)
                                     setStakeModalOpen(true)
                                   }}
-                                  className="text-gray-400 hover:text-indigo-600 p-1"
+                                  className="text-gray-400 hover:text-indigo-600 p-2"
                                   title="Editar"
                                 >
                                   <Pencil className="w-3.5 h-3.5" />
                                 </button>
                                 <button
                                   onClick={() => handleDeleteStake(s.id)}
-                                  className="text-gray-400 hover:text-red-600 p-1"
+                                  className="text-gray-400 hover:text-red-600 p-2"
                                   title="Quitar"
                                 >
                                   <Trash2 className="w-3.5 h-3.5" />
@@ -540,6 +540,7 @@ export default function OwnersPage() {
                                 Aún no tiene edificios asignados.
                               </p>
                             ) : (
+                              <div className="overflow-x-auto">
                               <table className="w-full text-sm">
                                 <thead>
                                   <tr className="text-left text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">
@@ -606,6 +607,7 @@ export default function OwnersPage() {
                                   })}
                                 </tbody>
                               </table>
+                              </div>
                             )}
                           </div>
                         </td>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -417,6 +417,7 @@ export default function MissionControl() {
               Sin pagos pendientes ni vencidos.
             </div>
           ) : (
+            <div className="overflow-x-auto">
             <table className="w-full text-[13px]">
               <thead className="table-header">
                 <tr>
@@ -453,6 +454,7 @@ export default function MissionControl() {
                 ))}
               </tbody>
             </table>
+            </div>
           )}
         </section>
 

--- a/src/app/units/BulkUnitsModal.tsx
+++ b/src/app/units/BulkUnitsModal.tsx
@@ -293,7 +293,7 @@ export default function BulkUnitsModal({
                 </button>
               </div>
               <div
-                className="rounded-md overflow-hidden"
+                className="rounded-md overflow-x-auto"
                 style={{ border: '1px solid var(--baw-border)' }}
               >
                 <table className="w-full text-xs">

--- a/src/app/units/UnitModal.tsx
+++ b/src/app/units/UnitModal.tsx
@@ -101,7 +101,7 @@ export default function UnitModal({ unit, onSave, onClose }: Props) {
               </select>
             </div>
           </div>
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <div>
               <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">Área (m²)</label>
               <input

--- a/src/app/units/page.tsx
+++ b/src/app/units/page.tsx
@@ -346,7 +346,7 @@ export default function UnitsPage() {
         />
       ) : (
         <div
-          className="rounded-lg overflow-hidden"
+          className="rounded-lg overflow-x-auto"
           style={{
             backgroundColor: 'var(--baw-surface)',
             border: '1px solid var(--baw-border)',

--- a/src/app/whatsapp/page.tsx
+++ b/src/app/whatsapp/page.tsx
@@ -340,7 +340,7 @@ export default function WhatsAppPage() {
                   <button
                     onClick={() => setReceivedPage((p) => Math.max(0, p - 1))}
                     disabled={receivedPage === 0}
-                    className="p-1 rounded text-gray-400 hover:text-white disabled:opacity-30"
+                    className="p-2 rounded text-gray-400 hover:text-white disabled:opacity-30"
                   >
                     <ChevronLeft className="w-4 h-4" />
                   </button>
@@ -348,7 +348,7 @@ export default function WhatsAppPage() {
                   <button
                     onClick={() => setReceivedPage((p) => Math.min(receivedTotalPages - 1, p + 1))}
                     disabled={receivedPage >= receivedTotalPages - 1}
-                    className="p-1 rounded text-gray-400 hover:text-white disabled:opacity-30"
+                    className="p-2 rounded text-gray-400 hover:text-white disabled:opacity-30"
                   >
                     <ChevronRight className="w-4 h-4" />
                   </button>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -239,7 +239,7 @@ export default function Sidebar() {
               </div>
               <button
                 onClick={() => setMobileOpen(false)}
-                className="p-1 md:hidden"
+                className="p-2 md:hidden"
                 style={{ color: 'var(--baw-muted)' }}
                 aria-label="Cerrar menú"
               >

--- a/src/components/StayOccupants.tsx
+++ b/src/components/StayOccupants.tsx
@@ -183,7 +183,7 @@ export default function StayOccupants({
             <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
               Nuevo ocupante
             </p>
-            <button onClick={resetForm} className="p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+            <button onClick={resetForm} className="p-2 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
               <X className="w-4 h-4" />
             </button>
           </div>

--- a/src/components/calendar/StayDrawer.tsx
+++ b/src/components/calendar/StayDrawer.tsx
@@ -73,7 +73,7 @@ export default function StayDrawer({
           </div>
           <button
             onClick={onClose}
-            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+            className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
             aria-label="Cerrar"
           >
             <X className="w-4 h-4 muted-text" />


### PR DESCRIPTION
## Summary

Auditoría de responsividad móvil (target iPhone, 390px) de TODO `src/` + fixes. **Hallazgo principal: el chrome ya era sólido** — hamburguesa + sidebar off-canvas, modales `w-full`, sub-nav con scroll horizontal, y el sitio público de booking está muy bien hecho para móvil. Los problemas eran puntuales; todos corregidos:

- **10 tablas sin scroll horizontal** → `overflow-x-auto`: home (Mission Control), `/units`, `/agents`, sub-tabla de `/owners`, portal de owner, `BulkUnitsModal`, wizard de onboarding, y las 3 tablas de `/admin`.
- **`/cobros`**: la barra de filtros "Desde/Hasta" (inputs de mes) no envolvía → `flex-wrap` (desbordaba en 390px).
- **`layout.tsx`**: `export const viewport` explícito (`device-width`, `initialScale: 1`).
- **Grids `grid-cols-3` sin breakpoint** en formularios/modales → `grid-cols-1|2 sm:grid-cols-3`: `UnitModal`, housekeeping, cargos adicionales, editor de políticas de agentes.
- **Objetivos táctiles**: acciones de fila con `p-1` (~24px) subidas a `p-2` (~36-40px): cobros, owners, whatsapp, botón cerrar del sidebar móvil, StayDrawer, StayOccupants.
- **Calendario**: en pantallas &lt;640px abre en zoom "2 semanas" (a 31 días las columnas fluidas bajan de 8px); el timeline ya comprime al 100% del ancho sin scroll y la vista mensual por unidad funciona bien a 390px (verificado visualmente).

## Verificación

- [x] `tsc --noEmit` + `npm run build` verdes
- [x] Screenshots con Chromium a 390×844 (deviceScaleFactor 2, touch): timeline a 14 días legible y tocable; a 31 días apretado pero funcional; vista mensual con celdas ~52-89px y precios legibles
- [x] Auditoría exhaustiva por agente sobre todo src/ (tablas, anchos fijos, grids, flex sin wrap, modales, touch targets, chrome, viewport, sitio público)
- [ ] Prueba real en tu iPhone tras el deploy: sidebar hamburguesa, /cobros, /units, /calendario (drag de barras funciona en touch — las barras llevan `touch-action: none`), sitio público

Notas de lo que NO se tocó a propósito:
- Kanban de `/clientes`: columnas de 220px con scroll horizontal intencional (UX estándar de kanban).
- Grids `grid-cols-7` de calendarios: son días de la semana, correctos.
- `/owners` y `/buildings` ya ocultan su tabla en móvil con alternativa (patrón `hidden md:block`).
- Selección por arrastre en la vista mensual: en touch funciona como tap por día (limitación anotada; el flujo completo de selección multi-día en touch es follow-up si lo necesitas en campo).

## Invariantes

- [x] Todas respetadas — cambios de clases utilitarias y un `useEffect`; sin tokens nuevos, sin navegación, sin migraciones.

## Merge

- [x] NO se mergeará automáticamente. Espero aprobación de @franduranv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6L5rZfdkJSULa2a3TrJWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6L5rZfdkJSULa2a3TrJWG)_