### PR TITLE
Cotización telefónica: click entrada→salida en calendario, apartado 24-72h con auto-liberación, y CRM mínimo (temperatura + etapa cotizado + historial)

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -45,6 +45,18 @@ Auditoría de responsividad iPhone/390px sobre todo `src/`. Veredicto: el chrome
 
 ---
 
+## 0.quinquies · Cotización telefónica + CRM mínimo (2026-07-04, rama `feat/quote-flow`)
+
+User story de Fran: llamada → disponibilidad en calendario → click entrada/click salida → cotizar → apartar 24-72h → enviar propuesta → confirma o se libera solo. Modelo acordado: **la cotización es una reservación `tentative` con `hold_expires_at`; el prospecto vive SOLO en CRM y se vuelve occupant al confirmar**.
+
+- Migración `20260704_quote_flow_crm.sql`: `reservations.hold_expires_at` + `reservations.occupant_id`, `crm_opportunities.temperature` (frio/tibio/caliente) + `.reservation_id`, etapa `cotizado` en el funnel, y `fn_unit_is_available` ignora tentativas vencidas + **incluye unit_blocks** (hueco: los bloqueos no cerraban el booking público — también corregido en la route de blocked_days). **⚠️ Aplicar en Supabase prod (después de 20260703_03).**
+- Selección **click entrada → click salida** en ambas vistas del calendario (touch-friendly, ESC cancela; el hover extiende la vista previa en desktop; en timeline se selecciona sobre la fila de la unidad con banda `tl-sel`).
+- `QuotePanel` (`src/components/calendar/QuotePanel.tsx` + lógica en `src/lib/quote-flow.ts`): desglose con el motor unificado, huéspedes, temperatura, hold 24/48/72h, contacto = buscar/crear en `crm_contacts` (source llamada); crea tentativa + oportunidad `cotizado` ligada (`reservation_id`); propuesta prellenada por WhatsApp (wa.me), correo (mailto) o copiar.
+- Drawer de tentativas: countdown del apartado ("expira en 36h"), **Confirmar** (→ confirmed, opp ganado, PROMUEVE contacto a occupant deduplicando el espejo del trigger `crm_contact_for_occupant`, liga `reservations.occupant_id`) y **Liberar** (→ cancelled, opp perdido).
+- CRM `/clientes`: etapa Cotizado en kanban, chip y select de temperatura, "Historial de transacciones" = contratos + reservaciones (via `reservations.occupant_id`); `/reservations` ahora persiste el occupant del PersonPicker.
+
+---
+
 ## 0.bis · Qué aterrizó entre 2026-06-11 y 2026-07-02
 
 - **Reencuadre estratégico (Fran, 2026-07-01):** BaW OS es a corto plazo la **herramienta interna de DuVa ReEs** (family office Durán Vargas: edificios 809 y 2020), no el producto SaaS a comercializar. La apuesta comercial de ZXY se mueve a **Engrane AI**. La productización de BaW OS queda en pausa, no cancelada.

--- a/src/app/api/public/v1/units/[slug]/availability/route.ts
+++ b/src/app/api/public/v1/units/[slug]/availability/route.ts
@@ -90,11 +90,12 @@ export async function GET(
     p_to: to,
   })
 
-  // Blocked date ranges (confirmed/checked_in reservations + active holds)
-  const [{ data: reservations }, { data: holds }] = await Promise.all([
+  // Blocked date ranges: reservas firmes + tentativas con hold vigente +
+  // holds de checkout + bloqueos operativos (unit_blocks, fase 3).
+  const [{ data: rawReservations }, { data: holds }, { data: blocks }] = await Promise.all([
     svc
       .from('reservations')
-      .select('check_in, check_out')
+      .select('check_in, check_out, status, hold_expires_at')
       .eq('unit_id', unit.id)
       .in('status', ['confirmed', 'checked_in', 'tentative'])
       .gte('check_out', from)
@@ -107,7 +108,21 @@ export async function GET(
       .gt('expires_at', new Date().toISOString())
       .gte('to_date', from)
       .lte('from_date', to),
+
+    svc
+      .from('unit_blocks')
+      .select('start_date, end_date')
+      .eq('unit_id', unit.id)
+      .gte('end_date', from)
+      .lte('start_date', to),
   ])
+
+  // Una cotización tentativa vencida ya no aparta fechas (se libera sola).
+  const nowIso = new Date().toISOString()
+  const reservations = (rawReservations ?? []).filter(
+    (r) =>
+      r.status !== 'tentative' || !r.hold_expires_at || r.hold_expires_at > nowIso,
+  )
 
   // Build a set of blocked day strings in range (ISO YYYY-MM-DD)
   const blockedDays = new Set<string>()
@@ -121,11 +136,17 @@ export async function GET(
     }
   }
 
-  for (const r of reservations ?? []) {
+  for (const r of reservations) {
     addBlockedDays(r.check_in, r.check_out)
   }
   for (const h of holds ?? []) {
     addBlockedDays(h.from_date, h.to_date)
+  }
+  for (const b of blocks ?? []) {
+    // end_date de unit_blocks es INCLUSIVO → el día end_date también se bloquea
+    const endExclusive = new Date(b.end_date)
+    endExclusive.setUTCDate(endExclusive.getUTCDate() + 1)
+    addBlockedDays(b.start_date, endExclusive.toISOString().slice(0, 10))
   }
 
   console.log(`action=unit_availability slug=${slug} available=${isAvailable} blocked_days=${blockedDays.size} status=ok`)

--- a/src/app/calendario/[unitId]/page.tsx
+++ b/src/app/calendario/[unitId]/page.tsx
@@ -20,6 +20,8 @@ import { useActiveContext } from '@/lib/useActiveContext'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 import StayDrawer from '@/components/calendar/StayDrawer'
+import QuotePanel from '@/components/calendar/QuotePanel'
+import { confirmQuote, releaseQuote } from '@/lib/quote-flow'
 import { INSTR_VAR, instrVarFor, unitTypeVar } from '@/components/calendar/calendar-ui'
 import type { CalendarStay, Season, RateOverride } from '@/lib/calendar-occupancy'
 import {
@@ -48,6 +50,8 @@ interface UnitDetail {
   status: string
   base_rate_mxn: number | null
   monthly_rate_mxn: number | null
+  cleaning_fee_mxn: number | null
+  max_guests: number | null
   is_publicly_bookable: boolean | null
   building: { id: string; name: string } | { id: string; name: string }[] | null
 }
@@ -75,10 +79,13 @@ export default function UnidadCalendarioPage() {
   const [monthsAhead, setMonthsAhead] = useState(6)
   const [selected, setSelected] = useState<CalendarStay | null>(null)
 
-  // Selección de rango (drag sobre días libres)
+  // Selección de rango: primer click/tap = día de ENTRADA, segundo = día de
+  // SALIDA (funciona igual con mouse y touch). El hover extiende la vista
+  // previa en desktop.
   const [selAnchor, setSelAnchor] = useState<string | null>(null)
   const [selEnd, setSelEnd] = useState<string | null>(null)
-  const [dragging, setDragging] = useState(false)
+  const [selComplete, setSelComplete] = useState(false)
+  const [quoteMode, setQuoteMode] = useState(false)
 
   useEffect(() => {
     if (ctxLoading) return
@@ -94,7 +101,7 @@ export default function UnidadCalendarioPage() {
         const [unitRes, contractsRes, reservationsRes, holdsRes, seasonsRes] = await Promise.all([
           supabase
             .from('units')
-            .select('id, number, floor, type, status, base_rate_mxn, monthly_rate_mxn, is_publicly_bookable, building:buildings(id, name)')
+            .select('id, number, floor, type, status, base_rate_mxn, monthly_rate_mxn, cleaning_fee_mxn, max_guests, is_publicly_bookable, building:buildings(id, name)')
             .eq('id', unitId)
             .eq('org_id', orgId)
             .maybeSingle(),
@@ -107,7 +114,7 @@ export default function UnidadCalendarioPage() {
           // reservations filtra por organization_id (esquema histórico)
           supabase
             .from('reservations')
-            .select('id, unit_id, guest_name, check_in, check_out, status, payment_status, total_price, guests_count, channel, notes')
+            .select('id, unit_id, guest_name, check_in, check_out, status, payment_status, total_price, guests_count, channel, notes, hold_expires_at')
             .eq('organization_id', orgId)
             .eq('unit_id', unitId),
           supabase
@@ -156,13 +163,14 @@ export default function UnidadCalendarioPage() {
     }
   }, [ctxLoading, activeOrgId, unitId, reloadKey])
 
-  // Terminar el drag donde sea que suelte el pointer
+  // ESC cancela la selección en curso
   useEffect(() => {
-    function onUp() {
-      setDragging(false)
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') clearSelection()
     }
-    window.addEventListener('pointerup', onUp)
-    return () => window.removeEventListener('pointerup', onUp)
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const months = useMemo(
@@ -208,7 +216,39 @@ export default function UnidadCalendarioPage() {
   function clearSelection() {
     setSelAnchor(null)
     setSelEnd(null)
-    setDragging(false)
+    setSelComplete(false)
+    setQuoteMode(false)
+  }
+
+  /** Click en una celda: arranca o completa la selección entrada→salida. */
+  function handleCellClick(iso: string, freeCell: boolean, bandOrEnding: CalendarStay | null) {
+    // Selección en curso: este click es el día de SALIDA (aunque ese día ya
+    // tenga check-in de alguien más — la salida es por la mañana).
+    if (selAnchor && !selComplete) {
+      let entrada = selAnchor
+      let salida = iso
+      if (salida < entrada) {
+        const tmp = entrada
+        entrada = salida
+        salida = tmp
+      } else if (salida === entrada) {
+        salida = addDaysISO(entrada, 1)
+      }
+      const lastNight = clampToFree(entrada, addDaysISO(salida, -1))
+      setSelAnchor(entrada)
+      setSelEnd(lastNight)
+      setSelComplete(true)
+      return
+    }
+    if (bandOrEnding) {
+      clearSelection()
+      setSelected(bandOrEnding)
+      return
+    }
+    if (!freeCell) return
+    setSelAnchor(iso)
+    setSelEnd(iso)
+    setSelComplete(false)
   }
 
   const building = one(unit?.building ?? null)
@@ -279,9 +319,8 @@ export default function UnidadCalendarioPage() {
             : ''}
         </p>
         <p className="text-xs muted-text mt-1">
-          Arrastra sobre días libres para seleccionar un rango: cotiza, fija precio de esta
-          unidad, crea/edita temporadas, bloquea el rango o crea una reservación con las fechas
-          prellenadas.
+          Toca el día de ENTRADA y luego el de SALIDA para seleccionar: cotiza y aparta 24-72h,
+          fija precio de esta unidad, crea/edita temporadas o bloquea el rango. ESC cancela.
         </p>
       </div>
 
@@ -347,22 +386,14 @@ export default function UnidadCalendarioPage() {
                     return (
                       <div
                         key={cell.iso}
-                        onPointerDown={() => {
-                          if (!free) return
-                          setSelAnchor(cell.iso)
-                          setSelEnd(cell.iso)
-                          setDragging(true)
-                        }}
                         onPointerEnter={() => {
-                          if (dragging && selAnchor) setSelEnd(clampToFree(selAnchor, cell.iso))
-                        }}
-                        onClick={() => {
-                          const target = band ?? ending
-                          if (target) {
-                            clearSelection()
-                            setSelected(target)
+                          if (selAnchor && !selComplete) {
+                            const targetLast =
+                              cell.iso > selAnchor ? addDaysISO(cell.iso, -1) : selAnchor
+                            setSelEnd(clampToFree(selAnchor, targetLast))
                           }
                         }}
+                        onClick={() => handleCellClick(cell.iso, free, band ?? ending)}
                         className={`relative min-h-[72px] p-1 border border-black/[0.04] dark:border-white/[0.04] transition-colors ${
                           band || ending ? 'cursor-pointer' : 'cursor-crosshair'
                         } ${season && !inSelection ? 'bg-emerald-500/[0.06]' : ''} ${
@@ -497,7 +528,27 @@ export default function UnidadCalendarioPage() {
       </div>
 
       {/* Panel de rango seleccionado (price management) */}
-      {selection && !selected && (
+      {selection && selComplete && !selected && quoteMode && activeOrgId && unit && (
+        <QuotePanel
+          orgId={activeOrgId}
+          unit={{
+            id: unit.id,
+            number: unit.number,
+            type: unit.type,
+            base_rate_mxn: unit.base_rate_mxn,
+            cleaning_fee_mxn: unit.cleaning_fee_mxn ?? null,
+            max_guests: unit.max_guests ?? null,
+            buildingName: building?.name ?? null,
+          }}
+          checkIn={selection.from}
+          checkOut={selection.checkOut}
+          seasons={seasons}
+          onClose={clearSelection}
+          onCreated={() => setReloadKey((k) => k + 1)}
+        />
+      )}
+
+      {selection && selComplete && !selected && !quoteMode && (
         <RangePanel
           unit={unit}
           orgId={activeOrgId}
@@ -506,6 +557,7 @@ export default function UnidadCalendarioPage() {
           overrides={overrides}
           onClose={clearSelection}
           onChanged={() => setReloadKey((k) => k + 1)}
+          onQuote={() => setQuoteMode(true)}
         />
       )}
 
@@ -513,6 +565,25 @@ export default function UnidadCalendarioPage() {
         stay={selected}
         unitLabel={`Unidad ${unit.number}${building ? ` · ${building.name}` : ''}`}
         onClose={() => setSelected(null)}
+        onConfirm={
+          selected?.kind === 'reservacion' && selected.status === 'tentative' && activeOrgId
+            ? async () => {
+                await confirmQuote(selected, activeOrgId)
+                setSelected(null)
+                setReloadKey((k) => k + 1)
+              }
+            : null
+        }
+        onRelease={
+          selected?.kind === 'reservacion' && selected.status === 'tentative'
+            ? async () => {
+                if (!window.confirm('¿Liberar estas fechas? La oportunidad pasa a "perdido".')) return
+                await releaseQuote(selected)
+                setSelected(null)
+                setReloadKey((k) => k + 1)
+              }
+            : null
+        }
         onDelete={
           selected?.kind === 'bloqueo'
             ? async () => {
@@ -538,6 +609,7 @@ function RangePanel({
   overrides,
   onClose,
   onChanged,
+  onQuote,
 }: {
   unit: UnitDetail
   orgId: string
@@ -546,6 +618,7 @@ function RangePanel({
   overrides: RateOverride[]
   onClose: () => void
   onChanged: () => void
+  onQuote: () => void
 }) {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -725,13 +798,22 @@ function RangePanel({
         </div>
       )}
 
-      {/* Acciones de creación */}
+      {/* Acción principal: flujo de cotización telefónica */}
+      <button
+        onClick={onQuote}
+        className="w-full px-3 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 hover:bg-indigo-700 text-white"
+      >
+        💬 Cotizar y apartar 24-72h
+      </button>
+
+      {/* Acciones de creación directa */}
       <div className="flex gap-2">
         <Link
           href={`/reservations?unit_id=${unit.id}&check_in=${selection.from}&check_out=${selection.checkOut}`}
-          className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-indigo-600 hover:bg-indigo-700 text-white transition-colors"
+          className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          style={{ color: 'var(--baw-text)' }}
         >
-          <BedDouble className="w-4 h-4" /> Crear reservación
+          <BedDouble className="w-4 h-4" /> Reservación directa
         </Link>
         <Link
           href="/contracts/new"

--- a/src/app/calendario/page.tsx
+++ b/src/app/calendario/page.tsx
@@ -31,7 +31,9 @@ import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 import { KPICard } from '@/components/ui/status'
 import StayDrawer from '@/components/calendar/StayDrawer'
+import QuotePanel from '@/components/calendar/QuotePanel'
 import ConfirmModal from '@/components/ConfirmModal'
+import { confirmQuote, releaseQuote, type QuoteUnitInfo } from '@/lib/quote-flow'
 import {
   INSTR_VAR,
   instrVarFor,
@@ -64,6 +66,18 @@ interface UnitRow {
   status: string
   base_rate_mxn: number | null
   monthly_rate_mxn: number | null
+  cleaning_fee_mxn: number | null
+  max_guests: number | null
+}
+
+/** Selección entrada→salida sobre la fila de una unidad (flujo de cotización). */
+interface RowSelection {
+  unitId: string
+  /** día de entrada (primera noche) */
+  anchor: string
+  /** última noche seleccionada (checkOut = end + 1) */
+  end: string
+  complete: boolean
 }
 
 const UNIT_TYPE_LABELS: Record<UnitType, string> = {
@@ -152,6 +166,23 @@ export default function CalendarioPage() {
   const [savingChange, setSavingChange] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
 
+  // Cotización telefónica: selección entrada→salida sobre una fila
+  const [rowSel, setRowSel] = useState<RowSelection | null>(null)
+  const [quoteFor, setQuoteFor] = useState<{
+    unit: UnitRow
+    checkIn: string
+    checkOut: string
+  } | null>(null)
+
+  // ESC cancela la selección en curso
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setRowSel(null)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
   // En pantallas chicas (iPhone) el zoom default es "2 semanas": a 31+ días
   // las columnas fluidas bajan de ~8px y dejan de ser legibles/tocables.
   useEffect(() => {
@@ -182,7 +213,7 @@ export default function CalendarioPage() {
         const [unitsRes, contractsRes, reservationsRes, seasonsRes] = await Promise.all([
           supabase
             .from('units')
-            .select('id, building_id, number, floor, type, status, base_rate_mxn, monthly_rate_mxn')
+            .select('id, building_id, number, floor, type, status, base_rate_mxn, monthly_rate_mxn, cleaning_fee_mxn, max_guests')
             .eq('org_id', orgId)
             .is('archived_at', null)
             .order('floor')
@@ -196,7 +227,7 @@ export default function CalendarioPage() {
           // Ojo: reservations filtra por organization_id, no org_id (esquema histórico)
           supabase
             .from('reservations')
-            .select('id, unit_id, guest_name, check_in, check_out, status, payment_status, total_price, guests_count, channel, notes')
+            .select('id, unit_id, guest_name, check_in, check_out, status, payment_status, total_price, guests_count, channel, notes, hold_expires_at')
             .eq('organization_id', orgId),
           supabase.from('str_seasons').select('*').order('start_date'),
         ])
@@ -483,6 +514,81 @@ export default function CalendarioPage() {
     return kind === 'reservacion' ? endExclusive : addDaysISO(endExclusive, -1)
   }
 
+  /* ── Cotización telefónica: primer click = entrada, segundo = salida ── */
+
+  function isRowDayFree(unitId: string, iso: string): boolean {
+    return !stays.some(
+      (s) =>
+        s.unitId === unitId &&
+        s.start <= iso &&
+        (s.endExclusive === null || iso < s.endExclusive),
+    )
+  }
+
+  /** Extiende desde la entrada hacia la salida sin cruzar días ocupados. */
+  function clampRowToFree(unitId: string, anchor: string, target: string): string {
+    let cur = anchor
+    while (cur < target) {
+      const next = addDaysISO(cur, 1)
+      if (!isRowDayFree(unitId, next)) break
+      cur = next
+    }
+    return cur
+  }
+
+  function dayFromTrackEvent(e: { clientX: number; currentTarget: EventTarget }): string | null {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+    const idx = Math.floor(((e.clientX - rect.left) / rect.width) * days)
+    if (idx < 0 || idx >= days) return null
+    return addDaysISO(windowStart, idx)
+  }
+
+  function handleTrackClick(u: UnitRow, e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target !== e.currentTarget) return // clicks sobre barras los maneja la barra
+    const iso = dayFromTrackEvent(e)
+    if (!iso || !isRowDayFree(u.id, iso)) {
+      setRowSel(null)
+      return
+    }
+    if (!rowSel || rowSel.unitId !== u.id || rowSel.complete) {
+      setRowSel({ unitId: u.id, anchor: iso, end: iso, complete: false })
+      return
+    }
+    // Segundo click = día de SALIDA (semiabierto). Si cae antes de la
+    // entrada, se invierten los roles; mismo día = 1 noche.
+    let entrada = rowSel.anchor
+    let salida = iso
+    if (salida < entrada) {
+      const tmp = entrada
+      entrada = salida
+      salida = tmp
+    } else if (salida === entrada) {
+      salida = addDaysISO(entrada, 1)
+    }
+    const lastNight = clampRowToFree(u.id, entrada, addDaysISO(salida, -1))
+    setRowSel({ unitId: u.id, anchor: entrada, end: lastNight, complete: true })
+    setQuoteFor({ unit: u, checkIn: entrada, checkOut: addDaysISO(lastNight, 1) })
+  }
+
+  function handleTrackMove(u: UnitRow, e: React.PointerEvent<HTMLDivElement>) {
+    if (!rowSel || rowSel.unitId !== u.id || rowSel.complete) return
+    const iso = dayFromTrackEvent(e)
+    if (!iso) return
+    const targetLast = iso > rowSel.anchor ? addDaysISO(iso, -1) : rowSel.anchor
+    const end = clampRowToFree(u.id, rowSel.anchor, targetLast)
+    if (end !== rowSel.end) setRowSel({ ...rowSel, end })
+  }
+
+  const quoteUnitInfo = (u: UnitRow): QuoteUnitInfo => ({
+    id: u.id,
+    number: u.number,
+    type: u.type,
+    base_rate_mxn: u.base_rate_mxn,
+    cleaning_fee_mxn: u.cleaning_fee_mxn,
+    max_guests: u.max_guests,
+    buildingName: orgBuildings.find((b) => b.id === u.building_id)?.name ?? null,
+  })
+
   // Densidad de números en el header: a Trimestre solo lunes (evita colisiones)
   const showAllDayNumbers = zoom !== 92
   const isMonday = (iso: string) => new Date(iso + 'T00:00:00Z').getUTCDay() === 1
@@ -750,7 +856,29 @@ export default function CalendarioPage() {
                           {free > 0 && free < days && <span className="tl-vac">{free}n libres</span>}
                           {free === days && <span className="tl-vac">libre</span>}
                         </div>
-                        <div className="tl-track" style={{ height: trackH }}>
+                        <div
+                          className="tl-track"
+                          style={{ height: trackH, cursor: 'crosshair' }}
+                          onClick={(e) => handleTrackClick(u, e)}
+                          onPointerMove={(e) => handleTrackMove(u, e)}
+                        >
+                          {rowSel?.unitId === u.id && (
+                            <span
+                              className="tl-sel"
+                              style={
+                                {
+                                  '--d': diffDaysISO(windowStart, rowSel.anchor),
+                                  '--len': diffDaysISO(rowSel.anchor, rowSel.end) + 1,
+                                  pointerEvents: 'none',
+                                } as CSSProperties
+                              }
+                            >
+                              <span>
+                                {diffDaysISO(rowSel.anchor, rowSel.end) + 1}n
+                                {rowSel.complete ? '' : ' · elige salida'}
+                              </span>
+                            </span>
+                          )}
                           {bars.map((b) => {
                             // Half-day: check-in arranca a mitad de día y
                             // check-out termina a mitad de día — salvo bordes
@@ -895,9 +1023,10 @@ export default function CalendarioPage() {
           )}
 
           <p className="text-xs muted-text">
-            Arrastra una barra para mover la estancia (orillas para extender/recortar) — se pide
-            confirmación antes de guardar · click simple abre el detalle · click en la unidad abre
-            su calendario mensual con precios por noche.
+            <strong>Cotizar:</strong> click en el día de entrada y luego en el de salida sobre una
+            fila libre — se abre la cotización con apartado de 24-72h · arrastra una barra para
+            mover la estancia (orillas para extender) · click simple abre el detalle · click en la
+            unidad abre su calendario mensual.
           </p>
         </>
       )}
@@ -924,10 +1053,46 @@ export default function CalendarioPage() {
         variant="default"
       />
 
+      {quoteFor && activeOrgId && (
+        <QuotePanel
+          orgId={activeOrgId}
+          unit={quoteUnitInfo(quoteFor.unit)}
+          checkIn={quoteFor.checkIn}
+          checkOut={quoteFor.checkOut}
+          seasons={seasons}
+          onClose={() => {
+            setQuoteFor(null)
+            setRowSel(null)
+          }}
+          onCreated={() => setReloadKey((k) => k + 1)}
+        />
+      )}
+
       <StayDrawer
         stay={selected}
         unitLabel={unitLabelFor(selected)}
         onClose={() => setSelected(null)}
+        onConfirm={
+          selected?.kind === 'reservacion' && selected.status === 'tentative' && activeOrgId
+            ? async () => {
+                const err = await confirmQuote(selected, activeOrgId)
+                setSelected(null)
+                if (err) setActionError(err)
+                setReloadKey((k) => k + 1)
+              }
+            : null
+        }
+        onRelease={
+          selected?.kind === 'reservacion' && selected.status === 'tentative'
+            ? async () => {
+                if (!window.confirm('¿Liberar estas fechas? La oportunidad pasa a "perdido".')) return
+                const err = await releaseQuote(selected)
+                setSelected(null)
+                if (err) setActionError(err)
+                setReloadKey((k) => k + 1)
+              }
+            : null
+        }
         onDelete={
           selected?.kind === 'bloqueo'
             ? async () => {

--- a/src/app/clientes/page.tsx
+++ b/src/app/clientes/page.tsx
@@ -15,7 +15,7 @@ import { formatCurrency } from '@/lib/utils'
 import { SkeletonTable } from '@/components/Skeleton'
 import EmptyState from '@/components/EmptyState'
 import { CRM_PRODUCT_OPTIONS } from '@/types'
-import type { CrmContact, CrmOpportunity, CrmStatus, CrmSource, CrmOppStage, CrmOppKind } from '@/types'
+import type { CrmContact, CrmOpportunity, CrmStatus, CrmSource, CrmOppStage, CrmOppKind , CrmTemperature} from '@/types'
 
 const STATUS_META: Record<CrmStatus, { label: string; cls: string }> = {
   nuevo: { label: 'Nuevo', cls: 'bg-blue-500/10 text-blue-400 border-blue-500/30' },
@@ -33,11 +33,21 @@ const STAGE_META: Record<CrmOppStage, { label: string }> = {
   identificado: { label: 'Identificado' },
   contactado: { label: 'Contactado' },
   interesado: { label: 'Interesado' },
+  cotizado: { label: 'Cotizado' },
   negociacion: { label: 'Negociación' },
   ganado: { label: 'Ganado' },
   perdido: { label: 'Perdido' },
 }
-const STAGE_ORDER: CrmOppStage[] = ['identificado', 'contactado', 'interesado', 'negociacion', 'ganado', 'perdido']
+const STAGE_ORDER: CrmOppStage[] = ['identificado', 'contactado', 'interesado', 'cotizado', 'negociacion', 'ganado', 'perdido']
+
+// Temperatura de la oportunidad (migración 20260704). Puede venir undefined
+// si la fila es previa a la migración.
+const TEMP_META: Record<CrmTemperature, { label: string; cls: string }> = {
+  caliente: { label: '🔥 Caliente', cls: 'bg-red-500/10 text-red-500 border border-red-500/30' },
+  tibio: { label: '🌤 Tibio', cls: 'bg-amber-500/10 text-amber-500 border border-amber-500/30' },
+  frio: { label: '❄️ Frío', cls: 'bg-blue-500/10 text-blue-400 border border-blue-500/30' },
+}
+const TEMP_ORDER: CrmTemperature[] = ['caliente', 'tibio', 'frio']
 
 interface RentalRow {
   id: string
@@ -47,6 +57,7 @@ interface RentalRow {
   status: string
   rent_type: string | null
   unit: { number: string } | null
+  kind?: 'contrato' | 'reservacion'
 }
 
 export default function ClientesPage() {
@@ -301,7 +312,14 @@ function RecompraBoard({
                     onClick={() => c && onOpen(c)}
                     className="w-full text-left card p-3 hover:border-indigo-500/50 transition-colors"
                   >
-                    <p className="text-sm font-medium text-gray-900 dark:text-white">{c?.name || 'Cliente'}</p>
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{c?.name || 'Cliente'}</p>
+                      {o.temperature && (
+                        <span className={`shrink-0 px-1.5 py-0.5 rounded-full text-[10px] font-medium ${TEMP_META[o.temperature].cls}`}>
+                          {TEMP_META[o.temperature].label}
+                        </span>
+                      )}
+                    </div>
                     <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                       {o.kind === 'recompra' ? 'Recompra' : o.kind === 'migracion' ? 'Migración' : 'Nueva'}
                       {o.target_product ? ` · ${o.target_product}` : ''}
@@ -363,13 +381,41 @@ function ContactDrawer({
       setRentals([])
       return
     }
-    supabase
-      .from('contracts')
-      .select('id, start_date, end_date, monthly_amount, status, rent_type, unit:units(number)')
-      .eq('occupant_id', contact.occupant_id)
-      .eq('org_id', orgId)
-      .order('start_date', { ascending: false })
-      .then(({ data }) => setRentals((data as unknown as RentalRow[]) || []))
+    // Historial de transacciones: contratos + reservaciones ligadas a la
+    // identidad durable (reservations.occupant_id, migración 20260704).
+    Promise.all([
+      supabase
+        .from('contracts')
+        .select('id, start_date, end_date, monthly_amount, status, rent_type, unit:units(number)')
+        .eq('occupant_id', contact.occupant_id)
+        .eq('org_id', orgId)
+        .order('start_date', { ascending: false }),
+      supabase
+        .from('reservations')
+        .select('id, check_in, check_out, total_price, status, unit:units(number)')
+        .eq('occupant_id', contact.occupant_id)
+        .order('check_in', { ascending: false }),
+    ]).then(([contractsRes, resRes]) => {
+      const fromContracts = ((contractsRes.data as unknown as RentalRow[]) || []).map((r) => ({
+        ...r,
+        kind: 'contrato' as const,
+      }))
+      const fromReservations = ((resRes.data as any[]) || []).map((r) => ({
+        id: r.id,
+        start_date: r.check_in,
+        end_date: r.check_out,
+        monthly_amount: r.total_price ?? 0,
+        status: r.status,
+        rent_type: 'STR',
+        unit: Array.isArray(r.unit) ? r.unit[0] ?? null : r.unit,
+        kind: 'reservacion' as const,
+      }))
+      setRentals(
+        [...fromContracts, ...fromReservations].sort((a, b) =>
+          (b.start_date ?? '').localeCompare(a.start_date ?? ''),
+        ),
+      )
+    })
   }, [contact.occupant_id, orgId])
 
   async function saveContact() {
@@ -391,6 +437,18 @@ function ContactDrawer({
     } else {
       toast.success('Contacto actualizado')
       if (data) onContactUpdated(data as CrmContact)
+      onChanged()
+    }
+  }
+
+  async function setTemperatureOpp(opp: CrmOpportunity, temperature: CrmTemperature) {
+    const { error } = await supabase
+      .from('crm_opportunities')
+      .update({ temperature, updated_at: new Date().toISOString() })
+      .eq('id', opp.id)
+    if (error) toast.error('No se pudo cambiar la temperatura (¿migración 20260704 aplicada?)')
+    else {
+      toast.success(`Temperatura → ${TEMP_META[temperature].label}`)
       onChanged()
     }
   }
@@ -473,7 +531,7 @@ function ContactDrawer({
 
           {/* Historial de rentas */}
           <div>
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2">Historial de rentas</h3>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2">Historial de transacciones</h3>
             {rentals.length === 0 ? (
               <p className="text-xs text-gray-400">
                 {contact.occupant_id ? 'Sin contratos registrados.' : 'Contacto no ligado a un inquilino del sistema.'}
@@ -486,7 +544,10 @@ function ContactDrawer({
                       <span className="font-medium text-gray-700 dark:text-gray-200">
                         {r.unit?.number ? `Unidad ${r.unit.number}` : 'Contrato'} · {r.rent_type || '—'}
                       </span>
-                      <span className="text-gray-500">{formatCurrency(r.monthly_amount)}/mes</span>
+                      <span className="text-gray-500">
+                        {formatCurrency(r.monthly_amount)}
+                        {r.kind === 'reservacion' ? ' total' : '/mes'}
+                      </span>
                     </div>
                     <div className="text-gray-400 mt-0.5">
                       {r.start_date}{r.end_date ? ` → ${r.end_date}` : ' → vigente'} · {r.status}
@@ -518,13 +579,20 @@ function ContactDrawer({
                       </span>
                       {o.est_monthly ? <span className="text-xs text-gray-400">{formatCurrency(o.est_monthly)}/mes</span> : null}
                     </div>
-                    <div className="mt-2">
+                    <div className="mt-2 grid grid-cols-2 gap-2">
                       <select
                         value={o.stage}
                         onChange={(e) => advanceOpp(o, e.target.value as CrmOppStage)}
                         className="input-field w-full text-xs py-1"
                       >
                         {STAGE_ORDER.map((s) => <option key={s} value={s}>{STAGE_META[s].label}</option>)}
+                      </select>
+                      <select
+                        value={o.temperature ?? 'tibio'}
+                        onChange={(e) => setTemperatureOpp(o, e.target.value as CrmTemperature)}
+                        className="input-field w-full text-xs py-1"
+                      >
+                        {TEMP_ORDER.map((t) => <option key={t} value={t}>{TEMP_META[t].label}</option>)}
                       </select>
                     </div>
                   </div>

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -257,6 +257,9 @@ export default function ReservationsPage() {
       status,
       payment_status: paymentStatus,
       amount_paid: amountPaid,
+      // Identidad durable del huésped (PersonPicker) — habilita el historial
+      // de transacciones en el CRM (migración 20260704).
+      occupant_id: guestPerson?.id ?? null,
       notes: notes || null,
       platform: platform || null,
       check_in_code: checkInCode || null,

--- a/src/components/calendar/QuotePanel.tsx
+++ b/src/components/calendar/QuotePanel.tsx
@@ -1,0 +1,456 @@
+'use client'
+
+// BaW OS — Panel "Cotizar y apartar" (flujo de llamada telefónica).
+//
+// Se abre al seleccionar entrada→salida en el calendario. Cotiza con el motor
+// unificado, busca o crea el CONTACTO CRM (el prospecto NO se vuelve occupant
+// aquí — eso pasa al confirmar), crea la reservación tentativa con hold de
+// 24-72h + la oportunidad 'cotizado', y arma la propuesta para WhatsApp/correo.
+
+import { useEffect, useMemo, useState } from 'react'
+import { X, Search, MessageCircle, Mail, Copy, Check, PhoneCall } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import type { Season, RateOverride } from '@/lib/calendar-occupancy'
+import { diffDaysISO } from '@/lib/calendar-occupancy'
+import {
+  buildQuoteBreakdown,
+  buildProposalText,
+  createQuote,
+  whatsappLink,
+  mailtoLink,
+  type QuoteUnitInfo,
+} from '@/lib/quote-flow'
+import { formatCurrency, formatDate } from '@/lib/utils'
+import type { CrmTemperature } from '@/types'
+
+interface ContactHit {
+  id: string
+  name: string
+  phone: string | null
+  email: string | null
+  is_client: boolean
+}
+
+const HOLD_OPTIONS = [24, 48, 72]
+const TEMP_OPTIONS: Array<{ value: CrmTemperature; label: string }> = [
+  { value: 'caliente', label: '🔥 Caliente' },
+  { value: 'tibio', label: '🌤 Tibio' },
+  { value: 'frio', label: '❄️ Frío' },
+]
+
+export default function QuotePanel({
+  orgId,
+  unit,
+  checkIn,
+  checkOut,
+  seasons,
+  onClose,
+  onCreated,
+}: {
+  orgId: string
+  unit: QuoteUnitInfo
+  checkIn: string
+  /** exclusivo (día de salida) */
+  checkOut: string
+  seasons: Season[]
+  onClose: () => void
+  onCreated: () => void
+}) {
+  const [guests, setGuests] = useState(2)
+  const [holdHours, setHoldHours] = useState(48)
+  const [temperature, setTemperature] = useState<CrmTemperature>('caliente')
+  const [overrides, setOverrides] = useState<RateOverride[]>([])
+
+  // Contacto: buscar en CRM o capturar nuevo
+  const [query, setQuery] = useState('')
+  const [hits, setHits] = useState<ContactHit[]>([])
+  const [picked, setPicked] = useState<ContactHit | null>(null)
+  const [newName, setNewName] = useState('')
+  const [newPhone, setNewPhone] = useState('')
+  const [newEmail, setNewEmail] = useState('')
+
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [created, setCreated] = useState<{ reservationId: string } | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const nights = diffDaysISO(checkIn, checkOut)
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  // Overrides de precio de esta unidad (si la tabla no existe, seguimos sin ellos)
+  useEffect(() => {
+    let cancelled = false
+    supabase
+      .from('unit_rate_overrides')
+      .select('id, unit_id, start_date, end_date, nightly_rate_mxn, notes')
+      .eq('unit_id', unit.id)
+      .then(({ data }) => {
+        if (!cancelled) setOverrides((data ?? []) as RateOverride[])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [unit.id])
+
+  // Búsqueda de contactos CRM (nombre / teléfono / correo)
+  useEffect(() => {
+    const q = query.trim()
+    if (q.length < 2) {
+      setHits([])
+      return
+    }
+    let cancelled = false
+    const t = setTimeout(() => {
+      supabase
+        .from('crm_contacts')
+        .select('id, name, phone, email, is_client')
+        .eq('org_id', orgId)
+        .or(`name.ilike.%${q}%,phone.ilike.%${q}%,email.ilike.%${q}%`)
+        .limit(6)
+        .then(({ data }) => {
+          if (!cancelled) setHits((data ?? []) as ContactHit[])
+        })
+    }, 250)
+    return () => {
+      cancelled = true
+      clearTimeout(t)
+    }
+  }, [query, orgId])
+
+  const breakdown = useMemo(
+    () => buildQuoteBreakdown(unit, checkIn, checkOut, guests, seasons, overrides),
+    [unit, checkIn, checkOut, guests, seasons, overrides],
+  )
+
+  const contactName = picked?.name ?? newName
+  const contactPhone = picked?.phone ?? newPhone
+  const contactEmail = picked?.email ?? newEmail
+
+  const proposalText = useMemo(
+    () =>
+      breakdown
+        ? buildProposalText({
+            contactName: contactName || 'buen día',
+            unit,
+            checkIn,
+            checkOut,
+            breakdown,
+            holdHours,
+          })
+        : '',
+    [breakdown, contactName, unit, checkIn, checkOut, holdHours],
+  )
+
+  async function handleCreate() {
+    if (!breakdown) return
+    if (!contactName.trim()) {
+      setError('Ponle nombre al contacto (o busca uno existente).')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    const result = await createQuote({
+      orgId,
+      unit,
+      checkIn,
+      checkOut,
+      breakdown,
+      contact: {
+        id: picked?.id ?? null,
+        name: contactName,
+        phone: contactPhone ?? '',
+        email: contactEmail ?? '',
+      },
+      holdHours,
+      temperature,
+    })
+    setSaving(false)
+    if (result.error) setError(result.error)
+    if (result.reservationId) {
+      setCreated({ reservationId: result.reservationId })
+      onCreated()
+    }
+  }
+
+  async function copyProposal() {
+    try {
+      await navigator.clipboard.writeText(proposalText)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setError('No se pudo copiar — selecciona el texto manualmente.')
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end" role="dialog" aria-modal="true">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <aside
+        className="relative h-full w-full max-w-md overflow-y-auto p-5 space-y-4 shadow-2xl"
+        style={{ backgroundColor: 'var(--baw-surface)', borderLeft: '1px solid var(--baw-border)' }}
+      >
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="font-semibold flex items-center gap-2" style={{ color: 'var(--baw-text)' }}>
+              <PhoneCall className="w-4 h-4 text-indigo-400" />
+              Cotizar y apartar
+            </h3>
+            <p className="text-xs muted-text mt-0.5">
+              Unidad {unit.number}
+              {unit.buildingName ? ` · ${unit.buildingName}` : ''} · {formatDate(checkIn)} →{' '}
+              {formatDate(checkOut)} ({nights} noche{nights === 1 ? '' : 's'})
+            </p>
+          </div>
+          <button onClick={onClose} className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="Cerrar">
+            <X className="w-4 h-4 muted-text" />
+          </button>
+        </div>
+
+        {created ? (
+          /* ── Paso 2: propuesta lista para enviar ── */
+          <>
+            <div
+              className="rounded-lg p-3 text-sm"
+              style={{
+                color: 'var(--baw-success-fg)',
+                backgroundColor: 'var(--baw-success-bg)',
+                border: '1px solid var(--baw-success-border)',
+              }}
+            >
+              ✓ Fechas apartadas por {holdHours}h y oportunidad creada en el CRM. Si el cliente no
+              confirma, se liberan solas.
+            </div>
+            <textarea
+              readOnly
+              value={proposalText}
+              rows={12}
+              className="input-field w-full text-xs font-mono leading-relaxed"
+            />
+            <div className="grid grid-cols-3 gap-2">
+              <a
+                href={whatsappLink(contactPhone, proposalText)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-emerald-600 hover:bg-emerald-700 text-white"
+              >
+                <MessageCircle className="w-4 h-4" /> WhatsApp
+              </a>
+              <a
+                href={mailtoLink(contactEmail, `Cotización · Unidad ${unit.number}`, proposalText)}
+                className="inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-indigo-600 hover:bg-indigo-700 text-white"
+              >
+                <Mail className="w-4 h-4" /> Correo
+              </a>
+              <button
+                onClick={copyProposal}
+                className="inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
+                style={{ color: 'var(--baw-text)' }}
+              >
+                {copied ? <Check className="w-4 h-4 text-emerald-500" /> : <Copy className="w-4 h-4" />}
+                {copied ? 'Copiado' : 'Copiar'}
+              </button>
+            </div>
+            <button
+              onClick={onClose}
+              className="w-full px-3 py-2 rounded-lg text-sm border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 muted-text"
+            >
+              Cerrar
+            </button>
+          </>
+        ) : (
+          /* ── Paso 1: armar la cotización ── */
+          <>
+            {/* Desglose */}
+            {breakdown ? (
+              <div className="rounded-lg p-3 space-y-1 text-sm" style={{ border: '1px solid var(--baw-border)' }}>
+                <div className="flex justify-between">
+                  <span className="muted-text">
+                    Hospedaje ({formatCurrency(breakdown.avgNight)}/noche prom. × {breakdown.nights})
+                  </span>
+                  <span style={{ color: 'var(--baw-text)' }}>{formatCurrency(breakdown.base)}</span>
+                </div>
+                {breakdown.extraFee > 0 && (
+                  <div className="flex justify-between">
+                    <span className="muted-text">
+                      Huéspedes extra ({guests - breakdown.includedGuests})
+                    </span>
+                    <span className="text-amber-500">+{formatCurrency(breakdown.extraFee)}</span>
+                  </div>
+                )}
+                {breakdown.cleaning > 0 && (
+                  <div className="flex justify-between">
+                    <span className="muted-text">Limpieza</span>
+                    <span style={{ color: 'var(--baw-text)' }}>{formatCurrency(breakdown.cleaning)}</span>
+                  </div>
+                )}
+                <div className="flex justify-between">
+                  <span className="muted-text">IVA (16%)</span>
+                  <span style={{ color: 'var(--baw-text)' }}>{formatCurrency(breakdown.iva)}</span>
+                </div>
+                <div className="flex justify-between pt-1 font-semibold" style={{ borderTop: '1px solid var(--baw-border)' }}>
+                  <span style={{ color: 'var(--baw-text)' }}>Total</span>
+                  <span className="text-emerald-600 dark:text-emerald-400">
+                    {formatCurrency(breakdown.total)}
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <p
+                className="text-sm rounded-lg p-3"
+                style={{
+                  color: 'var(--baw-warning-fg)',
+                  backgroundColor: 'var(--baw-warning-bg)',
+                  border: '1px solid var(--baw-warning-border)',
+                }}
+              >
+                Esta unidad no tiene tarifa por noche configurada — captúrala en Finanzas → Precios
+                o fija un precio para el rango desde su calendario.
+              </p>
+            )}
+
+            {/* Huéspedes + hold + temperatura */}
+            <div className="grid grid-cols-3 gap-2">
+              <div>
+                <p className="text-xs uppercase tracking-wide muted-text mb-1">Huéspedes</p>
+                <input
+                  type="number"
+                  min={1}
+                  value={guests}
+                  onChange={(e) => setGuests(Math.max(1, Number(e.target.value)))}
+                  className="input-field w-full text-sm py-1.5"
+                />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide muted-text mb-1">Apartar por</p>
+                <select
+                  value={holdHours}
+                  onChange={(e) => setHoldHours(Number(e.target.value))}
+                  className="input-field w-full text-sm py-1.5"
+                >
+                  {HOLD_OPTIONS.map((h) => (
+                    <option key={h} value={h}>
+                      {h} horas
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide muted-text mb-1">Temperatura</p>
+                <select
+                  value={temperature}
+                  onChange={(e) => setTemperature(e.target.value as CrmTemperature)}
+                  className="input-field w-full text-sm py-1.5"
+                >
+                  {TEMP_OPTIONS.map((t) => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {/* Contacto CRM */}
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-wide muted-text">Contacto (CRM)</p>
+              {picked ? (
+                <div
+                  className="flex items-center justify-between rounded-lg px-3 py-2 text-sm"
+                  style={{ border: '1px solid var(--baw-border)' }}
+                >
+                  <div>
+                    <p style={{ color: 'var(--baw-text)' }} className="font-medium">
+                      {picked.name} {picked.is_client && <span className="text-[10px] text-emerald-500">cliente</span>}
+                    </p>
+                    <p className="text-xs muted-text">{picked.phone ?? '—'} · {picked.email ?? '—'}</p>
+                  </div>
+                  <button onClick={() => setPicked(null)} className="text-xs text-indigo-500 hover:text-indigo-400">
+                    Cambiar
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <div className="relative">
+                    <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                    <input
+                      type="text"
+                      value={query}
+                      onChange={(e) => setQuery(e.target.value)}
+                      placeholder="Buscar contacto por nombre, teléfono o correo…"
+                      className="input-field w-full pl-9 text-sm py-1.5"
+                    />
+                  </div>
+                  {hits.length > 0 && (
+                    <div className="rounded-lg divide-y divide-gray-100 dark:divide-gray-800" style={{ border: '1px solid var(--baw-border)' }}>
+                      {hits.map((h) => (
+                        <button
+                          key={h.id}
+                          onClick={() => {
+                            setPicked(h)
+                            setQuery('')
+                            setHits([])
+                          }}
+                          className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                        >
+                          <span style={{ color: 'var(--baw-text)' }}>{h.name}</span>{' '}
+                          <span className="text-xs muted-text">{h.phone ?? h.email ?? ''}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  <div className="grid grid-cols-1 gap-2">
+                    <input
+                      type="text"
+                      value={newName}
+                      onChange={(e) => setNewName(e.target.value)}
+                      placeholder="Nombre del interesado *"
+                      className="input-field w-full text-sm py-1.5"
+                    />
+                    <div className="grid grid-cols-2 gap-2">
+                      <input
+                        type="tel"
+                        value={newPhone}
+                        onChange={(e) => setNewPhone(e.target.value)}
+                        placeholder="Teléfono (WhatsApp)"
+                        className="input-field w-full text-sm py-1.5"
+                      />
+                      <input
+                        type="email"
+                        value={newEmail}
+                        onChange={(e) => setNewEmail(e.target.value)}
+                        placeholder="Correo"
+                        className="input-field w-full text-sm py-1.5"
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+
+            <button
+              onClick={handleCreate}
+              disabled={saving || !breakdown}
+              className="w-full px-3 py-2.5 rounded-lg text-sm font-semibold bg-indigo-600 hover:bg-indigo-700 text-white disabled:opacity-50"
+            >
+              {saving ? 'Apartando…' : `Cotizar y apartar ${holdHours}h`}
+            </button>
+            <p className="text-[10px] muted-text">
+              Crea contacto + oportunidad "cotizado" en el CRM y una reservación tentativa que
+              bloquea el sitio público hasta que venza el apartado. El interesado se vuelve
+              ocupante solo al confirmar.
+            </p>
+          </>
+        )}
+
+        {error && <p className="text-xs text-red-500">{error}</p>}
+      </aside>
+    </div>
+  )
+}

--- a/src/components/calendar/StayDrawer.tsx
+++ b/src/components/calendar/StayDrawer.tsx
@@ -6,9 +6,10 @@
 
 import { useEffect, type CSSProperties } from 'react'
 import Link from 'next/link'
-import { X, FileText, BedDouble, Clock, ExternalLink, Users } from 'lucide-react'
+import { X, FileText, BedDouble, Clock, ExternalLink, Users, CheckCircle2, CalendarX } from 'lucide-react'
 import type { CalendarStay } from '@/lib/calendar-occupancy'
 import { diffDaysISO } from '@/lib/calendar-occupancy'
+import { holdCountdownLabel } from '@/lib/quote-flow'
 import { formatCurrency, formatDate } from '@/lib/utils'
 import { INSTR_VAR, statusChipFor, PAYMENT_STATUS_LABEL, CHANNEL_LABEL } from './calendar-ui'
 
@@ -17,6 +18,8 @@ export default function StayDrawer({
   unitLabel,
   onClose,
   onDelete,
+  onConfirm,
+  onRelease,
 }: {
   stay: CalendarStay | null
   unitLabel?: string
@@ -24,6 +27,10 @@ export default function StayDrawer({
   /** Acción destructiva opcional (p.ej. eliminar un bloqueo). El caller decide
    *  para qué kinds pasarla y ejecuta el write + refetch. */
   onDelete?: (() => void) | null
+  /** Cotización tentativa: cerrar la venta (→ confirmed + CRM ganado + occupant). */
+  onConfirm?: (() => void) | null
+  /** Cotización tentativa: liberar fechas (→ cancelled + CRM perdido). */
+  onRelease?: (() => void) | null
 }) {
   useEffect(() => {
     if (!stay) return
@@ -39,6 +46,8 @@ export default function StayDrawer({
   const chip = statusChipFor(stay)
   const nights =
     stay.endExclusive !== null ? diffDaysISO(stay.start, stay.endExclusive) : null
+  const holdLabel = stay.status === 'tentative' ? holdCountdownLabel(stay.holdExpiresAt) : null
+  const isTentative = stay.kind === 'reservacion' && stay.status === 'tentative'
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end" role="dialog" aria-modal="true">
@@ -139,6 +148,17 @@ export default function StayDrawer({
           <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${chip.cls}`}>
             {chip.label}
           </span>
+          {holdLabel && (
+            <span
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+              style={{
+                color: holdLabel.includes('expiró') ? 'var(--baw-danger-fg)' : 'var(--baw-warning-fg)',
+                backgroundColor: holdLabel.includes('expiró') ? 'var(--baw-danger-bg)' : 'var(--baw-warning-bg)',
+              }}
+            >
+              <Clock className="w-3 h-3" /> {holdLabel}
+            </span>
+          )}
           {stay.paymentStatus && (
             <span className="inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-800/60 dark:text-gray-300">
               {PAYMENT_STATUS_LABEL[stay.paymentStatus] ?? stay.paymentStatus}
@@ -152,6 +172,27 @@ export default function StayDrawer({
             <p className="text-sm whitespace-pre-wrap" style={{ color: 'var(--baw-text)' }}>
               {stay.notes}
             </p>
+          </div>
+        )}
+
+        {isTentative && (onConfirm || onRelease) && (
+          <div className="flex items-center gap-2">
+            {onConfirm && (
+              <button
+                onClick={onConfirm}
+                className="flex-1 inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold bg-emerald-600 hover:bg-emerald-700 text-white transition-colors"
+              >
+                <CheckCircle2 className="w-4 h-4" /> Confirmar reservación
+              </button>
+            )}
+            {onRelease && (
+              <button
+                onClick={onRelease}
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 muted-text transition-colors"
+              >
+                <CalendarX className="w-4 h-4" /> Liberar fechas
+              </button>
+            )}
           </div>
         )}
 

--- a/src/lib/calendar-occupancy.ts
+++ b/src/lib/calendar-occupancy.ts
@@ -38,6 +38,8 @@ export interface CalendarStay {
   guests?: number | null
   paymentStatus?: string | null
   notes?: string | null
+  /** Cotización: la tentativa aparta fechas hasta aquí (null = sin vencimiento) */
+  holdExpiresAt?: string | null
 }
 
 export interface Season {
@@ -130,6 +132,7 @@ export interface ReservationRow {
   guests_count: number | null
   channel: string | null
   notes?: string | null
+  hold_expires_at?: string | null
 }
 
 export interface HoldRow {
@@ -186,7 +189,19 @@ export function reservationToStay(r: ReservationRow): CalendarStay | null {
     guests: r.guests_count,
     paymentStatus: r.payment_status,
     notes: r.notes ?? null,
+    holdExpiresAt: r.hold_expires_at ?? null,
   }
+}
+
+/** true si la estancia es una cotización tentativa cuyo apartado ya venció. */
+export function isHoldExpired(stay: CalendarStay, nowIso: string): boolean {
+  return (
+    stay.kind === 'reservacion' &&
+    stay.status === 'tentative' &&
+    stay.holdExpiresAt !== null &&
+    stay.holdExpiresAt !== undefined &&
+    stay.holdExpiresAt <= nowIso
+  )
 }
 
 export interface BlockRow {

--- a/src/lib/quote-flow.ts
+++ b/src/lib/quote-flow.ts
@@ -1,0 +1,310 @@
+// BaW OS — Flujo de cotización telefónica (user story Fran 2026-07-03).
+//
+// Llamada → seleccionar fechas en el calendario → cotizar → crear contacto CRM
+// + oportunidad 'cotizado' + reservación TENTATIVA con hold de 24-72h → enviar
+// propuesta (WhatsApp/correo). La tentativa aparta las fechas en el sitio
+// público hasta hold_expires_at; si vence, se libera sola (la disponibilidad
+// pública ignora tentativas vencidas — migración 20260704).
+//
+// Modelo CRM: el prospecto vive SOLO en crm_contacts (occupant_id NULL).
+// Se convierte en occupant únicamente al CONFIRMAR (cierre de venta).
+
+import { supabase } from '@/lib/supabase'
+import type { Season, RateOverride, CalendarStay } from '@/lib/calendar-occupancy'
+import { addDaysISO, diffDaysISO, nightlyPrice } from '@/lib/calendar-occupancy'
+import { formatCurrency, formatDate } from '@/lib/utils'
+import type { CrmTemperature } from '@/types'
+
+export const EXTRA_PERSON_FEE = 250 // $/persona/noche sobre max_guests (regla vigente del cotizador)
+
+export interface QuoteUnitInfo {
+  id: string
+  number: string
+  type: string
+  base_rate_mxn: number | null
+  cleaning_fee_mxn: number | null
+  max_guests: number | null
+  buildingName?: string | null
+}
+
+export interface QuoteBreakdown {
+  nights: number
+  guests: number
+  includedGuests: number
+  base: number
+  extraFee: number
+  cleaning: number
+  iva: number
+  total: number
+  avgNight: number
+}
+
+/** Desglose noche por noche — mismo motor que /quotes y el calendario. */
+export function buildQuoteBreakdown(
+  unit: QuoteUnitInfo,
+  checkIn: string,
+  checkOut: string, // exclusivo
+  guests: number,
+  seasons: Season[],
+  overrides: RateOverride[],
+): QuoteBreakdown | null {
+  const nights = diffDaysISO(checkIn, checkOut)
+  if (nights < 1) return null
+  let base = 0
+  for (let iso = checkIn; iso < checkOut; iso = addDaysISO(iso, 1)) {
+    const p = nightlyPrice(unit.base_rate_mxn, seasons, iso, overrides)
+    if (p === null) return null // sin tarifa configurada: no se puede cotizar
+    base += p
+  }
+  const includedGuests = unit.max_guests ?? 4
+  const extraFee = Math.max(0, guests - includedGuests) * EXTRA_PERSON_FEE * nights
+  const cleaning = unit.cleaning_fee_mxn ?? 0
+  const iva = (base + extraFee + cleaning) * 0.16
+  const total = base + extraFee + cleaning + iva
+  return {
+    nights,
+    guests,
+    includedGuests,
+    base,
+    extraFee,
+    cleaning,
+    iva,
+    total,
+    avgNight: Math.round(base / nights),
+  }
+}
+
+/** Mensaje de propuesta listo para WhatsApp / correo. */
+export function buildProposalText(opts: {
+  contactName: string
+  unit: QuoteUnitInfo
+  checkIn: string
+  checkOut: string
+  breakdown: QuoteBreakdown
+  holdHours: number
+}): string {
+  const { contactName, unit, checkIn, checkOut, breakdown: b, holdHours } = opts
+  const lugar = unit.buildingName ? `${unit.buildingName}, unidad ${unit.number}` : `unidad ${unit.number}`
+  const lines = [
+    `Hola ${contactName}, gracias por tu interés. Esta es tu cotización:`,
+    ``,
+    `🏠 ${lugar}`,
+    `📅 Entrada ${formatDate(checkIn)} · Salida ${formatDate(checkOut)} (${b.nights} noche${b.nights === 1 ? '' : 's'})`,
+    `👥 ${b.guests} huésped${b.guests === 1 ? '' : 'es'}`,
+    ``,
+    `Hospedaje: ${formatCurrency(b.base)} (${formatCurrency(b.avgNight)}/noche prom.)`,
+    ...(b.extraFee > 0 ? [`Huéspedes extra: ${formatCurrency(b.extraFee)}`] : []),
+    ...(b.cleaning > 0 ? [`Limpieza: ${formatCurrency(b.cleaning)}`] : []),
+    `IVA (16%): ${formatCurrency(b.iva)}`,
+    `*Total: ${formatCurrency(b.total)}*`,
+    ``,
+    `Te apartamos estas fechas por ${holdHours} horas. Confirma antes para asegurarlas 🙌`,
+  ]
+  return lines.join('\n')
+}
+
+export function whatsappLink(phone: string | null | undefined, text: string): string {
+  const digits = (phone ?? '').replace(/\D/g, '')
+  const encoded = encodeURIComponent(text)
+  return digits ? `https://wa.me/${digits}?text=${encoded}` : `https://wa.me/?text=${encoded}`
+}
+
+export function mailtoLink(email: string | null | undefined, subject: string, body: string): string {
+  return `mailto:${email ?? ''}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
+}
+
+/** "expira en 36h" / "expiró hace 2h" / null si no hay hold. */
+export function holdCountdownLabel(holdExpiresAt: string | null | undefined): string | null {
+  if (!holdExpiresAt) return null
+  const ms = new Date(holdExpiresAt).getTime() - Date.now()
+  const hours = Math.round(Math.abs(ms) / 3_600_000)
+  const label = hours >= 48 ? `${Math.round(hours / 24)}d` : `${hours}h`
+  return ms > 0 ? `apartado expira en ${label}` : `apartado expiró hace ${label}`
+}
+
+/* ───────────────────────────── Escrituras ───────────────────────────── */
+
+export interface QuoteContactInput {
+  /** id de crm_contacts existente, o null para crear uno nuevo */
+  id: string | null
+  name: string
+  phone: string
+  email: string
+}
+
+export interface CreateQuoteResult {
+  reservationId?: string
+  contactId?: string
+  error?: string
+}
+
+/** Crea contacto CRM (si es nuevo) + reservación tentativa con hold +
+ *  oportunidad 'cotizado'. El prospecto NO se vuelve occupant aquí. */
+export async function createQuote(opts: {
+  orgId: string
+  unit: QuoteUnitInfo
+  checkIn: string
+  checkOut: string
+  breakdown: QuoteBreakdown
+  contact: QuoteContactInput
+  holdHours: number
+  temperature: CrmTemperature
+}): Promise<CreateQuoteResult> {
+  const { orgId, unit, checkIn, checkOut, breakdown, contact, holdHours, temperature } = opts
+
+  let contactId = contact.id
+  if (!contactId) {
+    const { data, error } = await supabase
+      .from('crm_contacts')
+      .insert({
+        org_id: orgId,
+        name: contact.name.trim(),
+        phone: contact.phone.trim() || null,
+        email: contact.email.trim() || null,
+        source: 'llamada',
+        status: 'contactado',
+        interest_product: 'Residencial corta',
+      })
+      .select('id')
+      .single()
+    if (error) return { error: `No se pudo crear el contacto: ${error.message}` }
+    contactId = data.id
+  }
+
+  const holdExpiresAt = new Date(Date.now() + holdHours * 3_600_000).toISOString()
+  const { data: res, error: resError } = await supabase
+    .from('reservations')
+    .insert({
+      organization_id: orgId,
+      unit_id: unit.id,
+      guest_name: contact.name.trim(),
+      guest_phone: contact.phone.trim() || null,
+      guest_email: contact.email.trim() || null,
+      check_in: checkIn,
+      check_out: checkOut,
+      mode: 'full',
+      guests_count: breakdown.guests,
+      price_per_night: breakdown.avgNight,
+      total_price: Math.round(breakdown.total),
+      status: 'tentative',
+      payment_status: 'pending',
+      channel: 'direct',
+      hold_expires_at: holdExpiresAt,
+      notes: `Cotización telefónica · apartado ${holdHours}h`,
+    })
+    .select('id')
+    .single()
+  if (resError) return { error: `No se pudo apartar: ${resError.message}`, contactId: contactId! }
+
+  const { error: oppError } = await supabase.from('crm_opportunities').insert({
+    org_id: orgId,
+    contact_id: contactId,
+    kind: 'nueva',
+    target_product: 'Residencial corta',
+    unit_id: unit.id,
+    stage: 'cotizado',
+    temperature,
+    reservation_id: res.id,
+    est_monthly: Math.round(breakdown.total),
+    notes: `Cotización ${formatDate(checkIn)} → ${formatDate(checkOut)} · ${breakdown.nights} noches · total ${formatCurrency(breakdown.total)}`,
+  })
+  // Si el CRM aún no tiene la migración 20260704 (temperature/cotizado), la
+  // reserva tentativa ya quedó: reportamos el error sin tirar el flujo.
+  if (oppError) {
+    return {
+      reservationId: res.id,
+      contactId: contactId!,
+      error: `Fechas apartadas, pero la oportunidad CRM falló: ${oppError.message}`,
+    }
+  }
+  return { reservationId: res.id, contactId: contactId! }
+}
+
+/** Confirma la cotización: reserva → confirmed, oportunidad → ganado, y el
+ *  contacto CRM se PROMUEVE a occupant (aquí nace la identidad operativa). */
+export async function confirmQuote(stay: CalendarStay, orgId: string): Promise<string | null> {
+  if (stay.kind !== 'reservacion') return 'Solo aplica a reservaciones.'
+  const reservationId = stay.key.slice(2)
+
+  const { error: resErr } = await supabase
+    .from('reservations')
+    .update({ status: 'confirmed', hold_expires_at: null })
+    .eq('id', reservationId)
+  if (resErr) return `No se pudo confirmar: ${resErr.message}`
+
+  // Oportunidad ligada (si existe): ganado + cierre
+  const { data: opp } = await supabase
+    .from('crm_opportunities')
+    .select('id, contact_id')
+    .eq('reservation_id', reservationId)
+    .maybeSingle()
+  if (!opp) return null
+  await supabase
+    .from('crm_opportunities')
+    .update({ stage: 'ganado', closed_at: new Date().toISOString() })
+    .eq('id', opp.id)
+
+  // Promoción contacto → occupant
+  const { data: contact } = await supabase
+    .from('crm_contacts')
+    .select('id, occupant_id, name, phone, email')
+    .eq('id', opp.contact_id)
+    .maybeSingle()
+  if (!contact) return null
+
+  let occupantId = contact.occupant_id as string | null
+  if (!occupantId) {
+    const { data: occ, error: occErr } = await supabase
+      .from('occupants')
+      .insert({
+        org_id: orgId,
+        name: contact.name,
+        phone: contact.phone,
+        email: contact.email,
+        type: 'str',
+      })
+      .select('id')
+      .single()
+    if (occErr) return `Confirmada, pero no se pudo crear el ocupante: ${occErr.message}`
+    occupantId = occ.id
+    // El trigger crm_contact_for_occupant crea un contacto espejo para el
+    // occupant nuevo; lo quitamos y ligamos NUESTRO contacto (que tiene la
+    // historia de la cotización) para no duplicar personas en el CRM.
+    await supabase
+      .from('crm_contacts')
+      .delete()
+      .eq('org_id', orgId)
+      .eq('occupant_id', occupantId)
+      .neq('id', contact.id)
+    await supabase
+      .from('crm_contacts')
+      .update({ occupant_id: occupantId, is_client: true, status: 'activo' })
+      .eq('id', contact.id)
+  } else {
+    await supabase
+      .from('crm_contacts')
+      .update({ is_client: true, status: 'activo' })
+      .eq('id', contact.id)
+  }
+
+  // Reservación ↔ identidad durable (historial de transacciones en CRM)
+  await supabase.from('reservations').update({ occupant_id: occupantId }).eq('id', reservationId)
+  return null
+}
+
+/** Libera las fechas: reserva → cancelled, oportunidad → perdido. */
+export async function releaseQuote(stay: CalendarStay): Promise<string | null> {
+  if (stay.kind !== 'reservacion') return 'Solo aplica a reservaciones.'
+  const reservationId = stay.key.slice(2)
+  const { error } = await supabase
+    .from('reservations')
+    .update({ status: 'cancelled' })
+    .eq('id', reservationId)
+  if (error) return `No se pudo liberar: ${error.message}`
+  await supabase
+    .from('crm_opportunities')
+    .update({ stage: 'perdido', closed_at: new Date().toISOString() })
+    .eq('reservation_id', reservationId)
+    .neq('stage', 'ganado')
+  return null
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -370,6 +370,10 @@ export interface Reservation {
   status: ReservationStatus
   payment_status: ReservationPaymentStatus
   amount_paid: number
+  /** Cotización telefónica: la tentativa aparta fechas hasta aquí (20260704) */
+  hold_expires_at?: string | null
+  /** Identidad durable del huésped; se liga al confirmar (20260704) */
+  occupant_id?: string | null
   notes?: string
   created_at: string
   updated_at: string
@@ -495,7 +499,9 @@ export interface WebhookEvent {
 export type CrmSource = 'llamada' | 'whatsapp' | 'referido' | 'portal' | 'anuncio' | 'manual' | 'otro'
 export type CrmStatus = 'nuevo' | 'contactado' | 'activo' | 'inactivo' | 'en_seguimiento' | 'recompro' | 'descartado'
 export type CrmOppKind = 'recompra' | 'migracion' | 'nueva'
-export type CrmOppStage = 'identificado' | 'contactado' | 'interesado' | 'negociacion' | 'ganado' | 'perdido'
+export type CrmOppStage = 'identificado' | 'contactado' | 'interesado' | 'cotizado' | 'negociacion' | 'ganado' | 'perdido'
+// Temperatura de la oportunidad (qué tan caliente está el prospecto)
+export type CrmTemperature = 'frio' | 'tibio' | 'caliente'
 
 // Producto/segmento del cliente. Texto libre (el negocio tiene productos
 // heterogéneos y crecientes); esta lista solo sugiere valores en la UI.
@@ -537,6 +543,8 @@ export interface CrmOpportunity {
   target_product?: string | null
   unit_id?: string | null
   stage: CrmOppStage
+  temperature?: CrmTemperature
+  reservation_id?: string | null
   est_monthly?: number | null
   owner?: string | null
   next_followup_at?: string | null

--- a/supabase/migrations/20260704_quote_flow_crm.sql
+++ b/supabase/migrations/20260704_quote_flow_crm.sql
@@ -1,0 +1,81 @@
+-- BaW OS — Flujo de cotización telefónica + CRM mínimo viable.
+--
+-- User story (Fran, 2026-07-03): llamada → ver disponibilidad en calendario →
+-- seleccionar fechas → cotizar → crear contacto CRM + oportunidad "cotizado" →
+-- enviar propuesta → las fechas quedan apartadas 24-72h y se liberan solas.
+-- Modelo: la cotización ES una reservación `tentative` con vencimiento; el
+-- prospecto vive SOLO en CRM y se convierte en occupant al confirmar.
+--
+-- Cambios:
+-- 1. reservations.hold_expires_at — vencimiento del apartado. Una tentativa
+--    vencida deja de bloquear el sitio público automáticamente (sin cron).
+-- 2. reservations.occupant_id — liga la reservación a la identidad durable
+--    (hoy solo guarda texto); habilita historial de transacciones en CRM.
+-- 3. crm_opportunities.temperature — frío/tibio/caliente.
+-- 4. crm_opportunities.reservation_id — liga oportunidad ↔ cotización.
+-- 5. Etapa 'cotizado' en el funnel.
+-- 6. fn_unit_is_available + disponibilidad pública: tentativas vencidas NO
+--    bloquean; unit_blocks (fase 3) SÍ bloquean (hueco detectado: los
+--    bloqueos de mantenimiento no cerraban el booking público).
+--
+-- Idempotente, no destructiva.
+
+-- ── 1-2. reservations ──────────────────────────────────────────────────────
+ALTER TABLE public.reservations
+  ADD COLUMN IF NOT EXISTS hold_expires_at timestamptz,
+  ADD COLUMN IF NOT EXISTS occupant_id uuid REFERENCES public.occupants(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_reservations_occupant
+  ON public.reservations (occupant_id) WHERE occupant_id IS NOT NULL;
+
+-- ── 3-4. crm_opportunities ─────────────────────────────────────────────────
+ALTER TABLE public.crm_opportunities
+  ADD COLUMN IF NOT EXISTS temperature text NOT NULL DEFAULT 'tibio'
+    CHECK (temperature IN ('frio', 'tibio', 'caliente')),
+  ADD COLUMN IF NOT EXISTS reservation_id uuid REFERENCES public.reservations(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_crm_opportunities_reservation
+  ON public.crm_opportunities (reservation_id) WHERE reservation_id IS NOT NULL;
+
+-- ── 5. Etapa 'cotizado' en el funnel (entre interesado y negociación) ──────
+ALTER TABLE public.crm_opportunities
+  DROP CONSTRAINT IF EXISTS crm_opportunities_stage_check;
+ALTER TABLE public.crm_opportunities
+  ADD CONSTRAINT crm_opportunities_stage_check CHECK (
+    stage IN ('identificado', 'contactado', 'interesado', 'cotizado', 'negociacion', 'ganado', 'perdido')
+  );
+
+-- ── 6. Disponibilidad pública ──────────────────────────────────────────────
+-- Tentativas: bloquean solo mientras su hold esté vigente (o si no tienen
+-- vencimiento, comportamiento previo). Bloqueos operativos: bloquean siempre
+-- (end_date inclusivo → daterange '[]').
+CREATE OR REPLACE FUNCTION public.fn_unit_is_available(
+  p_unit_id uuid,
+  p_from    date,
+  p_to      date
+) RETURNS boolean LANGUAGE sql STABLE AS $$
+  SELECT
+    NOT EXISTS (
+      SELECT 1 FROM public.reservations
+      WHERE unit_id = p_unit_id
+        AND (
+          status IN ('confirmed', 'checked_in')
+          OR (
+            status = 'tentative'
+            AND (hold_expires_at IS NULL OR hold_expires_at > now())
+          )
+        )
+        AND daterange(check_in, check_out, '[)') && daterange(p_from, p_to, '[)')
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.reservation_holds
+      WHERE unit_id   = p_unit_id
+        AND expires_at > now()
+        AND daterange(from_date, to_date, '[)') && daterange(p_from, p_to, '[)')
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.unit_blocks
+      WHERE unit_id = p_unit_id
+        AND daterange(start_date, end_date, '[]') && daterange(p_from, p_to, '[)')
+    );
+$$;


### PR DESCRIPTION
## Summary

User story de Fran (2026-07-03): *llega una llamada → ver disponibilidad → seleccionar entrada y salida → cotizar → crear contacto → enviar propuesta → apartar 24-72h → confirma o se liberan las fechas*.

**Modelo acordado:** la cotización ES una reservación `tentative` con `hold_expires_at` — bloquea el sitio público mientras el apartado esté vigente y **se libera sola al vencer** (sin cron: la disponibilidad pública ignora tentativas vencidas). El prospecto vive SOLO en el CRM y **se convierte en occupant únicamente al confirmar** (cierre de venta).

### El flujo completo

1. **Seleccionar fechas**: click/tap en el día de ENTRADA y luego en el de SALIDA — funciona en el timeline (sobre la fila de la unidad libre, con banda de selección `tl-sel` de la spec del kit) y en la vista mensual. Hover extiende la vista previa en desktop; ESC cancela; touch-friendly (era el follow-up móvil anotado en #146).
2. **`QuotePanel`**: desglose con el motor unificado (noche×temporada×overrides + extras + limpieza + IVA), huéspedes, temperatura, apartar 24/48/72h, y contacto = **buscar o crear en `crm_contacts`** (source `llamada`). Crea la tentativa + oportunidad **`cotizado`** ligada (`reservation_id`).
3. **Enviar propuesta**: mensaje prellenado con el desglose y la vigencia del apartado → botones WhatsApp (wa.me, sale de tu teléfono — la API de Meta queda para cuando estén las env vars), Correo (mailto) y Copiar.
4. **Cierre**: el drawer de una tentativa muestra el countdown ("apartado expira en 36h" / "expiró hace 2h") y botones **Confirmar** (→ confirmed, oportunidad `ganado`, el contacto se PROMUEVE a occupant y la reservación queda ligada a la persona) y **Liberar** (→ cancelled, oportunidad `perdido`).

### CRM mínimo viable (pedido de Fran)

- **Temperatura** de oportunidad (🔥 caliente / 🌤 tibio / ❄️ frío): columna nueva, chip en las tarjetas del kanban, select en el drawer.
- **Etapa `cotizado`** en el funnel (entre interesado y negociación).
- **Historial de transacciones**: el detalle del contacto ahora suma **reservaciones** a los contratos (nueva `reservations.occupant_id`; `/reservations` ya persiste la persona del PersonPicker).
- Datos principales y funnel ya existían.

## ⚠️ Migración `20260704_quote_flow_crm.sql` (aplicar en Supabase DESPUÉS de 20260703_03)

`reservations.hold_expires_at` + `reservations.occupant_id` · `crm_opportunities.temperature` + `.reservation_id` · etapa `cotizado` en el CHECK del funnel · `fn_unit_is_available` actualizada. **Bonus/fix**: los `unit_blocks` de fase 3 NO bloqueaban el booking público — ahora la función y la route de blocked_days los incluyen.

Detalle técnico fino: al promover contacto→occupant, el trigger `crm_contact_for_occupant` crea un contacto espejo; `confirmQuote()` lo elimina y liga NUESTRO contacto (el que trae la historia) para no duplicar personas.

## Pre-flight

- [x] Rama sobre `origin/main` (`10ac96a`) · [x] `tsc` + `npm run build` verdes · [x] scope: un feature end-to-end acordado en chat

## Invariantes

- [x] Todas respetadas. Migración con patrón RLS `org_members`; sin navegación ni tokens nuevos.

## Verification

- [x] Build verde
- [ ] En prod tras aplicar la migración: flujo completo — seleccionar fechas → cotizar → ver la tentativa punteada en el calendario y las fechas bloqueadas en el sitio público → confirmar y verificar que el contacto aparece como cliente con su transacción en `/clientes`
- [ ] Verificar que una tentativa vencida deja de bloquear el sitio público (crear con hold de 24h y ajustar `hold_expires_at` a mano hacia atrás para probar)

## Follow-ups (NO incluidos)

- Cron de limpieza (tentativas vencidas → `cancelled` para higiene; hoy solo dejan de bloquear).
- Propuesta como página pública con link (en vez de texto), envío por WhatsApp API / email real.
- Registrar actividad/timeline en el CRM (llamadas, mensajes).

## Merge

- [x] NO se mergeará automáticamente. Espero aprobación de @franduranv. **Recordatorio: aplicar `20260704` en Supabase al mergear.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6L5rZfdkJSULa2a3TrJWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6L5rZfdkJSULa2a3TrJWG)_